### PR TITLE
16845: Adds parameters to return conditioned marginal stats, MINOR

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -2349,19 +2349,37 @@
 
 
 	;outputs all marginal stats (min, max, median, mean, mode, count, uniques, mean_absdev, variance, stddev, skew, kurtosis, entropy)
-	;for all features in the format of feature -> assoc stat -> value
+	;for all features in the format of feature -> assoc stat -> value. The marginal stats can be computed for a subset of the data using condition, precision, and num_cases
 	;
 	;parameters:
 	; weight_feature: optional, name of case weight feature
+	; condition: assoc of feature->value(s)
+	;		no value = must have feature
+	;   	- for continuous or numeric ordinal features:
+	;			one value = must equal exactly the value or be close to it for fuzzy match
+	;			two values = inclusive between
+	;   	- for nominal or string ordinal features:
+	;			n values = must match any of these values exactly
+	; precision: optional string,  default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
+	; num_cases: optional, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
+	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
 	#get_marginal_stats
 		(declare
 			(assoc
 				weight_feature (null)
+				condition (null)
+				precision "exact"
+				num_cases (null)
 			)
 
 			(call !return (assoc
 				payload
-					(call_entity trainee "GetFeatureMarginalStats" (assoc weight_feature weight_feature))
+					(call_entity trainee "GetFeatureMarginalStats" (assoc
+						weight_feature weight_feature
+						condition condition
+						precision precision
+						num_cases num_cases
+					))
 			))
 		)
 

--- a/trainee_template/marginal.amlg
+++ b/trainee_template/marginal.amlg
@@ -542,23 +542,59 @@
 	;
 	;parameters:
 	; weight_feature: optional, name of case weight feature
+	; condition: assoc of feature->value(s)
+	;		no value = must have feature
+	;   	- for continuous or numeric ordinal features:
+	;			one value = must equal exactly the value or be close to it for fuzzy match
+	;			two values = inclusive between
+	;   	- for nominal or string ordinal features:
+	;			n values = must match any of these values exactly
+	; precision: optional string,  default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
+	; num_cases: optional, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
+	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
 	#GetFeatureMarginalStats
 		(declare
-			(assoc weight_feature (null))
+			(assoc
+				weight_feature (null)
+				condition (null)
+				precision "exact"
+				num_cases (null)
+			)
 
 			(if (= (null) weight_feature)
 				(assign (assoc weight_feature ".none"))
 			)
 
-			;if marginal stats haven't been computed yet, compute them here
-			(if (not (contains_index featureMarginalStatsMap weight_feature))
-				(call CalculateMarginalStats (assoc
-					weight_feature (if (!= ".none" weight_feature) weight_feature)
-				))
-			)
+			(if (= (null) condition)
+				(seq
+					;if marginal stats haven't been computed yet, compute them here
+					(if (not (contains_index featureMarginalStatsMap weight_feature))
+						(call CalculateMarginalStats (assoc
+							weight_feature (if (!= ".none" weight_feature) weight_feature)
+						))
+					)
 
-			;get the stats for the specified weight_feature
-			(get featureMarginalStatsMap weight_feature)
+					;get the stats for the specified weight_feature
+					(get featureMarginalStatsMap weight_feature)
+				)
+
+				;else we have a condition
+				(declare
+					(assoc
+						case_ids
+							(call GetCasesByCondition (assoc
+								condition condition
+								num_cases num_cases
+								prevision precision
+							))
+					)
+
+					(call CalculateMarginalStats (assoc
+						weight_feature weight_feature
+						filtering_queries (list (query_in_entity_list case_ids))
+					))
+				)
+			)
 		)
 
 
