### PR TITLE
17500: fix feature contributions may be computed incorrectly for encoded features

### DIFF
--- a/trainee_template/contributions.amlg
+++ b/trainee_template/contributions.amlg
@@ -239,7 +239,8 @@
 													context_features filtered_context_features
 													context_values (unzip case_values_map filtered_context_features)
 													action_features (list action_feature)
-													skip_decoding 1
+													skip_decoding (true)
+													skip_encoding (true)
 													;ignore the local case
 													ignore_case case_id
 													details (assoc "categorical_action_probabilities" action_is_nominal)
@@ -451,7 +452,8 @@
 													context_features (append filtered_context_features feature)
 													context_values (unzip case_values_map (append filtered_context_features feature))
 													action_features (list action_feature)
-													skip_decoding 1
+													skip_decoding (true)
+													skip_encoding (true)
 													;ignore the local case
 													ignore_case case_id
 													details (assoc "categorical_action_probabilities" action_is_nominal)
@@ -462,7 +464,8 @@
 													context_features filtered_context_features
 													context_values (unzip case_values_map filtered_context_features)
 													action_features (list action_feature)
-													skip_decoding 1
+													skip_decoding (true)
+													skip_encoding (true)
 													;ignore the local case
 													ignore_case case_id
 													details (assoc "categorical_action_probabilities" action_is_nominal)

--- a/unit_tests/ut_h_edit_dist_features.amlg
+++ b/unit_tests/ut_h_edit_dist_features.amlg
@@ -154,6 +154,7 @@
 			(or
 				(= "number" (get_type_string (get parsed_assoc "a")) )
 				(= "number" (get_type_string (get parsed_assoc "b")) )
+				(= (assoc) parsed_assoc)
 			)
 	))
 


### PR DESCRIPTION
specifically features that needed encoding (datetime, string ordinals and edit_distance) features