### PR TITLE
17711: Fixes warnings logic in get_prediction_stats

### DIFF
--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -27,7 +27,7 @@
 
 		(declare (assoc
 			output_map (assoc)
-			warnings (list)
+			warnings (assoc)
 		))
 
 		;if no stats were specified, return all of them (except for confusion_matrix) by default
@@ -194,7 +194,7 @@
 		;output payload and warnings
 		(assoc
 			"payload" output_map
-			"warnings" (if (size warnings) warnings)
+			"warnings" (if (size warnings) (indices warnings) )
 		)
 	)
 
@@ -252,7 +252,7 @@
 
 		(declare (assoc
 			output_map (assoc)
-			warnings (list)
+			warnings (assoc)
 			case_ids
 				(call_entity trainee "GetCasesByCondition" (assoc
 					condition condition
@@ -437,7 +437,7 @@
 		;output payload and warnings
 		(assoc
 			"payload" output_map
-			"warnings" (if (size warnings) warnings)
+			"warnings" (if (size warnings) (indices warnings) )
 		)
 	)
 


### PR DESCRIPTION
Warnings was initialized as a (list) rather than an (assoc). Additionally, the entire assoc was being passed to #return, which was fine when it was a list, but now it needs to be the indices that are passed.