### PR TITLE
17748: Fixes an issue with .series_progress when using continue_series

### DIFF
--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -491,16 +491,22 @@
 					(if (size (last series_data))
 						(let
 							(assoc
-								no_time_derived_action_features
-									(filter (lambda (!= tsTimeFeature (target_value))) derived_action_features)
+								initial_progress_context_features
+									(append
+										;use all value, delta, and rate features to determine initial series progress
+										;exclude time feature (and delta)
+										(filter (lambda (!= tsTimeFeature (target_value))) derived_action_features)
+										(filter (lambda (!= (concat "." tsTimeFeature "_delta_1") (target_value))) (get tsModelFeaturesMap "delta_features"))
+										(get tsModelFeaturesMap "rate_features")
+									)
 							)
 
 							(assign (assoc
 								initial_existing_progress
 									(first (get
 										(call React (assoc
-											context_features no_time_derived_action_features
-											context_values (unzip (zip features (last series_data)) no_time_derived_action_features )
+											context_features initial_progress_context_features
+											context_values (unzip (zip features (last series_data)) initial_progress_context_features )
 											action_features (list ".series_progress")
 											;do not derive anything during this react
 											derived_action_features (list)
@@ -653,6 +659,11 @@
 						all_context_features
 					)
 			))
+
+			;if first case of series and using continue_series, start with computed series_progress
+			(if (and use_initial_context_features initial_existing_progress)
+				(assign (assoc current_case_map (set current_case_map ".series_progress" initial_existing_progress)))
+			)
 
 			;filter out action (rate and delta) features that are dependent on lags that were skipped due to referencing rows that have not been synthed yet
 			(if (> (size original_derived_context_features) (size derived_context_features))

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -492,12 +492,15 @@
 						(let
 							(assoc
 								initial_progress_context_features
-									(append
-										;use all value, delta, and rate features to determine initial series progress
-										;exclude time feature (and delta)
-										(filter (lambda (!= tsTimeFeature (target_value))) derived_action_features)
-										(filter (lambda (!= (concat "." tsTimeFeature "_delta_1") (target_value))) (get tsModelFeaturesMap "delta_features"))
-										(get tsModelFeaturesMap "rate_features")
+									(let
+										(assoc time_delta_feature_name (concat "." tsTimeFeature "_delta_1") )
+										(append
+											;use all value, delta, and rate features to determine initial series progress
+											;exclude time feature (and delta)
+											(filter (lambda (!= tsTimeFeature (target_value))) derived_action_features)
+											(filter (lambda (!= time_delta_feature_name (target_value))) (get tsModelFeaturesMap "delta_features"))
+											(get tsModelFeaturesMap "rate_features")
+										)
 									)
 							)
 

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -376,8 +376,7 @@
 	(call assert_true (assoc
 		obs
 			(and
-				;first and second series, first and second cases, first feature is stock id
-				;there should always be at least two cases because of two lags
+				;check that each series has at least one case where first feature is series ID and it is correct
 				(=
 					"stk_A"
 					(get series_list (list 0 0 0))

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -216,8 +216,8 @@
 	(print "Continued average series length is notably shorter: ")
 	(call assert_approximate (assoc
 		obs (/ (apply "+" series_lengths) (size series_lengths))
-		exp 3.5
-		thresh 1
+		exp 5
+		thresh 1.5
 	))
 
 	(call exit_if_failures (assoc msg "Unconditioned continue series."))
@@ -268,7 +268,7 @@
 	(print "Continued average series length from middle is medium length: ")
 	(call assert_approximate (assoc
 		obs (/ (apply "+" series_lengths) (size series_lengths))
-		exp 7.5
+		exp 6
 		thresh 2
 	))
 
@@ -381,21 +381,16 @@
 				(=
 					"stk_A"
 					(get series_list (list 0 0 0))
-					(get series_list (list 0 1 0))
 					(get series_list (list 1 0 0))
-					(get series_list (list 1 1 0))
 				)
 				(=
 					"stkB"
 					(get series_list (list 2 0 0))
-					(get series_list (list 2 1 0))
 					(get series_list (list 3 0 0))
-					(get series_list (list 3 1 0))
 				)
 				(=
 					"stoC"
 					(get series_list (list 4 0 0))
-					(get series_list (list 4 1 0))
 				)
 			)
 	))


### PR DESCRIPTION
The predicted initial series progress used in continue_series flows was not being properly used in downstream case generation. This fix allows series forecasting to have more accurate series length to the rest of the data trained in the Trainee.