@@ -569,7 +605,10 @@
 	; weight_feature: optional, name of case weight feature
 	#CalculateMarginalStats
 		(declare
-			(assoc weight_feature (null))
+			(assoc
+				weight_feature (null)
+				filtering_queries (list)
+			)
 
 			(declare (assoc
 				stats
@@ -607,39 +646,39 @@
 										min
 											(retrieve_from_entity
 												(first (contained_entities
-													(list (query_min feature 1))
+													(append filtering_queries (query_min feature 1))
 												))
 												feature
 											)
 										max
 											(retrieve_from_entity
 												(first (contained_entities
-													(list (query_max feature 1))
+													(append filtering_queries (query_max feature 1))
 												))
 												feature
 											)
 										mean
-											(compute_on_contained_entities (list
+											(compute_on_contained_entities (append filtering_queries
 												(query_not_equals feature (null))
 												;calculate arithmetic average
 												(query_generalized_mean feature 1 weight_feature)
 											))
 										median
-											(compute_on_contained_entities (list (query_quantile feature 0.5 weight_feature)))
+											(compute_on_contained_entities (append filtering_queries (query_quantile feature 0.5 weight_feature)))
 										percentile_25
-											(compute_on_contained_entities (list (query_quantile feature 0.25 weight_feature)))
+											(compute_on_contained_entities (append filtering_queries (query_quantile feature 0.25 weight_feature)))
 										percentile_75
-											(compute_on_contained_entities (list (query_quantile feature 0.75 weight_feature)))
+											(compute_on_contained_entities (append filtering_queries (query_quantile feature 0.75 weight_feature)))
 									))
 
 									(assign (assoc
 										mean_absdev
-											(compute_on_contained_entities (list
+											(compute_on_contained_entities (append filtering_queries
 												(query_not_equals feature (null))
 												(query_generalized_mean feature 1 weight_feature mean (true) (true))
 											))
 										variance
-											(compute_on_contained_entities (list
+											(compute_on_contained_entities (append filtering_queries
 												(query_not_equals feature (null))
 												(query_generalized_mean feature 2 weight_feature mean (true))
 											))
@@ -649,7 +688,7 @@
 										stddev (sqrt variance)
 										skew
 											(/
-												(compute_on_contained_entities (list
+												(compute_on_contained_entities (append filtering_queries
 													(query_not_equals feature (null))
 													(query_generalized_mean feature 3 weight_feature mean (true))
 												))
@@ -658,7 +697,7 @@
 										kurtosis
 											(-
 												(/
-													(compute_on_contained_entities (list
+													(compute_on_contained_entities (append filtering_queries
 														(query_not_equals feature (null))
 														(query_generalized_mean feature 4 weight_feature mean (true))
 													))
@@ -672,17 +711,17 @@
 
 							(assign (assoc
 								mode
-									(compute_on_contained_entities (list
+									(compute_on_contained_entities (append filtering_queries
 										(query_mode feature weight_feature feature_is_numeric)
 									))
 								count
-									(compute_on_contained_entities (list
+									(compute_on_contained_entities (append filtering_queries
 										(query_not_equals feature (null))
 										(query_count)
 									))
 								uniques
 									(size
-										(compute_on_contained_entities (list
+										(compute_on_contained_entities (append filtering_queries
 											(query_value_masses feature (null) feature_is_numeric)
 										))
 									)
@@ -694,7 +733,7 @@
 										(let
 											(assoc
 												class_counts_map
-													(compute_on_contained_entities (list
+													(compute_on_contained_entities (append filtering_queries
 														(query_value_masses feature weight_feature feature_is_numeric)
 													))
 												total 0
@@ -734,8 +773,13 @@
 				(assign (assoc weight_feature ".none"))
 			)
 
-			(accum_to_entities (assoc
-				featureMarginalStatsMap (associate weight_feature stats)
-			))
+			(if (= (list) filtering_queries)
+				(accum_to_entities (assoc
+					featureMarginalStatsMap (associate weight_feature stats)
+				))
+
+				;else this was conditioned, return the marginal stats
+				stats
+			)
 		)
 )

--- a/trainee_template/marginal.amlg
+++ b/trainee_template/marginal.amlg
@@ -579,7 +579,7 @@
 				)
 
 				;else we have a condition
-				(declare
+				(let
 					(assoc
 						case_ids
 							(call GetCasesByCondition (assoc
@@ -658,7 +658,8 @@
 												feature
 											)
 										mean
-											(compute_on_contained_entities (append filtering_queries
+											(compute_on_contained_entities (append
+												filtering_queries
 												(query_not_equals feature (null))
 												;calculate arithmetic average
 												(query_generalized_mean feature 1 weight_feature)
@@ -673,12 +674,14 @@
 
 									(assign (assoc
 										mean_absdev
-											(compute_on_contained_entities (append filtering_queries
+											(compute_on_contained_entities (append
+												filtering_queries
 												(query_not_equals feature (null))
 												(query_generalized_mean feature 1 weight_feature mean (true) (true))
 											))
 										variance
-											(compute_on_contained_entities (append filtering_queries
+											(compute_on_contained_entities (append
+												filtering_queries
 												(query_not_equals feature (null))
 												(query_generalized_mean feature 2 weight_feature mean (true))
 											))
@@ -688,7 +691,8 @@
 										stddev (sqrt variance)
 										skew
 											(/
-												(compute_on_contained_entities (append filtering_queries
+												(compute_on_contained_entities (append
+													filtering_queries
 													(query_not_equals feature (null))
 													(query_generalized_mean feature 3 weight_feature mean (true))
 												))
@@ -697,7 +701,8 @@
 										kurtosis
 											(-
 												(/
-													(compute_on_contained_entities (append filtering_queries
+													(compute_on_contained_entities (append
+														filtering_queries
 														(query_not_equals feature (null))
 														(query_generalized_mean feature 4 weight_feature mean (true))
 													))
@@ -711,17 +716,20 @@
 
 							(assign (assoc
 								mode
-									(compute_on_contained_entities (append filtering_queries
+									(compute_on_contained_entities (append
+										filtering_queries
 										(query_mode feature weight_feature feature_is_numeric)
 									))
 								count
-									(compute_on_contained_entities (append filtering_queries
+									(compute_on_contained_entities (append
+										filtering_queries
 										(query_not_equals feature (null))
 										(query_count)
 									))
 								uniques
 									(size
-										(compute_on_contained_entities (append filtering_queries
+										(compute_on_contained_entities (append
+											filtering_queries
 											(query_value_masses feature (null) feature_is_numeric)
 										))
 									)
@@ -733,7 +741,8 @@
 										(let
 											(assoc
 												class_counts_map
-													(compute_on_contained_entities (append filtering_queries
+													(compute_on_contained_entities (append
+														filtering_queries
 														(query_value_masses feature weight_feature feature_is_numeric)
 													))
 												total 0

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -46,10 +46,10 @@
 				(list 	6.9 7.1 7.5		.13 	.71 	"large" 	14.5 	"melon")
 				(list 	8.6 7.4 8.5		.14 	.78 	"large" 	18 		"melon")
 
-				(list 	6 	3.7 4.1		.699	.70		"large" 	11 		"pinapple")
-				(list 	6.8 4.1 4.3		.75 	.65 	"large" 	13 		"pinapple")
-				(list 	7.5 4.8 5.0		.8 		.62 	"large" 	14 		"pinapple")
-				(list 	8.6	5.4	5.5		.85		.60 	"large" 	17	 	"pinapple")
+				(list 	6 	3.7 4.1		.699	.70		"large" 	11 		"pineapple")
+				(list 	6.8 4.1 4.3		.75 	.65 	"large" 	13 		"pineapple")
+				(list 	7.5 4.8 5.0		.8 		.62 	"large" 	14 		"pineapple")
+				(list 	8.6	5.4	5.5		.85		.60 	"large" 	17	 	"pineapple")
 		)
 	))
 
@@ -80,6 +80,18 @@
 		percent 0.01
 	))
 
+	(assign (assoc
+		result (call_entity "howso" "get_marginal_stats" (assoc condition (assoc fruit "pineapple")))
+	))
+	(print "Correct Conditioned Marginal Stats: ")
+	(call assert_equal (assoc
+		obs (unzip (get result "payload" "fruit") (list "count" "mode" "uniques" "entropy"))
+		exp (list 4 "pinenapple" 1 0)
+	))
+	(call assert_equal (assoc
+		obs (unzip (get result "payload" "weight") (list "count" "uniques" "max" "min" "mean"))
+		exp (list 4 4 17 11 13.75)
+	))
 
 	(call_entity "howso" "analyze" (assoc
 		context_features context_features


### PR DESCRIPTION
Add 'condition', 'precision', and 'num_cases' parameters to get_marginal_stats which allows users to get marginal statistics on a subset of the data that matches a given condition.