### PR TITLE
17464: Adds linux arm64 tests

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -55,6 +55,14 @@ jobs:
     needs: ['get-dependency-details', 'build']
     runs-on: ubuntu-latest
     steps:
+
+    - name: Collect Workflow Telemetry
+      uses: runforesight/workflow-telemetry-action@v1
+      with:
+        comment_on_pr: off
+        proc_trace_chart_show: off
+        proc_trace_table_show: off
+
     - uses: actions/checkout@v3
 
     - name: Download Amalgam
@@ -65,19 +73,104 @@ jobs:
         # Needed because release/non-release downloads are different structure
         cd target && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
 
-    - name: Amalgam version
-      run: |
-        ${{ github.workspace }}/target/bin/amalgam-mt --version
-
     - name: Test
       run: |
-        sudo locale-gen es_ES.utf8
+        sudo locale-gen es_ES.UTF-8
         ./build.sh test ${{ inputs.version }}
+
+  test-linux-arm64:
+    if: true
+    needs: ['get-dependency-details', 'build']
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Collect Workflow Telemetry
+      uses: runforesight/workflow-telemetry-action@v1
+      with:
+        comment_on_pr: off
+        proc_trace_chart_show: off
+        proc_trace_table_show: off
+
+    - uses: actions/checkout@v3
+
+    - name: Download Amalgam
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        SEARCH_POSTFIX=""
+        if [[ "${{ needs.get-dependency-details.outputs.run-type }}" == "release" ]]; then
+          SEARCH_POSTFIX=".tar.gz"
+        fi
+
+        gh ${{ needs.get-dependency-details.outputs.run-type }} download -D target -R "howsoai/amalgam" -p "*linux-arm64${SEARCH_POSTFIX}" "${{ needs.get-dependency-details.outputs.run-id }}"
+        # Needed because release/non-release downloads are different structure
+        cd target && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
+
+    - name: Test
+      uses: pguyot/arm-runner-action@v2
+      with:
+        base_image: raspios_lite_arm64:latest
+        cpu: cortex-a8
+        image_additional_mb: 1000
+        commands: |
+          set -e
+
+          sudo apt-get install --no-install-recommends -y git jq
+          sudo sed -i "s/en_GB.UTF-8/es_ES.UTF-8/g" /etc/locale.gen
+          sudo locale-gen es_ES.UTF-8 UTF-8
+
+          ./build.sh test ${{ inputs.version }}
+
+  test-linux-arm64_8a:
+    if: true
+    needs: ['get-dependency-details', 'build']
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Collect Workflow Telemetry
+      uses: runforesight/workflow-telemetry-action@v1
+      with:
+        comment_on_pr: off
+        proc_trace_chart_show: off
+        proc_trace_table_show: off
+
+    - uses: actions/checkout@v3
+
+    - name: Download Amalgam
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh ${{ needs.get-dependency-details.outputs.run-type }} download -D target -R "howsoai/amalgam" -p "*linux-arm64_8a*" "${{ needs.get-dependency-details.outputs.run-id }}"
+        # Needed because release/non-release downloads are different structure
+        cd target && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
+
+    - name: Test
+      uses: pguyot/arm-runner-action@v2
+      with:
+        base_image: raspios_lite_arm64:latest
+        cpu: cortex-a7
+        image_additional_mb: 1000
+        commands: |
+          set -e
+
+          sudo apt-get install --no-install-recommends -y git jq
+          sudo sed -i "s/en_GB.UTF-8/es_ES.UTF-8/g" /etc/locale.gen
+          sudo locale-gen es_ES.UTF-8 UTF-8
+
+          ./build.sh test ${{ inputs.version }} arm64_8a
 
   test-macos-amd64:
     needs: ['get-dependency-details', 'build']
     runs-on: macos-latest
     steps:
+
+    - name: Collect Workflow Telemetry
+      uses: runforesight/workflow-telemetry-action@v1
+      with:
+        comment_on_pr: off
+        proc_trace_chart_show: off
+        proc_trace_table_show: off
+
     - uses: actions/checkout@v3
 
     - name: Download Amalgam
@@ -88,11 +181,6 @@ jobs:
         # Needed because release/non-release downloads are different structure
         cd target && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
 
-    # GitHub macos runner does not support AVX
-    - name: Amalgam version
-      run: |
-        ${{ github.workspace }}/target/bin/amalgam-mt-noavx --version
-
     - name: Test
       run: |
         ./build.sh test ${{ inputs.version }}
