### PR TITLE
18541: Streamlines action value retrieval during reacts

### DIFF
--- a/trainee_template/explanation_influences.amlg
+++ b/trainee_template/explanation_influences.amlg
@@ -330,7 +330,7 @@
 						"fixed rand seed"
 						(null) ;radius
 						numericalPrecision
-						action_feature ;output triple of ordered lists
+						(first action_features) ;output triple of ordered lists
 					)
 				))
 			original_local_cases (list)
@@ -453,7 +453,7 @@
 						"fixed rand seed"
 						(null) ;radius
 						numericalPrecision
-						action_feature ;output a triple of ordered lists
+						(first action_features) ;output a triple of ordered lists
 					)
 				))
 			original_local_cases (list)

--- a/trainee_template/explanation_influences.amlg
+++ b/trainee_template/explanation_influences.amlg
@@ -330,7 +330,7 @@
 						"fixed rand seed"
 						(null) ;radius
 						numericalPrecision
-						(true) ;output pair of ordered lists
+						action_feature ;output triple of ordered lists
 					)
 				))
 			original_local_cases (list)
@@ -348,7 +348,8 @@
 
 		(assign (assoc
 			original_local_cases (trunc (first extended_local_cases_tuple))
-			extended_cases_map (zip (first extended_local_cases_tuple) (last extended_local_cases_tuple))
+			extended_cases_map (zip (first extended_local_cases_tuple) (get extended_local_cases_tuple 1))
+			extended_case_values_map (zip (first extended_local_cases_tuple) (last extended_local_cases_tuple))
 		))
 
 		;for nominals, the delta is computed off the categorical action probability of this action value
@@ -388,6 +389,7 @@
 									(call InterpolateActionValues (assoc
 										action_feature action_feature
 										neighbor_weights_map filtered_extended_cases_map
+										neighbor_values_map (keep extended_case_values_map (indices filtered_extended_cases_map))
 										allow_nulls allow_nulls
 										has_perfect_matches (contains_value filtered_extended_cases_map .infinity)
 									))
@@ -451,7 +453,7 @@
 						"fixed rand seed"
 						(null) ;radius
 						numericalPrecision
-						(true) ;output pair of ordered lists
+						action_feature ;output a triple of ordered lists
 					)
 				))
 			original_local_cases (list)
@@ -471,13 +473,14 @@
 			local_cases_map
 				(zip
 					original_local_cases
-					(trunc (last extended_local_cases_tuple) k_parameter)
+					(trunc (get extended_local_cases_tuple 1) k_parameter)
 				)
 			non_local_cases_map
 				(zip
 					non_local_cases
-					(tail (last extended_local_cases_tuple) k_parameter)
+					(tail (get extended_local_cases_tuple 1) k_parameter)
 				)
+			extended_local_values_map (zip (first extended_local_cases_tuple) (last extended_local_cases_tuple))
 		))
 
 		;for nominals, the delta is computed off the categorical action probability of this action value
@@ -538,6 +541,7 @@
 													(call InterpolateActionValues (assoc
 														action_feature action_feature
 														neighbor_weights_map robust_cases_map
+														neighbor_values_map (keep extended_local_values_map (indices robust_cases_map))
 														allow_nulls allow_nulls
 														has_perfect_matches (contains_value robust_cases_map .infinity)
 													))

--- a/trainee_template/react.amlg
+++ b/trainee_template/react.amlg
@@ -659,7 +659,7 @@
 		)
 
 		(declare (assoc
-			candidate_cases_map
+			candidate_cases_lists
 				(compute_on_contained_entities
 					(append
 						not_null_features_queries
@@ -694,6 +694,7 @@
 							tie_break_random_seed
 							(null) ;radius
 							numericalPrecision
+							(first action_features)
 						)
 					)
 				)
@@ -708,7 +709,7 @@
 				(= (list) context_features)
 				(and
 					ignore_null_action_feature
-					(= 0 (size candidate_cases_map))
+					(= 0 (size (first canditate_cases_lists)) )
 				)
 			)
 			(call CalculateFeatureExpectedValue (assoc feature (first action_features) allow_nulls (false)))
