### PR TITLE
17581: Fixes bug where influential cases wouldn't be correct if requesting global or local_case_feature_residuals in the same details call

### DIFF
--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -275,18 +275,6 @@
 		))
 
 		(if (or
-				(get details "case_feature_residuals")
-				(get details "local_case_feature_residual_convictions")
-				(get details "global_case_feature_residual_convictions")
-			)
-			(call CalculateResidualsForCase (assoc
-				features features
-				case_values (append context_values action_values)
-				ignore_case ignore_case
-			))
-		)
-
-		(if (or
 				(get details "influential_cases")
 				(get details "hypothetical_values")
 				(get details "influential_cases_raw_weights")
@@ -310,6 +298,18 @@
 		(if
 			(and (!= (null) most_similar_cases_parameter) (!= (false) most_similar_cases_parameter))
 			(call ComputeMostSimilarCases)
+		)
+
+		(if (or
+				(get details "case_feature_residuals")
+				(get details "local_case_feature_residual_convictions")
+				(get details "global_case_feature_residual_convictions")
+			)
+			(call CalculateResidualsForCase (assoc
+				features features
+				case_values (append context_values action_values)
+				ignore_case ignore_case
+			))
 		)
 
 		(if (get details "similarity_conviction")

--- a/unit_tests/ut_h_edit_dist_features.amlg
+++ b/unit_tests/ut_h_edit_dist_features.amlg
@@ -372,9 +372,9 @@
 				amalgam (assoc mda 0.1)
 				yaml (assoc mda 0.1)
 				json (assoc mda 0.2)
-				x (assoc mda -0.2)
+				x (assoc mda -0.3)
 			)
-		thresh 0.4
+		thresh 0.6
 	))
 
 	(assign (assoc


### PR DESCRIPTION
requesting global or local_case_feature_residuals flows themselves call ReactDiscriminative which continues to accumulate influential cases, resulting in incorrect output of influential_cases if requested in the details.
The simple fix is to ensure that influentials are returned as requested before computing the feature residual details.