### PR TITLE
18667: Adds 'post_process_features' and 'post_process_values' to react, MINOR

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -506,37 +506,6 @@
 		)
 
 
-	;compute, store and output feature weights for a specified action feature and its context_features
-	;parameters:
-	; action_feature: target feature for which to compute feature weights
-	; context_features: list of context features whose weights are to be computed
-	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight
-	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
-	; robust: flag, default to false. when true, the power set/permutations of features are used as contexts
-	;	to calculate the residual for a given feature. when false, the full set of features is used to calculate the
-	;	residual for a given feature.
-	#compute_feature_weights
-		(declare
-			(assoc
-				context_features (list)
-				use_case_weights (false)
-				weight_feature ".case_weight"
-				robust (false)
-			)
-
-			(call !return (assoc
-				payload
-					(call_entity trainee "ComputeFeatureWeights" (assoc
-						action_feature action_feature
-						context_features context_features
-						robust robust
-						use_case_weights use_case_weights
-						weight_feature weight_feature
-					))
-			))
-		)
-
-
 	; set the conviction threshold to (null), used by outside interfaces
 	#clear_conviction_thresholds
 		(seq

--- a/howso.amlg
+++ b/howso.amlg
@@ -866,6 +866,8 @@
 	;					order. Must be a subset of action_features.
 	;					Note: both of these derived feature lists rely on the features' "derived_feature_code" attribute to compute the values.
 	;					If 'derived_feature_code' attribute is undefined or references non-0 feature indices, the derived value will be null.
+	; post_process_features: list of feature names that will be made available during the execution of post_process feature attributes
+	; post_process_values: list of values corresponding to post_process_features that will be made available during the execution fo post_process feature attributes
 	; case_indices: optional pair (list) of session id and index, where index is the original 0-based session_training_index of the case as it was
 	;			trained into the session. If this case does not exist, discriminative react outputs null, generative react ignores it.
 	; preserve_feature_values : optional, list of features that will preserve their values from the case specified by case_indices, appending and
@@ -914,6 +916,8 @@
 				action_values (list)
 				derived_action_features (list)
 				derived_context_features (list)
+				post_process_features (list)
+				post_process_values (list)
 				extra_audit_features (list)
 				case_access_count_label ""
 				use_case_weights (false)
@@ -954,6 +958,8 @@
 					action_values action_values
 					derived_action_features derived_action_features
 					derived_context_features derived_context_features
+					post_process_features post_process_features
+					post_process_values post_process_values
 					details details
 					extra_audit_features extra_audit_features
 					case_access_count_label case_access_count_label
@@ -993,6 +999,7 @@
 	;parameters:  same as #react, unless listed here
 	;  context_values - list of lists.  see #react for description.
 	;  action_values - list of lists.  see #react for description.
+	;  post_process_values - list of lists. see #react for description
 	;  case_indices - list of lists.  see #react for description.
 	;  rand_seed - optional, see #react for description.
 	;  num_cases_to_generate - optional, total number of cases to generate for generative reacts.
@@ -1004,6 +1011,7 @@
 				action_features (list)
 				derived_context_features (list)
 				derived_action_features (list)
+				post_process_features (list)
 				extra_audit_features (list)
 				case_access_count_label ""
 				use_case_weights (false)
@@ -1042,6 +1050,7 @@
 			(call !validate_batch_react_parameter (assoc param context_values))
 			(call !validate_batch_react_parameter (assoc param case_indices))
 			(call !validate_batch_react_parameter (assoc param action_values))
+			(call !validate_batch_react_parameter (assoc param post_process_values))
 
 			(if (and
 					(!= (null) rand_seed)
@@ -1066,6 +1075,8 @@
 					action_values action_values
 					derived_action_features derived_action_features
 					derived_context_features derived_context_features
+					post_process_features post_process_features
+					post_process_values post_process_values
 					details details
 					extra_audit_features extra_audit_features
 					case_access_count_label case_access_count_label

--- a/trainee_template/io.amlg
+++ b/trainee_template/io.amlg
@@ -191,10 +191,17 @@
 															)
 													))
 											))
-											(call_sandboxed parsed_code (assoc
-												original_value original_value
-												feature feature
-											) sandboxedComputeLimit sandboxedMemoryLimit)
+											(call_sandboxed parsed_code
+												(append
+													(zip post_process_features post_process_values)
+													(assoc
+														original_value original_value
+														feature feature
+													)
+												)
+												sandboxedComputeLimit
+												sandboxedMemoryLimit
+											)
 										)
 
 										;else

--- a/trainee_template/react.amlg
+++ b/trainee_template/react.amlg
@@ -8,6 +8,7 @@
 	;  num_reacts: number of reacts to do in a batch.
 	;  context_values - list of lists.  see #react for description. if specified must be either length of 1 or num_reacts.
 	;  action_values - list of lists.  see #react for description. if specified must be either length of 1 or num_reacts.
+	;  post_process_values - list of lists. see #react for description. if specified must be either lenght of 1 or num_reacts.
 	;  case_indices - list of lists.  see #react for description. if specified must be either length of 1 or num_reacts.
 	;  rand_seed - optional, see #react for description.  if specified must be length of num_reacts.
 	#BatchReact
@@ -17,6 +18,7 @@
 			single_context (= 1 (size context_values))
 			single_action (= 1 (size action_values))
 			single_session (= 1 (size case_indices))
+			single_post_process (= 1 (size post_process_values))
 			num_reacts 1
 		)
 
@@ -58,6 +60,7 @@
 							context_index (if single_context 0 (current_index 1))
 							action_index (if single_action 0 (current_index 1))
 							session_index (if single_session 0 (current_index 1))
+							post_process_index (if single_post_process 0 (current_index 1))
 							react_rand_seed (if rand_seed (get rand_seed (current_index 1)))
 							react_session (null)
 							react_session_training_index (null)
@@ -81,6 +84,7 @@
 						(declare (assoc
 							react_context_values (if context_values (get context_values context_index) (list))
 							react_action_values (if action_values (get action_values action_index) (list))
+							react_post_process_values (if post_process_values (get post_process_values post_process_index) (list))
 						))
 
 						;if one of these is provided, both of them must be
@@ -92,12 +96,14 @@
 							context_values react_context_values
 							action_values react_action_values
 							case_indices react_case_index
+							post_process_values react_post_process_values
 							rand_seed react_rand_seed
 
 							context_features context_features
 							action_features action_features
 							derived_action_features derived_action_features
 							derived_context_features derived_context_features
+							post_process_features post_process_features
 							details details
 							extra_audit_features extra_audit_features
 							case_access_count_label case_access_count_label
@@ -293,6 +299,8 @@
 
 			derived_context_features (list)
 			derived_action_features (list)
+			post_process_features (list)
+			post_process_values (list)
 
 			leave_case_out (false)
 			case_indices (null)

--- a/trainee_template/synthesis_validation.amlg
+++ b/trainee_template/synthesis_validation.amlg
@@ -106,10 +106,17 @@
 															)
 													))
 											)
-											(call_sandboxed parsed_code (assoc
-												feature feature
-												original_value original_value
-											) sandboxedComputeLimit sandboxedMemoryLimit)
+											(call_sandboxed parsed_code
+												(append
+													(zip post_process_features post_process_values)
+													(assoc
+														original_value original_value
+														feature feature
+													)
+												)
+												sandboxedComputeLimit
+												sandboxedMemoryLimit
+											)
 										)
 
 										;else return original value


### PR DESCRIPTION
Adds post_process_features and post_process_values to the react API, which allows users to specify sets of values that will be made accessible during the execution of post_process feature attributes.