### PR TITLE
17719:  Adds warning to continue_series flows where given series IDs are not in the Trainee

### DIFF
--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -447,6 +447,10 @@
 						))
 				))
 
+				(if (= (size existing_series_cases) 0)
+					(accum (assoc warnings "There is no series trained with the given set of IDs."))
+				)
+
 				;if there is more than one existing series case, we'll need to sort them by the time feature to ensure ascending order
 				(if (> largest_max_row_lag 1)
 					(assign (assoc

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -448,7 +448,13 @@
 				))
 
 				(if (= (size existing_series_cases) 0)
-					(accum (assoc warnings (assoc "There is no series trained with the given set of IDs.")))
+					(accum (assoc
+						warnings
+							(associate (concat
+								"There is no series trained with the set of IDs:\n"
+								(apply "concat" (values (map (lambda (concat (target_index) ": "  (target_value) "\n")) id_values_map)))
+							))
+					))
 				)
 
 				;if there is more than one existing series case, we'll need to sort them by the time feature to ensure ascending order

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -448,7 +448,7 @@
 				))
 
 				(if (= (size existing_series_cases) 0)
-					(accum (assoc warnings "There is no series trained with the given set of IDs."))
+					(accum (assoc warnings (assoc "There is no series trained with the given set of IDs.")))
 				)
 
 				;if there is more than one existing series case, we'll need to sort them by the time feature to ensure ascending order

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -452,7 +452,7 @@
 						warnings
 							(associate (concat
 								"There is no series trained with the set of IDs:\n"
-								(apply "concat" (values (map (lambda (concat (target_index) ": "  (target_value) "\n")) id_values_map)))
+								(apply "concat" (map (lambda (concat ": "  (target_value) "\n")) id_values_map))
 							))
 					))
 				)

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -420,7 +420,7 @@
 
 	(print "Warning given when using an ID that was not trained: ")
 	(call assert_same (assoc
-		exp (list (assoc detail "There is no series trained with the given set of IDs."))
+		exp (list (assoc detail "There is no series trained with the set of IDs:\nstock: fake_stock\n"))
 		obs (get result "warnings")
 	))
 

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -402,6 +402,28 @@
 
 	(call exit_if_failures (assoc msg "Continue conditioned on IDs and start time."))
 
+	(assign (assoc
+		result
+			(call_entity "howso" "batch_react_series" (assoc
+				trainee "temp"
+				num_series_to_generate 1
+				action_features (list "stock" "time" "value" ".value_lag_2")
+				desired_conviction 5
+				use_regional_model_residuals (false)
+				continue_series (true)
+				init_time_steps (list 10)
+				output_new_series_ids (false)
+				initial_features (list "stock")
+				initial_values (list (list "fake_stock"))
+			))
+	))
+
+	(print "Warning given when using an ID that was not trained: ")
+	(call assert_same (assoc
+		exp (list (assoc detail "There is no series trained with the given set of IDs."))
+		obs (get result "warnings")
+	))
+
 	;set attributes to verify that continue doesn't work on terminated series
 	(call_entity "howso" "set_feature_attributes" (assoc
 		trainee "temp"


### PR DESCRIPTION
When using #react_series with the continue_series flag, there is an added warning that will indicate if the IDs specified by initial_values/initial_features do not belong to any cases/series in the model.