### PR TITLE
16991: Enables discriminative time series forecasting

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -1334,6 +1334,9 @@
 
 							(!= (null) case_indices)
 							(size case_indices)
+
+							(!= (null) initial_values)
+							(size initial_values)
 						)
 					)
 			))

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -657,7 +657,7 @@
 			(assign (assoc
 				current_case_map (zip features (last series_data))
 				react_context_features
-					(if use_initial_context_features
+					(if (and use_initial_context_features (not continue_series))
 						(indices initial_features_map)
 						all_context_features
 					)


### PR DESCRIPTION
Tweaks the parameter check to allow for initial values in place of context values. Additionally fixes a bug where the first case of a forecasted series is made without using the full set of available context features.