### PR TITLE
18727: Updates git tag retrieval to skip non-repo tags

### DIFF
--- a/.github/workflows/create-branch-build.yml
+++ b/.github/workflows/create-branch-build.yml
@@ -42,9 +42,10 @@ jobs:
 
       - name: Get previous git tag
         id: previous-tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: 0.0.0
+        run: |
+          tag=$(git for-each-ref --sort=-creatordate --count 5 --format="%(refname:short)" "refs/tags/" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)
+          echo "Found tag: $tag"
+          echo "tag=$(echo $tag)" >> $GITHUB_OUTPUT
 
       - name: Get next semver from previous tag
         id: next-semvers

--- a/.github/workflows/create-pr-build.yml
+++ b/.github/workflows/create-pr-build.yml
@@ -28,9 +28,10 @@ jobs:
 
       - name: Get previous git tag
         id: previous-tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: 0.0.0
+        run: |
+          tag=$(git for-each-ref --sort=-creatordate --count 5 --format="%(refname:short)" "refs/tags/" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)
+          echo "Found tag: $tag"
+          echo "tag=$(echo $tag)" >> $GITHUB_OUTPUT
 
       - name: Get next semver from previous tag
         id: next-semvers

--- a/.github/workflows/create-release-build.yml
+++ b/.github/workflows/create-release-build.yml
@@ -30,9 +30,10 @@ jobs:
 
       - name: Get previous git tag
         id: previous-tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: 0.0.0
+        run: |
+          tag=$(git for-each-ref --sort=-creatordate --count 5 --format="%(refname:short)" "refs/tags/" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)
+          echo "Found tag: $tag"
+          echo "tag=$(echo $tag)" >> $GITHUB_OUTPUT
 
       - name: Get next semver from previous tag
         id: next-semvers


### PR DESCRIPTION
Since other processes create tags on repos, this will ignore all tags that are not a semver release tag when determining next version.