@@ -101,6 +189,14 @@ jobs:
     needs: ['get-dependency-details', 'build']
     runs-on: windows-latest
     steps:
+
+    - name: Collect Workflow Telemetry
+      uses: runforesight/workflow-telemetry-action@v1
+      with:
+        comment_on_pr: off
+        proc_trace_chart_show: off
+        proc_trace_table_show: off
+
     - uses: actions/checkout@v3
 
     - name: Download Amalgam
@@ -115,10 +211,6 @@ jobs:
       shell: pwsh
       run: |
         ./build/powershell/Download-Tzdata.ps1
-
-    - name: Amalgam version
-      run: |
-        "${{ github.workspace }}/target/bin/amalgam-mt.exe" --version
 
     - name: Test
       run: |

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -9,6 +9,9 @@ on:
       payload:
         required: false
         type: string
+      build-type:
+        required: true
+        type: string
 
 defaults:
   run:
@@ -79,7 +82,7 @@ jobs:
         ./build.sh test ${{ inputs.version }}
 
   test-linux-arm64:
-    if: true
+    if: inputs.build-type != 'PR'
     needs: ['get-dependency-details', 'build']
     runs-on: ubuntu-latest
     steps:
@@ -122,7 +125,7 @@ jobs:
           ./build.sh test ${{ inputs.version }}
 
   test-linux-arm64_8a:
-    if: true
+    if: inputs.build-type != 'PR'
     needs: ['get-dependency-details', 'build']
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/create-branch-build.yml
+++ b/.github/workflows/create-branch-build.yml
@@ -65,6 +65,7 @@ jobs:
     with:
       version: ${{ needs.set-branch-version.outputs.version }}
       payload: ${{ inputs.payload }}
+      build-type: "branch"
 
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'

--- a/.github/workflows/create-pr-build.yml
+++ b/.github/workflows/create-pr-build.yml
@@ -51,6 +51,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.set-pr-version.outputs.version }}
+      build-type: "PR"
 
   # This job is here to have only one final step to add for "Status Checks"
   # in GitHub, instead of adding every leaf test from 'build-test-package'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ inputs.version }}
+      build-type: "release"
 
   create-release:
     needs: ['build-test-package']

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,6 @@ rel_dir=${src_dir}/release
 timestamp=$(date +%x_%H:%M)
 
 # Get the Platform we are running the build on.
-# This will be used to pick compiler options for 'linux' or 'darwin'
 plat=$(uname | tr '[:upper:]' '[:lower:]')
 if [[ "$plat" = 'darwin' ]]; then amlg_exe="${src_dir}/target/bin/amalgam-mt-noavx"; fi
 
@@ -63,6 +62,11 @@ build() {
 test() {
   engine_version=${1:-'0.0.0'}
   echo "Testing Howso Engine version ${engine_version}..."
+
+  arm_ver=${2:-''}
+  if [[ "$arm_ver" == "arm64_8a" ]]; then
+    amlg_exe=${src_dir}/target/bin/amalgam-st
+  fi
 
   update_version_file ${engine_version}
   cd ${src_dir}/unit_tests

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -304,8 +304,8 @@
 	(assign (assoc post_analyze_time (- (system_time) post_analyze_time) ))
 	(print "Load All: " (- (system_time) start) "\n")
 
-	(print "Post analyze load time is < 10 seconds: " post_analyze_time " ")
-	(call assert_true (assoc obs (< post_analyze_time 10) ))
+	(print "Post analyze load time is < 20 seconds: " post_analyze_time " ")
+	(call assert_true (assoc obs (< post_analyze_time 20) ))
 
 	(assign (assoc
 		result

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
   "dependencies": {
-    "amalgam": "6413343737"
+    "amalgam": "6414070566"
   }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
   "dependencies": {
-    "amalgam": "6414070566"
+    "amalgam": "45.0.0"
   }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
   "dependencies": {
-    "amalgam": "44.0.3"
+    "amalgam": "6413343737"
   }
 }


### PR DESCRIPTION
* Adds linux arm64 tests for engine UTs
* Adds ability to turn off jobs based on build type (currently only arm are disable on PRs since they can take over an hour to run sometimes, very flaky)
* Updates test slightly for slower arm runs on loads
* Bumps Amalgam version for needed fix for arm tests