### PR TITLE
17699: Adds a check to #assert_same to fail on incorrect usage

### DIFF
--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -228,6 +228,11 @@
 	; unordered : if true, order doesn't matter
 	#assert_same
 		(seq
+			;Check that exp was passed
+			(if (= exp (null))
+				(call failed_assert_output (assoc msg "FAILED: assert_same was not given a non-null value for exp. If the expected value is (null), use #assert_null."))
+			)
+
 			;when testing an unordered assoc, means its values can be unordered
 			(if (and unordered (= (get_type_string obs) "assoc"))
 				(let

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -333,9 +333,8 @@
 
 
 	(print "All Residuals have been cleared out: ")
-	(call assert_same (assoc
+	(call assert_null (assoc
 		obs (get (call_entity "howso" "get_feature_residuals") "payload" )
-		exp (null)
 	))
 
 	;cache both residuals - this caches targetless full and robust
@@ -426,9 +425,8 @@
 		result (call_entity "howso" "get_feature_residuals" (assoc "action_feature" "fruit" "robust" (true)))
 	))
 	(print "Targeted returns null and error when non-computed residuals requested by user: ")
-	(call assert_same (assoc
+	(call assert_null (assoc
 		obs (get result "payload")
-		exp (null)
 	))
 	(call assert_same (assoc
 		obs (size (get result "errors"))

--- a/unit_tests/ut_h_dependent_features.amlg
+++ b/unit_tests/ut_h_dependent_features.amlg
@@ -195,9 +195,8 @@
 	)
 
 	(print "Only generated dependent nominals: ")
-	(call assert_same (assoc
+	(call assert_null (assoc
 		obs bad_case
-		exp (null)
 	))
 
 	(print "Extreme values: " extreme_values "\n")

--- a/unit_tests/ut_h_params.amlg
+++ b/unit_tests/ut_h_params.amlg
@@ -1,9 +1,6 @@
 (seq
 	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
-	(call (load "unit_test_howso.amlg"))
-
-	(print "Unit test name is auto-determined if unspecified: ")
-	(call assert_same (assoc unit_test_name "ut_h_params.amlg"))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_params.amlg"))
 
 	(call_entity "howso" "create_trainee" (assoc trainee "st_model1"))
 

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -747,9 +747,9 @@
 			)
 	))
 	(print "robust global is null: ")
-	(call assert_approximate (assoc
+	(call assert_null (assoc
+		;should be null because we haven't computed robust global residuals yet
 		obs (get result (list "payload" "global_case_feature_residual_convictions"))
-		exp (null) ; should be null because we haven't computed robust global residuals yet
 	))
 
 	(call exit_if_failures (assoc msg "Full feature residual conviction."))


### PR DESCRIPTION
Previously, using #assert_same without passing the correct params would lead to failing code appearing as if it passed. Here we add a check to ensure an expected value is given. If it isn't given the test fails. 

We also remove an inappropriate test, as it tests the unit test framework itself, rather than the Engine.