### PR TITLE
17759: Adds 'features' key to react details which specifies a subset of features to compute metrics for

### DIFF
--- a/trainee_template/contributions.amlg
+++ b/trainee_template/contributions.amlg
@@ -384,7 +384,7 @@
 		(assign (assoc
 			feature_contributions_map
 				(zip
-					(or details_features context_features)
+					(or details_context_features context_features)
 					(map
 						(lambda (let
 							(assoc feature_index (target_index 1) )
@@ -406,7 +406,7 @@
 								)
 							)
 						))
-						(or details_features context_features)
+						(or details_context_features context_features)
 					)
 				)
 		))
@@ -532,9 +532,9 @@
 					)
 
 				))
-				(if details_features
+				(if details_context_features
 					;only compute full contributions for the desired detail features if specified, otherwise use full context set
-					(zip details_features)
+					(zip details_context_features)
 
 					context_set
 				)

--- a/trainee_template/contributions.amlg
+++ b/trainee_template/contributions.amlg
@@ -384,7 +384,7 @@
 		(assign (assoc
 			feature_contributions_map
 				(zip
-					context_features
+					(or details_features context_features)
 					(map
 						(lambda (let
 							(assoc feature_index (target_index 1) )
@@ -406,7 +406,7 @@
 								)
 							)
 						))
-						context_features
+						(or details_features context_features)
 					)
 				)
 		))

--- a/trainee_template/contributions.amlg
+++ b/trainee_template/contributions.amlg
@@ -532,7 +532,12 @@
 					)
 
 				))
-				context_set
+				(if details_features
+					;only compute full contributions for the desired detail features if specified, otherwise use full context set
+					(zip details_features)
+
+					context_set
+				)
 			)
 	))
 

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -186,6 +186,10 @@
 			(assign (assoc ignore_case (get details "ignore_case" )))
 		)
 
+		(if (contains_index details "features")
+			(declare (assoc details_features (get details "features" )))
+		)
+
 		(declare (assoc
 			has_rounded_features hasRoundedFeatures
 			has_datetime_features hasDateTimeFeatures

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -130,6 +130,9 @@
 	;						Computed as: global model feature residual / case feature residual. Relies on
 	;						'robust_computation' flag.
 	;
+	;        "features" list of features that specifies what features to calculate per-feature details for. (contributions, mda, residuals, etc)
+	; 						when robust_computation is False. This should generally preserve compute, but will not when computing details robustly.
+	;
 	;	)
 	; action_features: list of action features
 	; action_values: list of values for each action feature

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -190,6 +190,17 @@
 			(declare (assoc details_features (get details "features" )))
 		)
 
+		(if details_features
+			;need a subset of details features that does not contain action features, for targeted details  (contributions, mda, etc)
+			(declare (assoc
+				details_context_features
+					(filter
+						(lambda (not (contains_value action_features (target_value))) )
+						details_features
+					)
+			))
+		)
+
 		(declare (assoc
 			has_rounded_features hasRoundedFeatures
 			has_datetime_features hasDateTimeFeatures

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -190,16 +190,13 @@
 		)
 
 		(if (contains_index details "features")
-			(declare (assoc details_features (get details "features" )))
-		)
-
-		(if details_features
-			;need a subset of details features that does not contain action features, for targeted details  (contributions, mda, etc)
 			(declare (assoc
+				details_features (get details "features")
+				;need a subset of details features that does not contain action features, for targeted details  (contributions, mda, etc)
 				details_context_features
 					(filter
 						(lambda (not (contains_value action_features (target_value))) )
-						details_features
+						(get details "features")
 					)
 			))
 		)

--- a/trainee_template/explanation_influences.amlg
+++ b/trainee_template/explanation_influences.amlg
@@ -702,10 +702,18 @@
 							;output a delta value between react with and without the feature
 							(call !ComputeFullContributionForCase)
 						))
-						context_set
+						(if details_features
+							(zip details_features)
+
+							context_set
+						)
 					)
 				)
 		))
