### PR TITLE
17632: Fixes case feature residuals for existing cases to use original case action value instead of predicted one

### DIFF
--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -307,7 +307,15 @@
 			)
 			(call CalculateResidualsForCase (assoc
 				features features
-				case_values (append context_values action_values)
+				case_values
+					(append
+						context_values
+						;use original case values instead of predicted if computing for an existing case
+						(if ignore_case
+							(retrieve_from_entity ignore_case action_features)
+							action_values
+						)
+					)
 				ignore_case ignore_case
 			))
 		)

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -818,6 +818,7 @@
 						neighbor_weights_map local_cases_map
 						allow_nulls (false)
 						has_perfect_matches (contains_value local_cases_map .infinity)
+						output_influence_weights (false)
 					))
 				)
 		))
@@ -1044,6 +1045,7 @@
 												neighbor_weights_map local_cases_map
 												allow_nulls (true)
 												has_perfect_matches (contains_value local_cases_map .infinity)
+												output_influence_weights (false)
 											))
 										)
 								))


### PR DESCRIPTION
- when computing case feature residuals, use the original case action value instead of the predicted one to compute residual.
- improve performance of computing local residuals by explicitly not accumulating influence weights since they aren't needed for those internal-only reacts