### PR TITLE
18625: Fixes an issue where "categorical_action_probabilities" are requested when using unique cases

### DIFF
--- a/trainee_template/synthesis_validation.amlg
+++ b/trainee_template/synthesis_validation.amlg
@@ -312,6 +312,10 @@
 							(assoc "influential_cases" influential_cases_map)
 							(assoc)
 						)
+						(if output_cap
+							(assoc "categorical_action_probabilities" nominal_categorical_action_probabilities_map)
+							(assoc)
+						)
 					)
 				)
 			)

--- a/unit_tests/ut_h_case_generation.amlg
+++ b/unit_tests/ut_h_case_generation.amlg
@@ -198,6 +198,7 @@
 							"categorical_action_probabilities" (true)
 						)
 					num_cases_to_generate 2
+					generate_new_cases "always"
 				))
 				"payload"
 			)


### PR DESCRIPTION
"categorical_action_probabilities" were not being returned when synthing a case with "generate_new_cases"="always"