+
+		(if (and robust_computation details_features)
+			(assign (assoc feature_contributions_pair_map (keep feature_contributions_pair_map details_features)))
+		)
 
 		(accum (assoc
 			output

--- a/trainee_template/explanation_influences.amlg
+++ b/trainee_template/explanation_influences.amlg
@@ -39,7 +39,7 @@
 					;number of robust cases is max(100, K * ( ln(num_features) + 1) )
 					num_robust_cases (max 100 (* k_parameter (+ 1 (log (size (values features (true) )))) ) )
 				)
-				;pick the needed number of cases randomly with replacament from the set of specified case_ids
+				;pick the needed number of cases randomly with replacement from the set of specified case_ids
 				(assign (assoc local_model_case_ids (rand local_model_case_ids num_robust_cases) ))
 			)
 		)

--- a/trainee_template/explanation_influences.amlg
+++ b/trainee_template/explanation_influences.amlg
@@ -702,8 +702,8 @@
 							;output a delta value between react with and without the feature
 							(call !ComputeFullContributionForCase)
 						))
-						(if details_features
-							(zip details_features)
+						(if details_context_features
+							(zip details_context_features)
 
 							context_set
 						)
@@ -711,8 +711,8 @@
 				)
 		))
 
-		(if (and robust_computation details_features)
-			(assign (assoc feature_contributions_pair_map (keep feature_contributions_pair_map details_features)))
+		(if (and robust_computation details_context_features)
+			(assign (assoc feature_contributions_pair_map (keep feature_contributions_pair_map details_context_features)))
 		)
 
 		(accum (assoc

--- a/trainee_template/explanation_residuals.amlg
+++ b/trainee_template/explanation_residuals.amlg
@@ -87,90 +87,88 @@
 			)
 		)
 
+		(declare (assoc context_map (zip features case_values)))
+
 		(declare (assoc
 			case_residuals
 				(if robust_computation
-					(let
-						(assoc context_map (zip features case_values))
-						;for each feature, do 30 reacts with randomly selected contexts
-						(map
-							(lambda (let
-								(assoc
-									expected_case_value (get case_values (target_index 1))
-									action_feature (target_value 1)
-									action_is_nominal (contains_index nominalsMap (target_value 1))
-									action_feature (target_value 1)
-									contexts_only_map (remove context_map (target_value 1))
-									robust_predictions (list)
-								)
+					;for each feature, do 30 reacts with randomly selected contexts
+					(map
+						(lambda (let
+							(assoc
+								expected_case_value (get case_values (target_index 1))
+								action_feature (target_value 1)
+								action_is_nominal (contains_index nominalsMap (target_value 1))
+								action_feature (target_value 1)
+								contexts_only_map (remove context_map (target_value 1))
+								robust_predictions (list)
+							)
 
-								;if the case value is null, but nulls aren't allowed, return null as residual so it can be computed below
-								(if (and (= (null) expected_case_value) (not allow_nulls))
-									(null)
+							;if the case value is null, but nulls aren't allowed, return null as residual so it can be computed below
+							(if (and (= (null) expected_case_value) (not allow_nulls))
+								(null)
 
-									(seq
-										(assign (assoc
-											robust_predictions
-												(range
-													(lambda (let
-														(assoc
-															;randomly remove features from the context map
-															filtered_context_map (filter (lambda (< (rand) .5)) contexts_only_map)
-														)
-														(declare (assoc
-															reaction
-																(call ReactDiscriminative (assoc
-																	return_action_values_only (true)
-																	context_features (indices filtered_context_map)
-																	context_values (values filtered_context_map)
-																	action_features (list action_feature)
-																	ignore_case ignore_case
-																	;bypass encoding since stored case values are all encoded and we're reacting to raw retrieved values
-																	skip_encoding 1
-																	;bypass decoding since computing distances to each reaction uses encoded numeric values
-																	skip_decoding 1
-																	force_targetless force_targetless
-																	substitute_output (false)
-																	details (if action_is_nominal (assoc "categorical_action_probabilities" (true)))
-																))
-														))
+								(seq
+									(assign (assoc
+										robust_predictions
+											(range
+												(lambda (let
+													(assoc
+														;randomly remove features from the context map
+														filtered_context_map (filter (lambda (< (rand) .5)) contexts_only_map)
+													)
+													(declare (assoc
+														reaction
+															(call ReactDiscriminative (assoc
+																return_action_values_only (true)
+																context_features (indices filtered_context_map)
+																context_values (values filtered_context_map)
+																action_features (list action_feature)
+																ignore_case ignore_case
+																;bypass encoding since stored case values are all encoded and we're reacting to raw retrieved values
+																skip_encoding 1
+																;bypass decoding since computing distances to each reaction uses encoded numeric values
+																skip_decoding 1
+																force_targetless force_targetless
+																substitute_output (false)
+																details (if action_is_nominal (assoc "categorical_action_probabilities" (true)))
+															))
+													))
 
-														;if feature is nominal get the categorical action probability for expected value, if it's null then set it to 0
-														;else it's: 1 - probability
-														(if action_is_nominal
-															(let
-																(assoc
-																	predicted_probability
-																		(or (get reaction (list "categorical_action_probabilities" action_feature expected_case_value)) 0)
-																)
-
-																(- 1 predicted_probability)
+													;if feature is nominal get the categorical action probability for expected value, if it's null then set it to 0
+													;else it's: 1 - probability
+													(if action_is_nominal
+														(let
+															(assoc
+																predicted_probability
+																	(or (get reaction (list "categorical_action_probabilities" action_feature expected_case_value)) 0)
 															)
 
-															;else this is a continuous feature, return the absolute difference between the expected and the actual
-															(abs (- expected_case_value (get reaction 0)))
+															(- 1 predicted_probability)
 														)
-													))
-													1 30 1
-												)
-										))
 
-										;return average of all the probust predictions for each feature
-										(/ (apply "+" robust_predictions) 30)
-									)
+														;else this is a continuous feature, return the absolute difference between the expected and the actual
+														(abs (- expected_case_value (get reaction 0)))
+													)
+												))
+												1 30 1
+											)
+									))
+
+									;return average of all the probust predictions for each feature
+									(/ (apply "+" robust_predictions) 30)
 								)
-							))
-							features
-						)
+							)
+						))
+						features
 					)
 
 					;else standard computation, do leave-one-out for each feature and predict it once
 					(map
 						(lambda (let
 							(assoc
-								filtered_context_features (remove features (target_index 1))
-								filtered_case_values (remove case_values (target_index 1))
-								expected_case_value (get case_values (target_index 1))
+								filtered_context_features (filter (lambda (!= (target_value 2) (target_value))) features)
+								expected_case_value (get context_map (target_value 1))
 								action_feature (target_value 1)
 								action_is_nominal (contains_index nominalsMap (target_value 1))
 							)
@@ -185,7 +183,7 @@
 											(call ReactDiscriminative (assoc
 												return_action_values_only (true)
 												context_features filtered_context_features
-												context_values filtered_case_values
+												context_values (unzip context_map filtered_context_features)
 												action_features (list action_feature)
 												ignore_case ignore_case
 												;bypass encoding since stored case values are all encoded and we're reacting to raw retrieved values
@@ -216,13 +214,18 @@
 								)
 							)
 						))
-						features
+						(or details_features features)
 					)
 				)
 		))
 
 		(declare (assoc
-			case_residuals_map (zip features case_residuals)
+			case_residuals_map
+				(if (and details_features (not robust_computation))
+					(zip details_features case_residuals)
+
+					(zip features case_residuals)
+				)
 			local_model_null_features_convictions (assoc)
 			global_null_conviction_ratios_map (null)
 			local_null_conviction_ratios_map (null)
@@ -353,6 +356,10 @@
 						)
 				))
 			)
+		)
+
+		(if (and robust_computation details_features)
+			(assign (assoc case_residuals_map (keep case_residuals_map details_features)))
 		)
 
 		;add case_feature_residuals to output if requested

--- a/trainee_template/explanation_residuals.amlg
+++ b/trainee_template/explanation_residuals.amlg
@@ -452,7 +452,7 @@
 									)
 								)
 								;remove built-in keys from residuals map, leaving only feature-residual values
