### PR TITLE
18481: Fixes bug where training time series was not respecting auto-analyze limit

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -701,7 +701,7 @@
 				auto_analyze_enabled (false)
 				analyze_threshold 100
 				analyze_growth_factor 7.389056
-				auto_analyze_limit_size 100000
+				auto_analyze_limit_size 200000
 			)
 
 			(call_entity trainee "SetAutoAnalyzeParams" (assoc

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -453,7 +453,7 @@
 			autoAnalyzeGrowthFactorAmount 7.389056
 
 			;if autoAnalyzeEnabledis set, the model size limit at which to stop auto-analyzing
-			autoAnalyzeLimitSize 100000
+			autoAnalyzeLimitSize 200000
 
 			;map of parameters used when analyze was called on this model
 			savedAnalyzeParameterMap (null)

--- a/trainee_template/custom_codes.amlg
+++ b/trainee_template/custom_codes.amlg
@@ -391,7 +391,14 @@
 				;if this dataset hasn't been analyzed yet or if it has grown significantly since lass analysis pass
 				;do an analyze pass in order to impute with good hyperparameters
 				#!AnalyzePreDerivationImpute
-				(if (>= (call GetNumTrainingCases) autoAnalyzeThreshold)
+				(if (and
+						(>= (call GetNumTrainingCases) autoAnalyzeThreshold)
+						(or
+							(< (call GetNumTrainingCases) autoAnalyzeLimitSize)
+							;no limit defined
+							(<= autoAnalyzeLimitSize 0)
+						)
+					)
 					(let
 						(assoc analyze_features defaultFeatures)
 

--- a/trainee_template/hyperparameters.amlg
+++ b/trainee_template/hyperparameters.amlg
@@ -564,7 +564,7 @@
 			auto_analyze_enabled (false)
 			analyze_threshold 100
 			analyze_growth_factor 7.389056
-			auto_analyze_limit_size 100000
+			auto_analyze_limit_size 200000
 
 			;local var
 			bad_param (false)
@@ -689,7 +689,7 @@
 			auto_analyze_enabled (false)
 			analyze_threshold 100
 			analyze_growth_factor 7.389056
-			auto_analyze_limit_size 100000
+			auto_analyze_limit_size 200000
 		)
 
 		;growth factor must be more than 1


### PR DESCRIPTION
Additionally bump up auto analyze limit to from 100k to 200k