### PR TITLE
17371 expose GetHyperparameters through get_internal_parameters, MINOR

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -2550,19 +2550,13 @@
 	#get_internal_parameters
 		(call !return (assoc
 			payload
-				(if (= (null) feature context_features mode weight_feature)
-					(call_entity trainee "GetInternalParameters")
-
-					;else at least one of these params were passed, use #GetHyperparameters
-					(call_entity trainee "GetHyperparameters" (assoc
-						feature feature
-						context_features context_features
-						mode mode
-						weight_feature weight_feature
-					))
-				)
+				(call_entity trainee "GetInternalParameters" (assoc
+					feature feature
+					context_features context_features
+					mode mode
+					weight_feature weight_feature
+				))
 		))
-
 
 	;sets internal hyperparameters
 	;

--- a/howso.amlg
+++ b/howso.amlg
@@ -2540,7 +2540,13 @@
 		)
 
 
-	;return the full internal parameters map
+	;return the full internal parameters map if no parameters are specified.
+	;if any of the parameters are specified, then GetHyperparameters is called, which uses the specified parameters to find the most suitable set of hyperparameters to return
+	; parameters:
+	; feature : optional, the target feature of the desired hyperparameters
+	; context_features : optional, the set of context features used for the desired hyperparameters
+	; mode : optional, the method of calculation used to find the desired hyperparameters
+	; weight_feature : optional, the weight feature used in the calculation of the desired hyperparameters
 	#get_internal_parameters
 		(call !return (assoc
 			payload

--- a/howso.amlg
+++ b/howso.amlg
@@ -2554,7 +2554,12 @@
 					(call_entity trainee "GetInternalParameters")
 
 					;else at least one of these params were passed, use #GetHyperparameters
-					(call_entity trainee "GetHyperparameters")
+					(call_entity trainee "GetHyperparameters" (assoc
+						feature feature
+						context_features context_features
+						mode mode
+						weight_feature weight_feature
+					))
 				)
 		))
 

--- a/howso.amlg
+++ b/howso.amlg
@@ -2542,7 +2542,15 @@
 
 	;return the full internal parameters map
 	#get_internal_parameters
-		(call !return (assoc payload (call_entity trainee "GetInternalParameters") ))
+		(call !return (assoc
+			payload
+				(if (= (null) feature context_features mode weight_feature)
+					(call_entity trainee "GetInternalParameters")
+
+					;else at least one of these params were passed, use #GetHyperparameters
+					(call_entity trainee "GetHyperparameters")
+				)
+		))
 
 
 	;sets internal hyperparameters

--- a/trainee_template/explanation_influences.amlg
+++ b/trainee_template/explanation_influences.amlg
@@ -64,7 +64,7 @@
 			;pull targetless hyperparameters because local model will include the action value and therefore is not targeted
 			targetless_hyperparam_map
 				(call GetHyperparameters (assoc
-				context_features context_features
+					context_features context_features
 					feature ".targetless"
 					mode
 						(if (or force_targetless robust_computation)

--- a/trainee_template/get_cases.amlg
+++ b/trainee_template/get_cases.amlg
@@ -266,10 +266,10 @@
 		)
 
 		(declare (assoc
-			session_indices_map 
+			session_indices_map
 				(map (lambda (retrieve_from_entity (target_index) ".indices_map")) (zip unique_session_ids))
 		))
-	
+
 		(map
 			(lambda (let
 				(assoc

--- a/trainee_template/hyperparameters.amlg
+++ b/trainee_template/hyperparameters.amlg
@@ -346,13 +346,7 @@
 
 
 	#GetHyperparameters
-	(declare
-		(assoc
-			feature (null)
-			context_features defaultFeatures
-			mode "robust"
-			weight_feature ".case_weight"
-		)
+	(seq
 		(if (= 0 (size hyperparameterParamPaths))
 			(seq
 				(accum (assoc
@@ -371,14 +365,25 @@
 			(conclude (get hyperparameterMetadataMap (first hyperparameterParamPaths)))
 		)
 
+		(if (= (null) mode)
+			(assign (assoc mode "robust"))
+		)
+
+		(if (= (null) weight_feature)
+			(assign (assoc weight_feature ".none"))
+		)
+
 		;there are multiple sets of analyze params, we must determine the best
 		(declare (assoc
-			context_key (call BuildContextFeaturesKey (assoc context_features context_features))
+			context_key
+				(if (or (= context_features (null)) (= context_features (list)))
+					defaultFeaturesContextKey
+
+					;else context_features were passed
+					(call BuildContextFeaturesKey (assoc context_features context_features))
+				)
 		))
 
-		(if (and (= feature ".targetless") (= context_features (list)))
-			(assign (assoc context_key defaultFeaturesContextKey))
-		)
 
 		;determine value for feature
 		(if (or (= (null) feature) (not (contains_index hyperparameterMetadataMap feature)))

--- a/trainee_template/hyperparameters.amlg
+++ b/trainee_template/hyperparameters.amlg
@@ -494,14 +494,33 @@
 
 	;return the full internal parameters map
 	#GetInternalParameters
-	(let
+	(declare
 		(assoc
+			feature (null)
+			context_features (null)
+			mode (null)
+			weight_feature (null)
+		)
+
+		(declare (assoc
 			internal_parameters_map
 				(assoc
-					"hyperparameter_map" hyperparameterMetadataMap
+					"hyperparameter_map"
+						(if (= (null) feature context_features mode weight_feature)
+							hyperparameterMetadataMap
+
+							;else one of these parameters were specified
+							(call GetHyperparameters (assoc
+								feature feature
+								context_features context_features
+								mode mode
+								weight_feature weight_feature
+							))
+						)
+
 					"default_hyperparameter_map" defaultHyperparameters
 				)
-		)
+		))
 
 		(if (!= (null) autoAnalyzeThreshold)
 			(accum (assoc

--- a/unit_tests/ut_h_params.amlg
+++ b/unit_tests/ut_h_params.amlg
@@ -45,6 +45,10 @@
 	(print "Test get_internal_parameters: ")
 	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list "payload" "hyperparameter_map" ".targetless" "A.B.C." "robust" ".none"))))
 
+	(assign (assoc result (call_entity "howso" "get_internal_parameters" (assoc trainee "st_model1" feature ".targetless"))))
+	(print "Test get_internal_parameters with GetHyperparameters logic: ")
+	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list "payload"))))
+
 	(call exit_if_failures (assoc msg "Test get_internal_parameters"))
 
 
@@ -165,7 +169,7 @@
 
 	(call assert_same (assoc
 		obs (get result (list "payload" "default_hyperparameter_map"))
-		exp 
+		exp
 			(assoc
 				"k" 8
 				"p" 0.1

--- a/unit_tests/ut_h_params.amlg
+++ b/unit_tests/ut_h_params.amlg
@@ -47,7 +47,7 @@
 
 	(assign (assoc result (call_entity "howso" "get_internal_parameters" (assoc trainee "st_model1" feature ".targetless"))))
 	(print "Test get_internal_parameters with GetHyperparameters logic: ")
-	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list "payload"))))
+	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list "payload" "hyperparameter_map"))))
 
 	(call exit_if_failures (assoc msg "Test get_internal_parameters"))
 


### PR DESCRIPTION
Allow calls to get_internal_parameters to specify feature, context_features, mode, or weight. If **any** of these are specified, then instead of returning the full dictionary of all internal parameters, the endpoint will return only the dictionary of hyperparameters that the Trainee would use for those parameters.