### PR TITLE
18856: Updates `get_prediction_stats` to return a single value for MAE and add 'missing_value_accuracy' as a stat, MINOR

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -2344,6 +2344,8 @@
 	;	"precision": precision (positive predictive) value for nominal features only.
 	;	"recall": recall (sensitivity) value for nominal features only.
 	;	"accuracy": The number of correct predictions divided by the total number of predictions.
+	;	"missing_value_accuracy": The number of correct predictions on cases with missing values values divided by the total number of cases with missing
+	;							  values for a specified feature.
 	;   "confusion_matrix": A matrix showing the number of predicted values of each class
 	;                       for each unique value of the predicted feature.
 	;

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -482,10 +482,12 @@
 					"paramPath" (list ".default")
 				)
 
-			;assoc of feature -> residual value, stored under a concatenated key starting with either 'robust' or 'full' based on
+			;assoc of feature -> residual value
+			;or feature -> [not-null/not-null residual, not-null/null residual, null/null residual] if the features contains nulls.
+			;Stored under a concatenated key starting with either 'robust' or 'full' based on
 			;how they were computed and the hyperparameter path keys.  contains built-in keys of '.robust' and '.hyperparam_path'
 			;eg: { 'full.targetlessfull.none'  : {".robust": false,  '.hyperparam_path': (list '.targetless' 'robust' '.none'),
-			;										"A" : 2, "B": 0.1, etc... } }
+			;										"A" : 2, "B": [0.1, 1, 0.05], etc... } }
 			residualsMap (assoc)
 
 			;assoc of feature -> MDA value, computed using dropping each feature, stored under a concatenated key starting with either

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -132,7 +132,7 @@
 	#regionalModelMinSize (null)
 	#regionalModelMinPercent (null)
 	#revision 0
-	#supportedPredictionStats (list "mae" "mda" "contribution" "confusion_matrix" "mda_permutation" "r2" "rmse" "spearman_coeff" "precision" "recall" "accuracy" "null_accuracy")
+	#supportedPredictionStats (list "mae" "mda" "contribution" "confusion_matrix" "mda_permutation" "r2" "rmse" "spearman_coeff" "precision" "recall" "accuracy" "missing_value_accuracy")
 	#sandboxedComputeLimit (null)
 	#sandboxedMemoryLimit (null)
 

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -120,6 +120,7 @@
 	#inactiveFeaturesMap (null)
 	#hasInactiveFeatures (null)
 	#residualsMap (null)
+	#featureNullAccuracyMap (null)
 	#mdaMap (null)
 	#mdaPermutationMap (null)
 	#featurePredictionStatsMap (null)
@@ -131,7 +132,7 @@
 	#regionalModelMinSize (null)
 	#regionalModelMinPercent (null)
 	#revision 0
-	#supportedPredictionStats (list "mae" "mda" "contribution" "confusion_matrix" "mda_permutation" "r2" "rmse" "spearman_coeff" "precision" "recall" "accuracy")
+	#supportedPredictionStats (list "mae" "mda" "contribution" "confusion_matrix" "mda_permutation" "r2" "rmse" "spearman_coeff" "precision" "recall" "accuracy" "null_accuracy")
 	#sandboxedComputeLimit (null)
 	#sandboxedMemoryLimit (null)
 
@@ -489,6 +490,13 @@
 			;eg: { 'full.targetlessfull.none'  : {".robust": false,  '.hyperparam_path': (list '.targetless' 'robust' '.none'),
 			;										"A" : 2, "B": [0.1, 1, 0.05], etc... } }
 			residualsMap (assoc)
+
+			;assoc of feature -> null prediction accuracy. The percentage of cases with with null values for a feature that we predict as null correctly
+			;Stored under a concatenated key starting with either 'robust' or 'full' based on
+			;how they were computed and the hyperparameter path keys.  contains built-in keys of '.robust' and '.hyperparam_path'
+			;eg: { 'full.targetlessfull.none'  : {".robust": false,  '.hyperparam_path': (list '.targetless' 'robust' '.none'),
+			;										"A" : 0.5, "B": 0.2, etc... } }
+			featureNullAccuracyMap (assoc)
 
 			;assoc of feature -> MDA value, computed using dropping each feature, stored under a concatenated key starting with either
 			;'robust' or 'full' based how they were computed, and the action_feature for which the mda was computed. contains built-in

--- a/trainee_template/feature_residuals.amlg
+++ b/trainee_template/feature_residuals.amlg
@@ -192,6 +192,46 @@
 		)
 	)
 
