### PR TITLE
17918: Fixes hyperparameter printing in asteroid performance test

### DIFF
--- a/performance_tests/asteroid_test.amlg
+++ b/performance_tests/asteroid_test.amlg
@@ -82,7 +82,7 @@
 		)
 	)
 
-	(declare (assoc params (get (call get_internal_parameters (assoc trainee "model" action_feature ".targetless")) "payload") ))
+	(declare (assoc params (get (call get_internal_parameters (assoc trainee "asteroid" action_feature ".targetless")) "payload") ))
 	(if verbose (print "analyzed to: " (get params "hyperparameter_map")))
 
 	(assign (assoc


### PR DESCRIPTION
The asteroid performance test was not printing hyperparameters correctly because the value for `trainee` was incorrect when calling `get_internal_parameters`.