### PR TITLE
18032: Refactors react robust_computation flag into robust_residuals and robust_influences, MAJOR

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -58,6 +58,7 @@
 ;	"pairwise_distances"
 ;	"distances"
 ;	"set_min_ablatement_model_size"
+;	"set_influence_weight_threshold"
 ;	"export_trainee"
 ;	"upgrade_trainee"
 ;	"get_api"
@@ -2636,7 +2637,7 @@
 
 	;set the influence weight threshold for outputting only the K neighbors whose inflence weight is <= to this threshold
 	;default value is 0.99
-	#set_influenceWeightThreshold
+	#set_influence_weight_threshold
 		(seq
 			(assign_to_entities trainee (assoc influenceWeightThreshold influenceWeightThreshold))
 			(accum_to_entities trainee (assoc revision 1))

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -281,7 +281,9 @@
 			p_parameter (get hyperparam_map "p")
 			dt_parameter (get hyperparam_map "dt")
 			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
-			robust_computation (get details "robust_computation")
+			;robust_influences defaults to true, so only set to false if explicitly passed in as false
+			robust_influences (not (= (false) (get details "robust_influences")))
+			robust_residuals (get details "robust_residuals")
 		))
 
 		(if (or
@@ -388,7 +390,7 @@
 		)
 
 		(if (get details "case_contributions")
-			(if robust_computation
+			(if robust_influences
 				(call ComputeCaseContributionsRobust)
 
 				(call ComputeCaseContributions)

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -73,48 +73,52 @@
 	;		 "observational_errors" true or false. If true outputs observational errors for all features as defined
 	;						in feature attributes.
 	;
-	;		 "robust_computation" true or false. Default is false, uses leave-one-out for features (or cases, as needed)
-	;						for all relevant computations. When true, uses uniform sampling from the power set of all
+	;		 "robust_residuals" true or false. Default is false, uses leave-one-out for features (or cases, as needed)
+	;						for all residual computations. When true, uses uniform sampling from the power set of all
 	;						combinations of features (or cases, as needed) instead.
+	;
+	;		 "robust_influences" true or false. Default is true, uses leave-one-out for features (or cases, as needed)
+	;						for all MDA and contribution computations. When true, uses uniform sampling from the power
+	;						set of all combinations of features (or cases, as needed) instead.
 	;
 	;		 "feature_residuals" true or false. If true outputs feature residuals for all (context and action) features
 	;						locally around the prediction. Uses only the context features of the reacted case to
-	;						determine that area. Relies on 'robust_computation' flag.
+	;						determine that area. Relies on 'robust_residuals' flag.
 	;
 	;		 "feature_mda" true or false. If true outputs each context feature's mean decrease in accuracy of predicting
 	;						the action feature given the context. Uses only the context features of the reacted
-	;						case to determine that area. Relies on 'robust_computation' flag.
+	;						case to determine that area. Relies on 'robust_influences' flag.
 	;
 	;		 "feature_mda_ex_post" true or false. If true outputs each context feature's mean decrease in accuracy of
 	;						predicting the action feature as an explanation given that the specified prediction was
 	;						already made as specified by the action value. Uses both context and action features of
-	;						the reacted case to determine that area. Relies on 'robust_computation' flag.
+	;						the reacted case to determine that area. Relies on 'robust_influences' flag.
 	;
 	;		 "feature_contributions" true or false. If true outputs each context feature's differences between the
 	;						predicted action feature value and the predicted action feature value if each context
 	;						feature were not in the model for all context features in the local model area. Outputs
 	;						both 'feature_contributions' and non-absolute 'directional_feature_contributions'.
-	;						Relies on 'robust_computation' flag.
+	;						Relies on 'robust_influences' flag.
 	;
 	;		 "case_mda" true or false. If true outputs each influential case's mean decrease in accuracy of predicting
 	;						the action feature in the local model area, as if each individual case were included
 	;						versus not included. Uses only the context features of the reacted case to determine
-	;						that area. Relies on 'robust_computation' flag for case holdouts.
+	;						that area. Relies on 'robust_influences' flag for case holdouts.
 	;
 	;		 "case_contributions" true or false. If true outputs each influential case's differences between the
 	;						predicted action feature value and the predicted action feature value if each
 	;						individual case were not included. Uses only the context features of the reacted case
-	;						to determine that area. Relies on 'robust_computation' flag for case holdouts.
+	;						to determine that area. Relies on 'robust_influences' flag for case holdouts.
 	;
 	;		 "case_feature_residuals"  true or false. If true outputs feature residuals for all (context and action)
 	;						features for just the specified case. Uses leave-one-out for each feature, while
 	;						using the others to predict the left out feature with their corresponding values
-	;						from this case. Relies on 'robust_computation' flag.
+	;						from this case. Relies on 'robust_residuals' flag.
 	;
 	;		 "case_feature_contributions" true or false. If true outputs each context feature's differences between the
 	;						predicted action feature value and the predicted action feature value if each context
 	;						feature were not in the model for all context features in this case, using only the
-	;						values from this specific case. Relies on 'robust_computation' flag.
+	;						values from this specific case. Relies on 'robust_influences' flag.
 	;
 	;		 "num_robust_influence_samples_per_case" integer. Specifies the number of robust samples to use for each case.
 	;						Applicable only for computing robust feature contributions or robust case feature contributions.
@@ -124,15 +128,15 @@
 	;						convictions for the region around the prediction. Uses only the context features of
 	;						the reacted case to determine that region.
 	;						Computed as: region feature residual / case feature residual. Relies on
-	;						'robust_computation' flag.
+	;						'robust_residuals' flag.
 	;
 	;		 "global_case_feature_residual_convictions" true or false. If true outputs this case's feature residual
 	;						convictions for the global model.
 	;						Computed as: global model feature residual / case feature residual. Relies on
-	;						'robust_computation' flag.
+	;						'robust_residuals' flag.
 	;
 	;        "features" list of features that specifies what features to calculate per-feature details for. (contributions, mda, residuals, etc)
-	; 						when robust_computation is False. This should generally preserve compute, but will not when computing details robustly.
+	; 						when robust computations are False. This should generally preserve compute, but will not when computing details robustly.
 	;
 	;	)
 	; action_features: list of action features

--- a/trainee_template/explanation_influences.amlg
+++ b/trainee_template/explanation_influences.amlg
@@ -33,7 +33,7 @@
 		)
 
 		;for robust computation, increase the number of cases to improve accuracy
-		(if robust_computation
+		(if robust_influences
 			(let
 				(assoc
 					;number of robust cases is max(100, K * ( ln(num_features) + 1) )
@@ -51,7 +51,7 @@
 						context_features context_features
 						action_features action_features
 						case_ids local_model_case_ids
-						robust robust_computation
+						robust robust_influences
 					))
 				)
 		))
@@ -67,7 +67,7 @@
 					context_features context_features
 					feature ".targetless"
 					mode
-						(if (or force_targetless robust_computation)
+						(if (or force_targetless robust_influences)
 							"robust"
 							"full"
 						)
@@ -100,7 +100,7 @@
 		))
 
 		;for robust computation, increase the number of cases to improve accuracy
