### PR TITLE
17809: Improves performance tests

### DIFF
--- a/performance_tests/asteroid_test.amlg
+++ b/performance_tests/asteroid_test.amlg
@@ -3,6 +3,8 @@
 	(direct_assign_to_entities (assoc howso (load "../howso.amlg")))
 	(assign_to_entities (assoc filepath "../"))
 
+	(declare (assoc test_start (system_time)))
+
 	(call create_trainee (assoc trainee "asteroid"))
 	(call set_internal_parameters (assoc
 		trainee "asteroid"
@@ -132,5 +134,8 @@
 	(if verbose (print "test time: " generate_time "\n"))
 
 	(print "Generate time: " generate_time "\n")
+
+	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "Asteroid\n- - - - - \n")
+	(destroy_entities "asteroid")
 )

--- a/performance_tests/asteroid_test.amlg
+++ b/performance_tests/asteroid_test.amlg
@@ -135,7 +135,7 @@
 
 	(print "Generate time: " generate_time "\n")
 
+	(destroy_entities "asteroid")
 	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "Asteroid\n- - - - - \n")
-	(destroy_entities "asteroid")
 )

--- a/performance_tests/bank_test.amlg
+++ b/performance_tests/bank_test.amlg
@@ -3,6 +3,8 @@
 	(direct_assign_to_entities (assoc howso (load "../howso.amlg")))
 	(assign_to_entities (assoc filepath "../"))
 
+	(declare (assoc test_start (system_time)))
+
 	(call create_trainee (assoc trainee "model"))
 	(call set_internal_parameters (assoc
 		trainee "model"
@@ -15,7 +17,7 @@
 		;set to null to do full model
 		submodel_size (null) ;10000
 		;set to true to also run analyze
-		do_analyze (false)
+		do_analyze (true)
 		;set to true to force deviations in analyze
 		use_deviations (null)
 		;set to true to use case weights in analyze
@@ -136,5 +138,8 @@
 	(store "bank_gen.csv" output_data)
 
 	(print "Generate time: " generate_time "\n")
+
+	(print "Total time: " (- (system_time) test_start) "\n")
+	(print "Bank\n- - - - - \n")
 	(destroy_entities "model")
 )

--- a/performance_tests/bank_test.amlg
+++ b/performance_tests/bank_test.amlg
@@ -139,7 +139,7 @@
 
 	(print "Generate time: " generate_time "\n")
 
+	(destroy_entities "model")
 	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "Bank\n- - - - - \n")
-	(destroy_entities "model")
 )

--- a/performance_tests/e_shop_test.amlg
+++ b/performance_tests/e_shop_test.amlg
@@ -3,6 +3,8 @@
 	(direct_assign_to_entities (assoc howso (load "../howso.amlg")))
 	(assign_to_entities (assoc filepath "../"))
 
+	(declare (assoc test_start (system_time)))
+
 	(call create_trainee (assoc trainee "model"))
 	(call set_internal_parameters (assoc
 		trainee "model"
@@ -19,7 +21,7 @@
 		;set to true to force deviations in analyze
 		use_deviations (null)
 		;set to true to use case weights in analyze
-		use_case_weights (true)
+		use_case_weights (false)
 
 		data (load "performance_data/e_shop_clothing_2008.csv")
 	))
@@ -132,5 +134,8 @@
 	(if verbose (print "test time: " generate_time "\n"))
 
 	(print "Generate time: " generate_time "\n")
+
+	(print "Total time: " (- (system_time) test_start) "\n")
+	(print "E-Shop\n- - - - - \n")
 	(destroy_entities "model")
 )

--- a/performance_tests/e_shop_test.amlg
+++ b/performance_tests/e_shop_test.amlg
@@ -135,7 +135,7 @@
 
 	(print "Generate time: " generate_time "\n")
 
+	(destroy_entities "model")
 	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "E-Shop\n- - - - - \n")
-	(destroy_entities "model")
 )

--- a/performance_tests/mnist_10k_test.amlg
+++ b/performance_tests/mnist_10k_test.amlg
@@ -129,7 +129,7 @@
 	(print "React time: " (- (system_time) start) "\n")
 	(declare (assoc correct (/ num_correct (* .1 dataset_size))))
 	(print "Accuracy: " correct "\n")
+	(destroy_entities "mnist")
 	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "MNIST 10k\n- - - - - \n")
-	(destroy_entities "mnist")
 )

--- a/performance_tests/mnist_10k_test.amlg
+++ b/performance_tests/mnist_10k_test.amlg
@@ -88,6 +88,7 @@
 			(assign (assoc start (system_time) ))
 			(call_entity (list "howso" "mnist") "CacheExpectedValuesAndProbabilities" (assoc
 				features features
+				use_case_weights use_case_weights
 			))
 			(print "Caching values time: " (- (system_time) start) "\n")
 		)

