### PR TITLE
18565: Fixes bug where nans could be output for residuals for inactive features

### DIFF
--- a/trainee_template/explanation_residuals.amlg
+++ b/trainee_template/explanation_residuals.amlg
@@ -88,7 +88,20 @@
 			)
 		)
 
-		(declare (assoc context_map (zip features case_values)))
+		(declare (assoc
+			context_map (zip features case_values)
+			inactive_features_zeros_map (assoc)
+		))
+
+		;remove any inactive features from the details_features or all features lists so they are ignored during compute
+		;and create an assoc of inactive feature -> 0 for all of them to add to output of all residual computations
+		(if hasInactiveFeatures
+			(assign (assoc
+				details_features (filter (lambda (not (contains_index inactiveFeaturesMap (current_value)))) details_features)
+				features (filter (lambda (not (contains_index inactiveFeaturesMap (current_value)))) features)
+				inactive_features_zeros_map (zip (indices inactiveFeaturesMap) 0)
+			))
+		)
 
 		(declare (assoc
 			case_residuals
@@ -97,7 +110,7 @@
 					(map
 						(lambda (let
 							(assoc
-								expected_case_value (get case_values (current_index 1))
+								expected_case_value (get context_map (current_value 1))
 								action_feature (current_value 1)
 								action_is_nominal (contains_index nominalsMap (current_value 1))
 								action_feature (current_value 1)
@@ -365,7 +378,7 @@
 
 		;add case_feature_residuals to output if requested
 		(if (get details "case_feature_residuals")
-			(accum (assoc output (assoc "case_feature_residuals" case_residuals_map) ))
+			(accum (assoc output (assoc "case_feature_residuals" (append case_residuals_map inactive_features_zeros_map)) ))
 		)
 
 		;include global feature residual convictions
@@ -482,7 +495,9 @@
 					(assign (assoc global_convictions_map (keep global_convictions_map details_features)))
 				)
 
-				(accum (assoc output (assoc "global_case_feature_residual_convictions" global_convictions_map) ))
+				(accum (assoc
+					output (assoc "global_case_feature_residual_convictions" (append global_convictions_map inactive_features_zeros_map) )
+				))
 			)
 		)
 
@@ -611,7 +626,9 @@
 					))
 				)
 
-				(accum (assoc output (assoc "local_case_feature_residual_convictions" local_convictions_map) ))
+				(accum (assoc
+					output (assoc "local_case_feature_residual_convictions" (append local_convictions_map inactive_features_zeros_map) )
+				))
 			)
 		)
 	)

--- a/trainee_template/explanation_residuals.amlg
+++ b/trainee_template/explanation_residuals.amlg
@@ -496,7 +496,10 @@
 				)
 
 				(accum (assoc
-					output (assoc "global_case_feature_residual_convictions" (append global_convictions_map inactive_features_zeros_map) )
+					output
+						(assoc "global_case_feature_residual_convictions"
+							(if global_convictions_map (append global_convictions_map inactive_features_zeros_map))
+						)
 				))
 			)
 		)


### PR DESCRIPTION
remove inactive features from list of features for which to compute any residuals. and simply append them at the end with values of 0.