-		(if robust_computation
+		(if robust_influences
 			(let
 				(assoc
 					;number of robust cases is max(100, K * ( ln(num_features) + 1) )
@@ -118,7 +118,7 @@
 						context_features context_features
 						action_features action_features
 						case_ids local_model_case_ids
-						robust robust_computation
+						robust robust_influences
 					))
 				)
 		))
@@ -182,7 +182,7 @@
 						)
 
 						;for robust residuals ensure at least 30 cases per case are used by duplicating the remaining cases list enough times
-						(if robust_computation
+						(if robust_influences
 							(assign (assoc
 								robust_remaining_k_cases_map
 									(if (< (size remaining_k_cases_map) 30)
@@ -214,7 +214,7 @@
 											(assign (assoc
 												ignore_case_list
 													;remove a random selection of local cases in addition to the react case
-													(if robust_computation
+													(if robust_influences
 														(append
 															(list react_case)
 															(filter (lambda (< (rand) .5)) (indices (remove remaining_k_cases_map react_case)) )
@@ -283,7 +283,7 @@
 										))
 
 										;iterate over the possibly larger list if robust
-										(if robust_computation
+										(if robust_influences
 											robust_remaining_k_cases_map
 
 											remaining_k_cases_map
@@ -613,7 +613,7 @@
 			;use larger amount of robust computes per case for explanations than global
 			; min(2000, 30 * 2^f) to get enough coverage for robust reacts for each case
 			num_robust_influence_samples_per_case
-				(if robust_computation
+				(if robust_influences
 					;use specified value if it was provided
 					(if (> (get details "num_robust_influence_samples_per_case") 1)
 						(get details "num_robust_influence_samples_per_case")
@@ -628,7 +628,7 @@
 				(call CalculateFeatureContributions (assoc
 					context_features context_features
 					action_feature action_feature
-					robust robust_computation
+					robust robust_influences
 					case_ids local_model_case_ids
 					num_robust_influence_samples_per_case num_robust_influence_samples_per_case
 					weight_feature weight_feature
@@ -664,7 +664,7 @@
 			;use larger amount of robust computes per case for explanations than global
 			; min(2000, 30 * 2^f) to get enough coverage for robust reacts for each case
 			num_robust_influence_samples_per_case
-				(if robust_computation
+				(if robust_influences
 					;use specified value if it was provided
 					(if (> (get details "num_robust_influence_samples_per_case") 1)
 						(get details "num_robust_influence_samples_per_case")
@@ -686,7 +686,7 @@
 		;create an assoc of feature -> [feature_contribution, directional_feature_contribution]
 		(assign (assoc
 			feature_contributions_pair_map
-				(if robust_computation
+				(if robust_influences
 					(seq
 						;populate local_case_reaction_pairs, then the call below computes the deltas for each feature
 						(call !ComputeRobustContributionReactsPerCase)
@@ -711,7 +711,7 @@
 				)
 		))
 
-		(if (and robust_computation details_context_features)
+		(if (and robust_influences details_context_features)
 			(assign (assoc feature_contributions_pair_map (keep feature_contributions_pair_map details_context_features)))
 		)
 

--- a/trainee_template/explanation_residuals.amlg
+++ b/trainee_template/explanation_residuals.amlg
@@ -41,7 +41,7 @@
 									features relevant_features
 									case_ids (indices regional_model_cases_map)
 									regional_model_only (true)
-									robust_residuals robust_computation
+									robust_residuals robust_residuals
 									;use the same hyperparameters that were used to make the original prediction
 									custom_hyperparam_map hyperparam_map
 								))
@@ -92,7 +92,7 @@
 
 		(declare (assoc
 			case_residuals
-				(if robust_computation
+				(if robust_residuals
 					;for each feature, do 30 reacts with randomly selected contexts
 					(map
 						(lambda (let
@@ -222,7 +222,7 @@
 
 		(declare (assoc
 			case_residuals_map
-				(if (and details_features (not robust_computation))
+				(if (and details_features (not robust_residuals))
 					(zip details_features case_residuals)
 
 					(zip features case_residuals)
@@ -359,7 +359,7 @@
 			)
 		)
 
-		(if (and robust_computation details_features)
+		(if (and robust_residuals details_features)
 			(assign (assoc case_residuals_map (keep case_residuals_map details_features)))
 		)
 
@@ -373,9 +373,9 @@
 			(let
 				(assoc
 					global_feature_residuals (null)
-					;set param_path to pull global residuals matching robust_computation flag for the given hyperparameters
+					;set param_path to pull global residuals matching robust_residuals flag for the given hyperparameters
 					param_path
-						(if robust_computation
+						(if robust_residuals
 							;concatenate the appropriate key for the cached residuals set
 							(apply "concat" (append "robust" (remove (get hyperparam_map "paramPath") 1) ) )
 							(apply "concat" (append "full" (remove (get hyperparam_map "paramPath") 1) ) )
@@ -394,7 +394,7 @@
 							warnings
 								(associate (concat
 									"Cannot compute 'global_case_feature_residual_convictions' because "
-									(if robust_computation "Robust" "Full")
+									(if robust_residuals "Robust" "Full")
 									" global residuals have not been computed for action_feature "
 									(if (size action_features)
 										(concat "'" (first hp_param_path) "'")
@@ -405,7 +405,7 @@
 										(concat " with case weights from '" (last hp_param_path) "'.\n")
 									)
 									"Please call 'react_into_trainee()', with "
-									(if robust_computation "residuals_robust=true" "residuals=True")
+									(if robust_residuals "residuals_robust=true" "residuals=True")
 									(if (!= ".none" (last hp_param_path))
 										(concat ", use_case_weights=true, weight_feature='" (last hp_param_path) "'")
 										""
@@ -538,7 +538,7 @@
 														target_residual_feature residual_feature
 														case_ids (indices regional_model_cases_map)
 														regional_model_only (true)
-														robust_residuals robust_computation
+														robust_residuals robust_residuals
 														focal_case ignore_case
 														;use the same hyperparameters that were used to make the original prediction
 														custom_hyperparam_map hyperparam_map

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -734,7 +734,7 @@
 						series_end_context_features (indices (filter (remove current_case_map ".series_progress")))
 					)
 
-						;predict .series_progress given the current case
+					;predict .series_progress given the current case
 					(assign (assoc
 						series_progress
 							(first (get

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -598,7 +598,7 @@
 				case_indices (list "unit_test" 7)
 				details
 					(assoc
-						;"robust_computation" (true)
+						"robust_influences" (false)
 						"feature_contributions" (true)
 					)
 			))
@@ -626,7 +626,7 @@
 				case_indices (list "unit_test" 0)
 				details
 					(assoc
-						"robust_computation" (true)
+						;should default to robust influences
 						"feature_contributions" (true)
 						"case_feature_contributions" (true)
 					)
@@ -693,7 +693,7 @@
 				case_indices (list "unit_test" 0)
 				details
 					(assoc
-						"robust_computation" (true)
+						;should default to robust
 						"feature_contributions" (true)
 						"case_feature_contributions" (true)
 						"num_robust_influence_samples_per_case" 4

--- a/unit_tests/ut_h_case_mda.amlg
+++ b/unit_tests/ut_h_case_mda.amlg
@@ -42,7 +42,7 @@
 				context_values (list 6.4 5.6 2.0 2)
 
 				action_features (list "sepal_width")
-				details (assoc "case_mda" (true))
+				details (assoc "case_mda" (true) "robust_influences" (false))
 			))
 	))
 	(print "standard continuous case mda: ")
@@ -66,7 +66,7 @@
 				context_values (list 6.4 5.6 2.0 2)
 
 				action_features (list "sepal_width")
-				details (assoc "case_mda" "robust" )
+				details (assoc "case_mda" "true" )
 			))
 	))
 	(print "robust continuous case mda: ")
@@ -91,7 +91,7 @@
 				context_values (list 6.7 5.0 1.7 2.8)
 
 				action_features (list "target")
-				details (assoc "case_mda" (true))
+				details (assoc "case_mda" (true) "robust_influences" (false))
 			))
 	))
 	(print "standard nominal case mda: ")
@@ -115,7 +115,7 @@
 				context_values (list 6.7 5.0 1.7 2.8)
 
 				action_features (list "target")
-				details (assoc "case_mda" (true))
+				details (assoc "case_mda" (true) "robust_influences" (false))
 			))
 	))
 	(print "robust nominal case mda: ")

--- a/unit_tests/ut_h_null_react.amlg
+++ b/unit_tests/ut_h_null_react.amlg
@@ -206,7 +206,7 @@
 				context_features ctx_features
 				context_values (list 6 4.999999999999)
 				allow_nulls (false)
-				details (assoc "case_contributions" (true))
+				details (assoc "robust_influences" (false) "case_contributions" (true))
 			))
 	))
 
@@ -235,7 +235,7 @@
 				context_features ctx_features
 				context_values (list 6 4.99999999999)
 				allow_nulls (false)
-				details (assoc "case_contributions" (true))
+				details (assoc "robust_influences" (false) "case_contributions" (true))
 			))
 	))
 
@@ -262,7 +262,7 @@
 				context_features ctx_features
 				context_values (list 6 5)
 				allow_nulls (false)
-				details (assoc "robust_computation" (true) "case_contributions" (true))
+				details (assoc "case_contributions" (true))
 			))
 	))
 
@@ -292,7 +292,7 @@
 				context_features ctx_features
 				context_values (list 6 5)
 				allow_nulls (false)
-				details (assoc "feature_contributions" (true))
+				details (assoc "robust_influences" (false) "feature_contributions" (true))
 			))
 	))
 	(print "Feature contributions: ")
@@ -310,7 +310,7 @@
 				context_features ctx_features
 				context_values (list 6 5)
 				allow_nulls (false)
-				details (assoc "robust_computation" (true) "feature_contributions" (true))
+				details (assoc "feature_contributions" (true))
 			))
 	))
 	(print "Robust Feature contributions: ")
@@ -328,7 +328,7 @@
 				context_features ctx_features
 				context_values (list 6 5)
 				allow_nulls (false)
-				details (assoc "robust_computation" (true) "feature_contributions" (true))
+				details (assoc "feature_contributions" (true))
 			))
 	))
 	(print "Robust Feature contributions for nominal: ")

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -347,6 +347,7 @@
 					details
 						(assoc
 							"feature_mda" (true)
+							"robust_influences" (false)
 						)
 				))
 				"payload"