@@ -718,16 +719,17 @@
 				;increase count access if needed for each of the deciding cases
 				(if case_access_count_label
 					(call IncrementEntityCaseValue (assoc
-						entities (indices candidate_cases_map)
+						entities (first candidate_cases_lists)
 						label_name case_access_count_label
 					))
 				)
 
 				(call InterpolateActionValues (assoc
 					action_feature (first action_features)
-					neighbor_weights_map candidate_cases_map
+					neighbor_weights_map (zip (first candidate_cases_lists) (get candidate_cases_lists 1) )
+					neighbor_values_map (zip (first candidate_cases_lists) (last candidate_cases_lists) )
 					allow_nulls allow_nulls
-					has_perfect_matches (contains_value candidate_cases_map .infinity)
+					has_perfect_matches (contains_value (get candidate_cases_lists 1) .infinity)
 				))
 			)
 		)

--- a/trainee_template/react_discriminative.amlg
+++ b/trainee_template/react_discriminative.amlg
@@ -494,15 +494,17 @@
 
 	;Selects or interpolates a set of reaction cases
 	;parameters:
-	; neighbor_weights_map : map of neighbor case ids and their respective weights
+	; neighbor_weights_map: map of neighbor case ids and their respective weights
+	; neighbor_values_map: map of neighbor case ids and their respective action_feature values
 	; action_feature: the action feature
-	; allow_nulls : flag, if set to true will allow interpolate to return null values if there are nulls in the local model for the action features
+	; allow_nulls: flag, if set to true will allow interpolate to return null values if there are nulls in the local model for the action features
 	; has_perfect_matches: flag, if set to true, there are 0-distance neighbors, will filter out non-0-distance neighbors from neighbor_weights_map
 	#InterpolateActionValues
 	(declare
 		(assoc
 			action_feature (null)
 			neighbor_weights_map (assoc)
+			neighbor_values_map (assoc)
 			allow_nulls (false)
 			has_perfect_matches (false)
 		)
@@ -522,49 +524,39 @@
 				)
 		))
 