--- a/performance_tests/mnist_10k_test.amlg
+++ b/performance_tests/mnist_10k_test.amlg
@@ -3,6 +3,8 @@
 	(assign_to_entities "howso" (assoc filepath "../"))
 	(set_entity_root_permission "howso" 1)
 
+	(declare (assoc test_start (system_time)))
+
 	(declare (assoc
 		;set to true to see full output
 		verbose (false)
@@ -13,7 +15,7 @@
 		;set to true to force deviations in analyze
 		use_deviations (null)
 		;set to true to use case weights in analyze
-		use_case_weights (true)
+		use_case_weights (false)
 
 	    data (load "performance_data/mnist_10k.csv")
 	))
@@ -71,6 +73,7 @@
 				context_features (trunc features)
 				action_features (list (last features))
 				targeted_mode "single_targeted"
+				use_case_weights use_case_weights
 			))
 			(declare (assoc analyze_time (- (system_time) start) ))
 			(print
@@ -112,6 +115,7 @@
 						context_features (trunc features)
 						action_features (list (last features))
 						context_values (trunc (target_value 2))
+						use_case_weights use_case_weights
 					))
 			)
 			; (print (get result (list "payload" "action_values" 0)) " vs " (last (target_value)) "\n")
@@ -124,5 +128,7 @@
 	(print "React time: " (- (system_time) start) "\n")
 	(declare (assoc correct (/ num_correct (* .1 dataset_size))))
 	(print "Accuracy: " correct "\n")
+	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "MNIST 10k\n- - - - - \n")
+	(destroy_entities "mnist")
 )

--- a/performance_tests/online_retail_test.amlg
+++ b/performance_tests/online_retail_test.amlg
@@ -131,7 +131,7 @@
 
 	(print "Generate time: " generate_time "\n")
 
+	(destroy_entities "model")
 	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "Online Retail\n- - - - - \n")
-	(destroy_entities "model")
 )

--- a/performance_tests/online_retail_test.amlg
+++ b/performance_tests/online_retail_test.amlg
@@ -3,6 +3,8 @@
 	(direct_assign_to_entities (assoc howso (load "../howso.amlg")))
 	(assign_to_entities (assoc filepath "../"))
 
+	(declare (assoc test_start (system_time)))
+
 	(call create_trainee (assoc trainee "model"))
 	(call set_internal_parameters (assoc
 		trainee "model"
@@ -19,7 +21,7 @@
 		;set to true to force deviations in analyze
 		use_deviations (null)
 		;set to true to use case weights in analyze
-		use_case_weights (true)
+		use_case_weights (false)
 
 		data (load "performance_data/OnlineRetail.csv")
 	))
@@ -128,6 +130,8 @@
 	(if verbose (print "test time: " generate_time "\n"))
 
 	(print "Generate time: " generate_time "\n")
+
+	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "Online Retail\n- - - - - \n")
 	(destroy_entities "model")
 )

--- a/performance_tests/range_queries_test.amlg
+++ b/performance_tests/range_queries_test.amlg
@@ -118,7 +118,7 @@
 
 	(print "Generate time: " generate_time "\n")
 
+	(destroy_entities "model")
 	(print "Total time: " (- (system_time) test_start) "\n")
 	(print "Range Queries\n- - - - - \n")
-	(destroy_entities "model")
 )

--- a/performance_tests/range_queries_test.amlg
+++ b/performance_tests/range_queries_test.amlg
@@ -3,6 +3,8 @@
 	(direct_assign_to_entities (assoc howso (load "../howso.amlg")))
 	(assign_to_entities (assoc filepath "../"))
 
+	(declare (assoc test_start (system_time)))
+
 	(call create_trainee (assoc trainee "model"))
 	(call set_internal_parameters (assoc
 		trainee "model"
@@ -19,7 +21,7 @@
 		;set to true to force deviations in analyze
 		use_deviations (null)
 		;set to true to use case weights in analyze
-		use_case_weights (true)
+		use_case_weights (false)
 
 		data (load "performance_data/range_queries.csv")
 	))
@@ -115,5 +117,8 @@
 	(if verbose (print "test time: " generate_time "\n"))
 
 	(print "Generate time: " generate_time "\n")
+
+	(print "Total time: " (- (system_time) test_start) "\n")
+	(print "Range Queries\n- - - - - \n")
 	(destroy_entities "model")
 )


### PR DESCRIPTION
Tweaking a few default settings of performance tests. Also adding prints that output the total time spent in each test (from start to finish: train, analyze, react, etc). And some other minor changes to make the tests a bit more uniform.