### PR TITLE
17371: Fixes parameter name of get_internal_parameters to be aligned

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -2543,7 +2543,7 @@
 	;return the full internal parameters map if no parameters are specified.
 	;if any of the parameters are specified, then GetHyperparameters is called, which uses the specified parameters to find the most suitable set of hyperparameters to return
 	; parameters:
-	; feature : optional, the target feature of the desired hyperparameters
+	; action_feature : optional, the target feature of the desired hyperparameters
 	; context_features : optional, the set of context features used for the desired hyperparameters
 	; mode : optional, the method of calculation used to find the desired hyperparameters
 	; weight_feature : optional, the weight feature used in the calculation of the desired hyperparameters
@@ -2551,7 +2551,7 @@
 		(call !return (assoc
 			payload
 				(call_entity trainee "GetInternalParameters" (assoc
-					feature feature
+					action_feature action_feature
 					context_features context_features
 					mode mode
 					weight_feature weight_feature

--- a/trainee_template/hyperparameters.amlg
+++ b/trainee_template/hyperparameters.amlg
@@ -496,7 +496,7 @@
 	#GetInternalParameters
 	(declare
 		(assoc
-			feature (null)
+			action_feature (null)
 			context_features (null)
 			mode (null)
 			weight_feature (null)
@@ -506,12 +506,12 @@
 			internal_parameters_map
 				(assoc
 					"hyperparameter_map"
-						(if (= (null) feature context_features mode weight_feature)
+						(if (= (null) action_feature context_features mode weight_feature)
 							hyperparameterMetadataMap
 
 							;else one of these parameters were specified
 							(call GetHyperparameters (assoc
-								feature feature
+								feature action_feature
 								context_features context_features
 								mode mode
 								weight_feature weight_feature

--- a/unit_tests/ut_h_params.amlg
+++ b/unit_tests/ut_h_params.amlg
@@ -45,7 +45,7 @@
 	(print "Test get_internal_parameters: ")
 	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list "payload" "hyperparameter_map" ".targetless" "A.B.C." "robust" ".none"))))
 
-	(assign (assoc result (call_entity "howso" "get_internal_parameters" (assoc trainee "st_model1" feature ".targetless"))))
+	(assign (assoc result (call_entity "howso" "get_internal_parameters" (assoc trainee "st_model1" action_feature ".targetless"))))
 	(print "Test get_internal_parameters with GetHyperparameters logic: ")
 	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list "payload" "hyperparameter_map"))))
 


### PR DESCRIPTION
Renaming the `feature` parameter of #get_internal_parameters to be more clear. It is being renamed to `action_feature` since it represents the targeted action feature of the desired hyperparameters.