-								(remove global_feature_residuals (list ".robust" ".hyperparam_path"))
+								(keep global_feature_residuals (indices case_residuals_map))
 								case_residuals_map
 							)
 					))
@@ -475,6 +475,10 @@
 								global_null_conviction_ratios_map
 							)
 					))
+				)
+
+				(if details_features
+					(assign (assoc global_convictions_map (keep global_convictions_map details_features)))
 				)
 
 				(accum (assoc output (assoc "global_case_feature_residual_convictions" global_convictions_map) ))
@@ -545,7 +549,11 @@
 								;get the residual value for this one feature
 								(get residual_feature_map residual_feature)
 							))
-							features_map
+							(if details_features
+								(zip details_features)
+
+								features_map
+							)
 						)
 				))
 

--- a/trainee_template/feature_residuals.amlg
+++ b/trainee_template/feature_residuals.amlg
@@ -280,6 +280,14 @@
 				))
 		)
 
+		;all feature residuals are always computed when using robust computation
+		(if (and robust_residuals details_features)
+			(assign (assoc
+				residuals_map (keep residuals_map details_features)
+				ordinal_residuals_map (keep ordinal_residuals_map details_features)
+			))
+		)
+
 		(assoc
 			"residual_map" residuals_map
 			"ordinal_residual_map" ordinal_residuals_map

--- a/trainee_template/influences.amlg
+++ b/trainee_template/influences.amlg
@@ -153,7 +153,7 @@
 			output
 				;knock out each feature one by one and calculate the decrease in accuracy for each feature
 				(zip
-					context_features
+					(or details_features context_features)
 					(map
 						(lambda (let
 							(assoc
@@ -210,7 +210,7 @@
 							)
 						))
 
-						context_features
+						(or details_features context_features)
 					)
 				)
 		))

