### PR TITLE
18695: Fixes an issue where null cases may be output from generative reacts if details are specified

### DIFF
--- a/trainee_template/react.amlg
+++ b/trainee_template/react.amlg
@@ -480,8 +480,8 @@
 					)
 				)
 
-				;output generated case with explanation of the case if needed
-				(if (!= details (null))
+				;output generated case with explanation of the case if the case is not null and details are requested
+				(if (and (!= details (null)) (!= (null) generated_case) )
 					(seq
 						;if user doesn't want to use case weights, change weight_feature to '.none'
 						(if (not use_case_weights)


### PR DESCRIPTION
When details are non-null in generative reacts with uniqueness constraints, sometimes null cases were returned to the user. This is undesired behavior, and a fix is presented here.