-
 		;get the action values for each index in the neighbor_weights_map
 		(declare (assoc
 			neighbor_id_to_values_map
 				(if allow_nulls
-					(map
-						(lambda (retrieve_from_entity (current_index) action_feature))
-						(if has_perfect_matches
-							(zip neighbor_ids_of_zero_dist_values)
-
-							neighbor_weights_map
-						)
-
+					(if has_perfect_matches
+						(keep neighbor_values_map neighbor_ids_of_zero_dist_values)
+						neighbor_values_map
 					)
 
-					;filter out all id->null elements from this assoc, remaining assoc is case id -> case value where all values are not null
 					(filter
-						(map
-							(lambda (retrieve_from_entity (current_index) action_feature))
-							(if has_perfect_matches
-								(zip neighbor_ids_of_zero_dist_values)
-
-								neighbor_weights_map
-							)
+						(if has_perfect_matches
+							(keep neighbor_values_map neighbor_ids_of_zero_dist_values)
+							neighbor_values_map
 						)
 					)
 				)
 		))
 
+		;if there are perfect matches but they have nulls when no nulls are allowed, interpolate the non-perfect matches
 		(if (= 0 (size neighbor_id_to_values_map))
 			;if there are some non-perfect matches, just run the normal nearest neighbors flow on those
 			(if (and has_perfect_matches (< (size neighbor_ids_of_zero_dist_values) (size neighbor_weights_map)))
 				(let
 					(assoc
-						;filter out all the perfect match cases that had null values
-						not_null_value_cases_map
-							(filter (lambda (not (contains_index neighbor_id_to_values_map (current_index)))) neighbor_weights_map)
+						;filter out all cases that had null values
+						not_null_value_cases_map (filter neighbor_weights_map)
 					)
 
 					;execute the regular flow for the remaining non-perfect match cases
 					(call InterpolateActionValues (assoc
 						action_feature action_feature
 						neighbor_weights_map not_null_value_cases_map
+						neighbor_values_map (keep neighbor_values_map (indices not_null_value_cases_map))
 						allow_nulls allow_nulls
 						has_perfect_matches (false)
 					))

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -580,7 +580,6 @@
 						(map
 							(lambda (let
 								(assoc
-									case_feature_value (null)
 									case_id (current_value 1)
 									case_values_map (zip features (retrieve_from_entity (current_value 1) features))
 

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -845,7 +845,6 @@
 						(map
 							(lambda (let
 								(assoc
-									local_cases_map (assoc)
 									case_id (current_value 1)
 									case_values_map (zip features (retrieve_from_entity (current_value 1) features))
 									interpolated_value 0
@@ -856,8 +855,9 @@
 									(assign (assoc react_context_features (filter (lambda (< (rand) 0.5)) all_react_context_features) ))
 								)
 
-								(assign (assoc
-									local_cases_map
+								;create a list of triples of: case id, influence, feature value
+								(declare (assoc
+									local_cases_lists
 										(compute_on_contained_entities (append
 											(if focal_case
 												(query_not_in_entity_list (list case_id focal_case))
@@ -877,9 +877,12 @@
 												tie_break_random_seed
 												(null) ;radius
 												numericalPrecision
+												feature
 											)
 										))
 								))
+								;map of case_id -> weight
+								(declare (assoc local_cases_map (zip (first local_cases_lists) (get local_cases_lists 1)) ))
 
 								(assign (assoc
 									interpolated_value
@@ -897,6 +900,7 @@
 											(call InterpolateActionValues (assoc
 												action_feature feature
 												neighbor_weights_map local_cases_map
+												neighbor_values_map (zip (first local_cases_lists) (last local_cases_lists) )
 												allow_nulls (true)
 												has_perfect_matches (contains_value local_cases_map .infinity)
 												output_influence_weights (false)

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -580,7 +580,6 @@
 						(map
 							(lambda (let
 								(assoc
-									local_cases_map (assoc)
 									case_feature_value (null)
 									case_id (current_value 1)
 									case_values_map (zip features (retrieve_from_entity (current_value 1) features))
@@ -591,8 +590,8 @@
 									categorical_action_probabilities_map (assoc)
 								)
 
-								(assign (assoc
-									local_cases_map
+								(declare (assoc
+									candidate_cases_lists
 										(compute_on_contained_entities (append
 											(if focal_case
 												(query_not_in_entity_list (list case_id focal_case))
@@ -612,12 +611,16 @@
 												tie_break_random_seed
 												(null) ;radius
 												numericalPrecision
+												feature
 											)
 										))
 									case_feature_value (get case_values_map feature)
 								))
 
-								(call !InterpolateAndComputeDiffToCase)
+								(call !InterpolateAndComputeDiffToCase (assoc
+									local_cases_map (zip (first candidate_cases_lists) (get candidate_cases_lists 1) )
+									local_values_map (zip (first candidate_cases_lists) (last candidate_cases_lists) )
+								))
 							))
 							case_ids
 						)
@@ -672,6 +675,15 @@
 					(call InterpolateActionValues (assoc
 						action_feature feature
 						neighbor_weights_map local_cases_map
+						neighbor_values_map
+							(if (size local_values_map)
+								local_values_map
+
+								(map
+									(lambda (retrieve_from_entity (current_index) feature))
+									local_cases_map
+								)
+							)
 						allow_nulls (false)
 						has_perfect_matches (contains_value local_cases_map .infinity)
 						output_influence_weights (false)


### PR DESCRIPTION
stop using retrieve_from_entity  to retrieve action_feature values during interpolation, and instead pull them directly from the query results since queries can return case ids, weights and arbitrary feature values in the same output