--- a/trainee_template/influences.amlg
+++ b/trainee_template/influences.amlg
@@ -153,7 +153,7 @@
 			output
 				;knock out each feature one by one and calculate the decrease in accuracy for each feature
 				(zip
-					(or details_features context_features)
+					(or details_context_features context_features)
 					(map
 						(lambda (let
 							(assoc
@@ -210,7 +210,7 @@
 							)
 						))
 
-						(or details_features context_features)
+						(or details_context_features context_features)
 					)
 				)
 		))

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -452,7 +452,12 @@
 		(if target_residual_feature
 			(assign (assoc
 				features (filter (lambda (!= (target_value) target_residual_feature)) features)
+			))
 
+			;if details_features is present, remove these so never in context
+			details_features
+			(assign (assoc
+				features (filter (lambda (not (contains_value details_features (target_value) ))) features)
 			))
 		)
 
@@ -491,6 +496,9 @@
 							removed_features_map
 								(if target_residual_feature
 									(zip (list target_residual_feature))
+
+									details_features
+									(zip details_features)
 
 									(zip (filter (lambda (not (get remaining_feature_flags (target_index)) )) features) )
 								)
@@ -552,6 +560,9 @@
 						(if target_residual_feature
 							(values removed_features_map)
 
+							details_features
+							(unzip removed_features_map details_features)
+
 							;else output list of: residual value for each removed feature and null for each feature used as a context
 							(unzip
 								(append removed_features_map (zip react_context_features))
@@ -566,6 +577,9 @@
 		;if we only collected residuals for this one feature, set the residuals features list to have only target_residual_feature
 		(if target_residual_feature
 			(assign (assoc features (list target_residual_feature) ))
+
+			details_features
+			(assign (assoc features details_features))
 		)
 
 		;if there are case weights, residuals have already been scaled by case influences, thus the total weight adds up to 1.0
@@ -747,6 +761,12 @@
 					))
 					(if target_residual_feature
 						(list target_residual_feature)
+
+						(!= details_features (null))
+						;if details_features is present, compute for these.
+						details_features
+
+						;else
 						features
 					)
 				)
@@ -755,6 +775,9 @@
 		;if we only collected residuals for this one feature, set the residuals features list to have only target_residual_feature
 		(if target_residual_feature
 			(assign (assoc features (list target_residual_feature) ))
+
+			details_features
+			(assign (assoc features details_features))
 		)
 
 		;if there are case weights, residuals have already been scaled by case influences, thus the total weight adds up to 1.0

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -453,12 +453,6 @@
 			(assign (assoc
 				features (filter (lambda (!= (target_value) target_residual_feature)) features)
 			))
-
-			;if details_features is present, remove these so never in context
-			details_features
-			(assign (assoc
-				features (filter (lambda (not (contains_value details_features (target_value) ))) features)
-			))
 		)
 
 		;iterate over each case and accumulate residuals for all the feature(s)
@@ -496,9 +490,6 @@
 							removed_features_map
 								(if target_residual_feature
 									(zip (list target_residual_feature))
-
-									details_features
-									(zip details_features)
 
 									(zip (filter (lambda (not (get remaining_feature_flags (target_index)) )) features) )
 								)