+	;returns cached feature null accuracies in the format of assoc feature -> null_accuracy
+	;parameters are optional, when not specified will auto-select a cached set for output, when specified will attempt to
+	;output the cached null_accuracies best matching the requested parameters, null if none match.
+	;
+	;parameters:
+	; robust: flag, optional. if specified will attempt to return null_accuracies that were computed with the specified robust or non-robust type.
+	; action_feature: string, optional. if specified will attempt to return null_accuracies that were computed for this specified action_feature.
+	;				  Note: ".targetless" is the action feature used during targetless analysis.
+	; robust_hyperparameters: flag, optional. if true, will attempt to return null_accuracies that were computed using hyperparameters with the
+	;						  specified robust or non-robust type.
+	; weight_feature: string, optional. if specified, will attempt to return null_accuracies that were computed using this weight_feature.
+	#GetFeatureNullAccuracies
+	(declare
+		(assoc
+			robust (null)
+			action_feature (null)
+			robust_hyperparameters (null)
+			weight_feature (null)
+		)
+
+		(if (= (null) robust action_feature robust_hyperparameters weight_feature)
+			;if only one residuals set has been computed, return it
+			(if (= 1 (size featureNullAccuracyMap))
+				(remove
+					(first (values featureNullAccuracyMap))
+					(list ".hyperparam_path" ".robust")
+				)
+
+				;there are several cached residuals, pick one 'smartly':
+				(remove
+					(call !AutoSelectPredictionStats (assoc original_values_map (retrieve_from_entity "featureNullAccuracyMap") ))
+					(list ".hyperparam_path" ".robust")
+				)
+			)
+
+			;else specified parameters, try to find the matching one
+			(call !SelectPredictionStats (assoc filtered_values_map (retrieve_from_entity "featureNullAccuracyMap") ))
+		)
+	)
+
 	;calculate feature residual values, i.e. the mae (mean absolute error of predictions on a sample of the model) for each of the specified features
 	;returns an assoc containing feature residuals, feature ordinal residuals and the hyperparam_map used for computations
 	;

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -47,7 +47,7 @@
 
 		(if (contains_value stats "mae")
 			(if (= 0 (size residualsMap))
-				(accum (assoc warnings "Feature Residuals have not been computed for this trainee. Please call 'react_into_trainee' with appropriate parameters to compute and store residuals prior to calling this method." ))
+				(accum (assoc warnings "Feature residuals have not been computed for this trainee. Please call 'react_into_trainee' with appropriate parameters to compute and store residuals prior to calling this method." ))
 
 				(accum (assoc
 					output_map
@@ -70,6 +70,25 @@
 										weight_feature weight_feature
 									))
 								)
+						)
+				))
+			)
+		)
+
+		(if (contains_value stats "null_accuracy")
+			(if (= 0 (size featureNullAccuracyMap))
+				(accum (assoc warnings "Feature null accuracies have not been computed for this trainee. Please call 'react_into_trainee' with appropriate parameters to compute and store null accuracies prior to calling this method." ))
+
+				(accum (assoc
+					output_map
+						(assoc
+							"null_accuracy"
+								(call GetFeatureNullAccuracies (assoc
+									robust robust
+									action_feature action_feature
+									robust_hyperparameters robust_hyperparameters
+									weight_feature weight_feature
+								))
 						)
 				))
 			)

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -75,14 +75,14 @@
 			)
 		)
 
-		(if (contains_value stats "null_accuracy")
+		(if (contains_value stats "missing_value_accuracy")
 			(if (= 0 (size featureNullAccuracyMap))
 				(accum (assoc warnings "Feature null accuracies have not been computed for this trainee. Please call 'react_into_trainee' with appropriate parameters to compute and store null accuracies prior to calling this method." ))
 
 				(accum (assoc
 					output_map
 						(assoc
-							"null_accuracy"
+							"missing_value_accuracy"
 								(call GetFeatureNullAccuracies (assoc
 									robust robust
 									action_feature action_feature

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -53,12 +53,23 @@
 					output_map
 						(assoc
 							"mae"
-								(call GetFeatureResiduals (assoc
-									robust robust
-									action_feature action_feature
-									robust_hyperparameters robust_hyperparameters
-									weight_feature weight_feature
-								))
+								(map
+									;GetFeatureResiduals returns the values in residualsMap, which contains a list of values for features containing nulls.
+									;In the case where residualsMap holds a list of values for a feature, the first value is the MAE.
+									(lambda
+										(if (= (get_type_string (current_value)) "list")
+											(first (current_value))
+
+											(current_value)
+										)
+									)
+									(call GetFeatureResiduals (assoc
+										robust robust
+										action_feature action_feature
+										robust_hyperparameters robust_hyperparameters
+										weight_feature weight_feature
+									))
+								)
 						)
 				))
 			)

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -77,7 +77,7 @@
 
 		(if (contains_value stats "missing_value_accuracy")
 			(if (= 0 (size featureNullAccuracyMap))
-				(accum (assoc warnings "Feature null accuracies have not been computed for this trainee. Please call 'react_into_trainee' with appropriate parameters to compute and store null accuracies prior to calling this method." ))
+				(accum (assoc warnings "Feature missing value accuracies have not been computed for this trainee. Please call 'react_into_trainee' with appropriate parameters to compute and store missing value accuracies prior to calling this method." ))
 
 				(accum (assoc
 					output_map

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -984,6 +984,20 @@
 				)
 		))
 
+		(accum_to_entities (assoc
+			featureNullAccuracyMap
+				(associate
+					(apply "concat" (append (if robust_residuals "robust" "full") (remove (get hyperparam_map "paramPath") 1) ))
+					(append
+						null_prediction_map
+						(assoc
+							".robust" robust_residuals
+							".hyperparam_path" (get hyperparam_map "paramPath")
+						)
+					)
+				)
+		))
+
 		;compute and cache all min-max values for all features
 		(if (= 0 (size featureMarginalStatsMap))
 			(call CalculateMarginalStats (assoc


### PR DESCRIPTION
residualsMap was updated to include the null uncertainties, which were returned when MAE was requested via get_prediction_stats.

This adds a fix that takes the first value for each feature if a list was returned (the first value holds the MAE between two non-null values).
Also updated some of the comments regarding residualsMap for clarity moving forward.