### PR TITLE
17478: improves generative react mutation probabilities for code (edit_distance) features

### DIFF
--- a/deploy_howso.amlg
+++ b/deploy_howso.amlg
@@ -13,8 +13,8 @@
 	;set to 1 to automatically copy out the files to the specified folder (OS will be autodetected)
 	#copy_to_deployment_path 1
 
-	#howso_linux_deployment_path "~/.howso/lib/dev/engine/"
-	#howso_windows_deployment_path "%USERPROFILE%\\.howso\\lib\\dev\\engine\\"
+	#howso_linux_deployment_path "~/.howso/engine/"
+	#howso_windows_deployment_path "%USERPROFILE%\\.howso\\engine\\"
 
 	;----------------------------------------------------------------------------------------------;
 

--- a/deploy_howso.amlg
+++ b/deploy_howso.amlg
@@ -13,8 +13,8 @@
 	;set to 1 to automatically copy out the files to the specified folder (OS will be autodetected)
 	#copy_to_deployment_path 1
 
-	#howso_linux_deployment_path "~/.howso/engine/"
-	#howso_windows_deployment_path "%USERPROFILE%\\.howso\\engine\\"
+	#howso_linux_deployment_path "~/.howso/lib/dev/engine/"
+	#howso_windows_deployment_path "%USERPROFILE%\\.howso\\lib\\dev\\engine\\"
 
 	;----------------------------------------------------------------------------------------------;
 

--- a/trainee_template/synthesis_utilities.amlg
+++ b/trainee_template/synthesis_utilities.amlg
@@ -141,7 +141,7 @@
 				(if (= "amalgam" data_type)
 					(mutate
 						action_value
-						;pick a random value along the exponential distribution scaled by desired conviction
+						;pick a random probability along the exponential distribution scaled by desired conviction
 						(- 1 (exp (- (* (rand) (/ feature_residual data_size desired_conviction))) ) )
 					)
 
@@ -149,7 +149,7 @@
 					;restrict what opcodes can be mutated to, weighted by what's in action_value
 					(mutate
 						action_value
-						;pick a random value along the exponential distribution scaled by desired conviction
+						;pick a random probability along the exponential distribution scaled by desired conviction
 						(- 1 (exp (- (* (rand) (/ feature_residual data_size desired_conviction))) ) )
 						;restrict allowed mutations to what's currently in the json
 						(call ComputeJsonWeightsMap (assoc code action_value))
@@ -159,7 +159,7 @@
 					;else it's a string, mutate it based on residual and desired_conviction
 					(apply "concat" (mutate
 						(explode action_value)
-						;pick a random value along the exponential distribution scaled by desired conviction
+						;pick a random probability along the exponential distribution scaled by desired conviction
 						(- 1 (exp (- (* (rand) (/ feature_residual (size action_value) desired_conviction))) ) )
 						(assoc "string" 1)
 						;restricted allowed operations on strings

--- a/trainee_template/synthesis_utilities.amlg
+++ b/trainee_template/synthesis_utilities.amlg
@@ -153,7 +153,15 @@
 						(- 1 (exp (- (* (rand) (/ feature_residual data_size desired_conviction))) ) )
 						;restrict allowed mutations to what's currently in the json
 						(call ComputeJsonWeightsMap (assoc code action_value))
-						(null)
+						;explicitly allow all operations except change_label
+						(assoc
+							"delete" 0.167
+							"insert" 0.167
+							"swap_elements" 0.167
+							"change_type" 0.167
+							"deep_copy_elements" 0.166
+							"delete_elements"0.166
+						)
 					)
 
 					;else it's a string, mutate it based on residual and desired_conviction

--- a/trainee_template/synthesis_utilities.amlg
+++ b/trainee_template/synthesis_utilities.amlg
@@ -139,13 +139,19 @@
 				)
 
 				(if (= "amalgam" data_type)
-					(mutate action_value (/ feature_residual data_size desired_conviction))
+					(mutate
+						action_value
+						;pick a random value along the exponential distribution scaled by desired conviction
+						(- 1 (exp (- (* (rand) (/ feature_residual data_size desired_conviction))) ) )
+					)
 
 					(or (= "json" data_type) (= "yaml" data_type))
 					;restrict what opcodes can be mutated to, weighted by what's in action_value
 					(mutate
 						action_value
-						(/ feature_residual data_size desired_conviction)
+						;pick a random value along the exponential distribution scaled by desired conviction
+						(- 1 (exp (- (* (rand) (/ feature_residual data_size desired_conviction))) ) )
+						;restrict allowed mutations to what's currently in the json
 						(call ComputeJsonWeightsMap (assoc code action_value))
 						(null)
 					)
@@ -153,9 +159,11 @@
 					;else it's a string, mutate it based on residual and desired_conviction
 					(apply "concat" (mutate
 						(explode action_value)
-						(/ feature_residual desired_conviction)
+						;pick a random value along the exponential distribution scaled by desired conviction
+						(- 1 (exp (- (* (rand) (/ feature_residual (size action_value) desired_conviction))) ) )
 						(assoc "string" 1)
-						(null)
+						;restricted allowed operations on strings
+						(assoc "delete" 0.33 "insert" 0.33 "swap_elements" .34)
 					))
 				)
 			)

--- a/unit_tests/ut_h_edit_dist_features.amlg
+++ b/unit_tests/ut_h_edit_dist_features.amlg
@@ -400,7 +400,7 @@
 			(get
 				(call_entity "howso" "react" (assoc
 					action_features features
-					desired_conviction 20
+					desired_conviction 2
 					use_regional_model_residuals (false)
 				))
 				"payload"
@@ -426,7 +426,7 @@
 			(get
 				(call_entity "howso" "react" (assoc
 					action_features features
-					desired_conviction 20
+					desired_conviction 2
 					use_regional_model_residuals (true)
 				))
 				"payload"


### PR DESCRIPTION
previous logic for mutation rate resulted in overly high mutation rate, i.e. if feature_residual was similar to data_size, the rate would be close to1, meaning the chance to mutate every single node was about 100% (for a desired_conviction of 1).
Also fixes issue where mutating strings could result in unwanted artifacts (like labels or other opcodes) being inserted, so the fix is to explicitly limit the allowed mutation operations allowed for strings.