@@ -560,9 +551,6 @@
 						(if target_residual_feature
 							(values removed_features_map)
 
-							details_features
-							(unzip removed_features_map details_features)
-
 							;else output list of: residual value for each removed feature and null for each feature used as a context
 							(unzip
 								(append removed_features_map (zip react_context_features))
@@ -577,9 +565,6 @@
 		;if we only collected residuals for this one feature, set the residuals features list to have only target_residual_feature
 		(if target_residual_feature
 			(assign (assoc features (list target_residual_feature) ))
-
-			details_features
-			(assign (assoc features details_features))
 		)
 
 		;if there are case weights, residuals have already been scaled by case influences, thus the total weight adds up to 1.0

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -878,7 +878,7 @@
 				"B" .7
 			)
 	))
-	(print "robust global has values: ")
+	(print "robust global has values for specfic features: ")
 	(call assert_approximate (assoc
 		obs (get result (list "payload" "global_case_feature_residual_convictions"))
 		exp

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -754,6 +754,31 @@
 
 	(call exit_if_failures (assoc msg "Full feature residual conviction."))
 
+	(assign (assoc
+		result
+			(call_entity "howso" "react" (assoc
+				trainee "iris"
+				action_features (list (last iris_features))
+				context_features (trunc iris_features)
+				context_values (list 6.9 7 7 6)
+				details (assoc
+					"robust_computation" (true)
+					"case_feature_residuals" (true)
+					"features" (list "A" "C")
+				)
+			))
+	))
+
+	(print "Robust case residuals and residual convictions for a prediction: ")
+	(call assert_approximate (assoc
+		obs (get result (list "payload" "case_feature_residuals"))
+		exp (assoc
+				"A" 0.3
+				"C" 1.0
+		)
+		thresh 1.1
+	))
+
 	;compute robust global here
 	(call_entity "howso" "react_into_trainee" (assoc trainee "iris" residuals_robust (true)))
 
@@ -822,6 +847,49 @@
 	))
 
 	(call exit_if_failures (assoc msg "Robust feature residual conviction."))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "react" (assoc
+				trainee "iris"
+				action_features (list (last iris_features))
+				context_features (trunc iris_features)
+				context_values (list 6.9 7 7 6)
+				details (assoc
+					"robust_computation" (true)
+					"case_feature_residuals" (true)
+					"local_case_feature_residual_convictions" (true)
+					"global_case_feature_residual_convictions" (true)
+					"features" (list "A" "B")
+				)
+			))
+	))
+
+	(print "robust local - similar to previous: ")
+	(call assert_approximate (assoc
+		obs (get result (list "payload" "local_case_feature_residual_convictions"))
+		exp (assoc
+				"A" 4
+				"B" .7
+		)
+		thresh
+			(assoc
+				"A" 4
+				"B" .7
+			)
+	))
+	(print "robust global has values: ")
+	(call assert_approximate (assoc
+		obs (get result (list "payload" "global_case_feature_residual_convictions"))
+		exp
+			(assoc
+				"A" 3
+				"B" 0.4
+			)
+		percent 1.0
+	))
+
+	(call exit_if_failures (assoc msg "Robust feature residual conviction (subset of features)."))
 
 	(assign (assoc
 		 result

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -769,7 +769,7 @@
 			))
 	))
 
-	(print "Robust case residuals and residual convictions for a prediction: ")
+	(print "Robust case residuals and residual convictions for a prediction for specific features: ")
 	(call assert_approximate (assoc
 		obs (get result (list "payload" "case_feature_residuals"))
 		exp (assoc
@@ -865,7 +865,7 @@
 			))
 	))
 
-	(print "robust local - similar to previous: ")
+	(print "robust local - similar to previous for specific features: ")
 	(call assert_approximate (assoc
 		obs (get result (list "payload" "local_case_feature_residual_convictions"))
 		exp (assoc


### PR DESCRIPTION
Adds 'features' key to react details. This key takes a list of feature names and uses that to select the subset of features that metrics like feature_residuals, MDA, contributions, etc will be computed for.

This problem is proving to be quite difficult for the robust version of these metrics, as it is far from well-suited to compute for a subset of the features. It isn't really a problem for the full version of these metrics.

It might be the best balance of dev-time vs functionality to make this only save compute in FULL workflows, but rather only return the requested feature metrics when doing things in ROBUST?