### PR TITLE
18308: Adds "derivation_parameters" as a detail to react, MINOR

### DIFF
--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -314,6 +314,7 @@
 								"k" k_parameter
 								"p" p_parameter
 								"dt" dt_parameter
+								"nominal_class_counts" nominalsMap
 							)
 					)
 			))

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -23,6 +23,9 @@
 	;		 "influential_cases_raw_weights" true or false. If true outputs the surprisal for each of the influential cases.
 	;						Not applicable to generative reacts.
 	;
+	;		"derivation_parameters" true or false. If true outputs the parameters used during the react. These parameters
+	;						include k, p, feature weights, and feature_deviations.
+	;
 	;		 "hypothetical_values"  assoc context feature -> values. If specified, shows how a prediction could change
 	;						in a what-if scenario where the influential cases' context feature values are replaced with
 	;						the specified values.  Iterates over all influential cases, predicting the action features
@@ -296,11 +299,23 @@
 					(assoc
 						"derivation_parameters"
 							(assoc
-								"feature_weights" (get hyperparam_map "featureWeights")
-								"k" (get hyperparam_map "k")
-								"p" (get hyperparam_map "p")
-								"dt" (get hyperparam_map "dt")
-								"feature_deviations" (get hyperparam_map "featureDeviations")
+								"feature_weights"
+									(if (= ".targetless" (get hyperparam_map (list "paramPath" 0)))
+										;targetless flows
+										(zip (append context_features action_features) 1)
+
+										;targeted flows
+										(or
+											feature_weights
+											(zip (append context_features action_features) 1)
+										)
+									)
+								"feature_deviations" (or (get hyperparam_map "featureDeviations") (zip (append context_features action_features) 0) )
+								"use_deviations" (get hyperparam_map "useDeviations")
+								"use_irw" (= ".targetless" (get hyperparam_map (list "paramPath" 0)))
+								"k" k_parameter
+								"p" p_parameter
+								"dt" dt_parameter
 							)
 					)
 			))

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -23,8 +23,9 @@
 	;		 "influential_cases_raw_weights" true or false. If true outputs the surprisal for each of the influential cases.
 	;						Not applicable to generative reacts.
 	;
-	;		"derivation_parameters" true or false. If true outputs the parameters used during the react. These parameters
-	;						include k, p, feature weights, and feature_deviations.
+	;		 "derivation_parameters" true or false. If true outputs the parameters used during the react. These parameters
+	;						include k, p, dt, feature weights, feature_deviations, nominal_class_counts, and flags to indicate
+	; 						if deviations or inverse residual weighting were used.
 	;
 	;		 "hypothetical_values"  assoc context feature -> values. If specified, shows how a prediction could change
 	;						in a what-if scenario where the influential cases' context feature values are replaced with

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -290,6 +290,22 @@
 			robust_residuals (get details "robust_residuals")
 		))
 
+		(if (get details "derivation_parameters")
+			(accum (assoc
+				output
+					(assoc
+						"derivation_parameters"
+							(assoc
+								"feature_weights" (get hyperparam_map "featureWeights")
+								"k" (get hyperparam_map "k")
+								"p" (get hyperparam_map "p")
+								"dt" (get hyperparam_map "dt")
+								"feature_deviations" (get hyperparam_map "featureDeviations")
+							)
+					)
+			))
+		)
+
 		(if (or
 				(get details "influential_cases")
 				(get details "hypothetical_values")

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -314,7 +314,7 @@
 								"use_irw" (= ".targetless" (get hyperparam_map (list "paramPath" 0)))
 								"k" k_parameter
 								"p" p_parameter
-								"dt" dt_parameter
+								"distance_transform" dt_parameter
 								"nominal_class_counts" nominalsMap
 							)
 					)

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -24,7 +24,7 @@
 	;						Not applicable to generative reacts.
 	;
 	;		 "derivation_parameters" true or false. If true outputs the parameters used during the react. These parameters
-	;						include k, p, dt, feature weights, feature_deviations, nominal_class_counts, and flags to indicate
+	;						include k, p, dt, feature_weights, feature_deviations, nominal_class_counts, and flags to indicate
 	; 						if deviations or inverse residual weighting were used.
 	;
 	;		 "hypothetical_values"  assoc context feature -> values. If specified, shows how a prediction could change

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -24,7 +24,7 @@
 	;						Not applicable to generative reacts.
 	;
 	;		 "derivation_parameters" true or false. If true outputs the parameters used during the react. These parameters
-	;						include k, p, dt, feature_weights, feature_deviations, nominal_class_counts, and flags to indicate
+	;						include k, p, distance_transform, feature_weights, feature_deviations, nominal_class_counts, and flags to indicate
 	; 						if deviations or inverse residual weighting were used.
 	;
 	;		 "hypothetical_values"  assoc context feature -> values. If specified, shows how a prediction could change

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -300,17 +300,15 @@
 						"derivation_parameters"
 							(assoc
 								"feature_weights"
-									(if (= ".targetless" (get hyperparam_map (list "paramPath" 0)))
-										;targetless flows
+									(or
+										feature_weights
 										(zip (append context_features action_features) 1)
-
-										;targeted flows
-										(or
-											feature_weights
-											(zip (append context_features action_features) 1)
-										)
 									)
-								"feature_deviations" (or (get hyperparam_map "featureDeviations") (zip (append context_features action_features) 0) )
+								"feature_deviations"
+									(or
+										context_deviations
+										(zip (append context_features action_features) 0)
+									)
 								"use_deviations" (get hyperparam_map "useDeviations")
 								"use_irw" (= ".targetless" (get hyperparam_map (list "paramPath" 0)))
 								"k" k_parameter


### PR DESCRIPTION
Adds "derivation_parameters" as a detail to react, which enables users to inspect the parameters that were used in the react (k, p, dt, feature weights, feature deviations, nominal class counts, etc.). 

