### PR TITLE
18748: Adds macOS arm64 tests

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -188,6 +188,32 @@ jobs:
       run: |
         ./build.sh test ${{ inputs.version }}
 
+  test-macos-arm64:
+    needs: ['get-dependency-details', 'build']
+    runs-on: macos-latest-xlarge
+    steps:
+
+    - name: Collect Workflow Telemetry
+      uses: runforesight/workflow-telemetry-action@v1
+      with:
+        comment_on_pr: off
+        proc_trace_chart_show: off
+        proc_trace_table_show: off
+
+    - uses: actions/checkout@v3
+
+    - name: Download Amalgam
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh ${{ needs.get-dependency-details.outputs.run-type }} download -D target -R "howsoai/amalgam" -p "*darwin-arm64*" "${{ needs.get-dependency-details.outputs.run-id }}"
+        # Needed because release/non-release downloads are different structure
+        cd target && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
+
+    - name: Test
+      run: |
+        ./build.sh test ${{ inputs.version }}
+
   test-windows-amd64:
     needs: ['get-dependency-details', 'build']
     runs-on: windows-latest

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,6 @@ timestamp=$(date +%x_%H:%M)
 
 # Get the Platform we are running the build on.
 plat=$(uname | tr '[:upper:]' '[:lower:]')
-if [[ "$plat" = 'darwin' ]]; then amlg_exe="${src_dir}/target/bin/amalgam-mt-noavx"; fi
 
 # Get the Platform chipset architecture. 'amd64' or 'arm64'
 arch=${ARCH:-$(uname -m | tr '[:upper:]' '[:lower:]')}


### PR DESCRIPTION
Adds arm64 tests and removes noavx special case (no longer needed on macOS runners on GitHub).