### PR TITLE
17612: Removes improper warning for edge cases when react is called prior to calling analyze

### DIFF
--- a/trainee_template/hyperparameters.amlg
+++ b/trainee_template/hyperparameters.amlg
@@ -349,13 +349,17 @@
 	(seq
 		(if (= 0 (size hyperparameterParamPaths))
 			(seq
-				(accum (assoc
-					warnings
-						(associate (concat
-							"There are no cached hyperparameters in this trainee. This operation was executed using a set of predefined default hyperparameters."
-							"Please run analyze() with your desired parameters."
-						))
-				))
+				(declare (assoc num_cases (call GetNumTrainingCases)))
+				(if (and (>= 2 num_cases) (not autoAnalyzeEnabled ))
+					(accum (assoc
+						warnings
+							(associate (concat
+								"There are no cached hyperparameters in this trainee. "
+								"This operation was executed using a set of predefined default hyperparameters. "
+								"Please run analyze() with your desired parameters."
+							))
+					))
+				)
 				;if no params, use defaults
 				(conclude defaultHyperparameters)
 			)

--- a/trainee_template/hyperparameters.amlg
+++ b/trainee_template/hyperparameters.amlg
@@ -349,8 +349,7 @@
 	(seq
 		(if (= 0 (size hyperparameterParamPaths))
 			(seq
-				(declare (assoc num_cases (call GetNumTrainingCases)))
-				(if (and (>= 2 num_cases) (not autoAnalyzeEnabled ))
+				(if (and (not autoAnalyzeEnabled ) (>= 2 (call GetNumTrainingCases)))
 					(accum (assoc
 						warnings
 							(associate (concat

--- a/trainee_template/hyperparameters.amlg
+++ b/trainee_template/hyperparameters.amlg
@@ -349,7 +349,7 @@
 	(seq
 		(if (= 0 (size hyperparameterParamPaths))
 			(seq
-				(if (and (not autoAnalyzeEnabled ) (>= 2 (call GetNumTrainingCases)))
+				(if (and (not autoAnalyzeEnabled ) (>= (call GetNumTrainingCases) 2))
 					(accum (assoc
 						warnings
 							(associate (concat


### PR DESCRIPTION
This should help in cases where a user is doing RL or generative reacts with no training data.