@@ -362,6 +363,7 @@
 					details
 						(assoc
 							"feature_mda_ex_post" (true)
+							"robust_influences" (false)
 						)
 				))
 				"payload"
@@ -376,6 +378,7 @@
 					details
 						(assoc
 							"feature_mda_ex_post" (true)
+							"robust_influences" (false)
 						)
 				))
 				"payload"
@@ -706,7 +709,7 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"robust_computation" (true)
+					"robust_residuals" (true)
 					"case_feature_residuals" (true)
 					"local_case_feature_residual_convictions" (true)
 					"global_case_feature_residual_convictions" (true)
@@ -762,7 +765,7 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"robust_computation" (true)
+					"robust_residuals" (true)
 					"case_feature_residuals" (true)
 					"features" (list "A" "C")
 				)
@@ -805,7 +808,7 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"robust_computation" (true)
+					"robust_residuals" (true)
 					"case_feature_residuals" (true)
 					"local_case_feature_residual_convictions" (true)
 					"global_case_feature_residual_convictions" (true)
@@ -856,7 +859,7 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"robust_computation" (true)
+					"robust_residuals" (true)
 					"case_feature_residuals" (true)
 					"local_case_feature_residual_convictions" (true)
 					"global_case_feature_residual_convictions" (true)

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -132,7 +132,7 @@
 				details
 					(assoc
 						global_case_feature_residual_convictions (true)
-						robust_computation (true)
+						robust_residuals (true)
 					)
 				use_case_weights (true)
 			))
@@ -192,7 +192,7 @@
 				details
 					(assoc
 						global_case_feature_residual_convictions (true)
-						robust_computation (true)
+						robust_residuals (true)
 					)
 			))
 	))
@@ -225,7 +225,7 @@
 				details
 					(assoc
 						global_case_feature_residual_convictions (true)
-						robust_computation (true)
+						robust_residuals (true)
 					)
 				use_case_weights (true)
 				weight_feature "target"


### PR DESCRIPTION
also fixed the inconsistent naming for the set_influence_weight_threshold method (which isn't used in clients)