### PR TITLE
18886: Adds 'missing_value_accuracy' in conditioned prediction stats, MINOR

### DIFF
--- a/trainee_template/feature_residuals.amlg
+++ b/trainee_template/feature_residuals.amlg
@@ -868,7 +868,7 @@
 			(seq
 				;compute null deviations and update hyperparam_map with them
 				(if (size features_with_nulls)
-					(call !ComputeNullResiduals)
+					(call !ComputeAndCacheNullResiduals)
 				)
 
 				;store capped residual value

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -302,6 +302,7 @@
 					mode (if (= robust_hyperparameters (true)) "robust" "full")
 					weight_feature (if (= weight_feature (null)) ".none" weight_feature)
 				))
+			features (if (!= action_feature (null)) (append context_features action_feature) context_features)
 		))
 
 		;if no stats were specified, return all of them by default
@@ -330,7 +331,7 @@
 				(assoc
 					temp_output
 						(call CalculateFeatureResiduals (assoc
-							features (if (!= action_feature (null)) (append context_features action_feature) context_features)
+							features features
 							case_ids case_ids
 							robust_residuals robust_hyperparameters
 							use_case_weights use_case_weights
@@ -360,6 +361,58 @@
 					)
 					basic_stats
 				)
+			)
+		)
+
+		(if (contains_value stats "missing_value_accuracy")
+			(seq
+				(declare (assoc
+					features_map (zip features)
+					null_prediction_map (null)
+					feature_residuals_lists (null)
+					robust_residuals robust
+				))
+				(declare (assoc
+					null_feature_cases_map
+						(map
+							(lambda
+								(filter
+									(lambda (= (retrieve_from_entity (current_value) (current_index 1)) (null)) )
+									case_ids
+								)
+							)
+							features_map
+						)
+				))
+
+				;filter out the features that did not have any nulls
+				(assign (assoc
+					null_feature_cases_map
+						(filter
+							(lambda (> (size (current_value)) 0) )
+							null_feature_cases_map
+						)
+				))
+
+				;if doing robust_residuals, supersample the null cases
+				(if robust_residuals
+					(assign (assoc
+						null_feature_cases_map
+							(map
+								(lambda
+									(rand (current_value) 200 (false))
+								)
+								null_feature_cases_map
+							)
+					))
+				)
+				(declare (assoc features_with_nulls (indices null_feature_cases_map) ))
+
+				(call ComputeNullAccuracies)
+
+				(accum (assoc
+					output_map (assoc "missing_value_accuracy" null_prediction_map)
+				))
 			)
 		)
 

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -382,7 +382,12 @@
 									case_ids
 								)
 							)
-							features_map
+
+							;the list of features that have nulls
+							(filter
+								(lambda (> (get featureNullRatiosMap (list (current_value 1) "num_nulls")) 0))
+								features
+							)
 						)
 				))
 
@@ -390,7 +395,7 @@
 				(assign (assoc
 					null_feature_cases_map
 						(filter
-							(lambda (> (size (current_value)) 0) )
+							(lambda (size (current_value)) )
 							null_feature_cases_map
 						)
 				))

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -365,13 +365,14 @@
 		)
 
 		(if (contains_value stats "missing_value_accuracy")
-			(seq
-				(declare (assoc
+			(let
+				(assoc
 					features_map (zip features)
 					null_prediction_map (null)
 					feature_residuals_lists (null)
 					robust_residuals robust
-				))
+				)
+
 				(declare (assoc
 					null_feature_cases_map
 						(map

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -370,28 +370,29 @@
 					features_map (zip features)
 					null_prediction_map (null)
 					feature_residuals_lists (null)
-					robust_residuals robust
+					robust_residuals (= robust (true))
 				)
 
+				;map of feature_name -> list of case ids with null values for the specified feature
 				(declare (assoc
 					null_feature_cases_map
 						(map
 							(lambda
-								(filter
-									(lambda (= (retrieve_from_entity (current_value) (current_index 1)) (null)) )
-									case_ids
-								)
+								(contained_entities (list
+									(query_in_entity_list case_ids)
+									(query_equals (current_index 1) (null))
+								))
 							)
 
-							;the list of features that have nulls
-							(filter
+							;the assoc of features that have nulls to (null)
+							(zip (filter
 								(lambda (> (get featureNullRatiosMap (list (current_value 1) "num_nulls")) 0))
 								features
-							)
+							))
 						)
 				))
 
-				;filter out the features that did not have any nulls
+				;filter out the features that did not have any nulls in case_ids
 				(assign (assoc
 					null_feature_cases_map
 						(filter

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -875,114 +875,120 @@
 	)
 
 	;Helper method to compute null deviations
-	#!ComputeNullResiduals
+	#!ComputeAndCacheNullResiduals
 	(seq
-		(declare (assoc features_map (zip features) ))
-
-		;iterate over all the features with nulls, and predict each feature's case's list
-		(assign (assoc
-			feature_residuals_lists
-				||(map
-					(lambda (let
-						(assoc
-							feature (get_value (current_value 1))
-							feature_is_nominal (contains_index nominalsMap (current_value 1))
-							react_context_features (indices (remove features_map (current_value 1)))
-							all_react_context_features (list)
-							null_case_ids (get null_feature_cases_map (current_value 1))
-						)
-
-						(if robust_residuals
-							(assign (assoc all_react_context_features react_context_features))
-						)
-
-						;iterate over list of cases that have nulls for this feature and predict each one,
-						;output a list of 1s and 0s where every correctly predicted null is a 1
-						(map
-							(lambda (let
-								(assoc
-									case_id (current_value 1)
-									case_values_map (zip features (retrieve_from_entity (current_value 1) features))
-									interpolated_value 0
-								)
-
-								;grab a random set of context features when computing robust residuals
-								(if robust_residuals
-									(assign (assoc react_context_features (filter (lambda (< (rand) 0.5)) all_react_context_features) ))
-								)
-
-								(declare (assoc
-									candidate_cases_lists
-										(compute_on_contained_entities (append
-											(if focal_case
-												(query_not_in_entity_list (list case_id focal_case))
-												(query_not_in_entity_list (list case_id))
-											)
-											(query_nearest_generalized_distance
-												k_parameter
-												react_context_features
-												(unzip case_values_map react_context_features)
-												(get hyperparam_map "featureWeights")
-												queryDistanceTypeMap
-												query_feature_attributes_map
-												(if (get hyperparam_map "useDeviations") (get hyperparam_map "featureDeviations") (get hyperparam_map "nullUncertainties") )
-												p_parameter
-												dt_parameter
-												(if valid_weight_feature weight_feature (null))
-												tie_break_random_seed
-												(null) ;radius
-												numericalPrecision
-												feature
-											)
-										))
-								))
-
-								(assign (assoc
-									interpolated_value
-										;no local_cases_map means we use expected feature value
-										(if (size (first candidate_cases_lists))
-											(call InterpolateActionValues (assoc
-												action_feature feature
-												candidate_case_ids (first candidate_cases_lists)
-												candidate_case_weights (get candidate_cases_lists 1)
-												candidate_case_values (last candidate_cases_lists)
-												allow_nulls (true)
-												output_influence_weights (false)
-											))
-
-											;else there's no local model, return expected values
-											(if feature_is_nominal
-												;pull global probability for feature
-												(get (call ComputeModelNominalClassProbabilities (assoc feature feature)) feature)
-
-												;else get continuous expected value
-												(call CalculateFeatureExpectedValue (assoc feature feature allow_nulls (true) ))
-											)
-										)
-								))
-
-								;output a 1 if predicted a null correctly, else a 0
-								(+ (= (null) interpolated_value))
-							))
-							null_case_ids
-						)
-					))
-
-					features_with_nulls
-				)
-		))
-
-		;create a map of feature -> null prediction probability by averaging out all the correctly predicted nulls for each feature
 		(declare (assoc
-			null_prediction_map
-				(zip
-					features_with_nulls
-					(map
-						(lambda (/ (apply "+" (current_value)) (size (current_value)) ) )
-						feature_residuals_lists
-					)
-				)
+			features_map (zip features)
+			null_prediction_map (null)
 		))
+
+		#ComputeNullAccuracies
+		(seq
+			;iterate over all the features with nulls, and predict each feature's case's list
+			(assign (assoc
+				feature_residuals_lists
+					||(map
+						(lambda (let
+							(assoc
+								feature (get_value (current_value 1))
+								feature_is_nominal (contains_index nominalsMap (current_value 1))
+								react_context_features (indices (remove features_map (current_value 1)))
+								all_react_context_features (list)
+								null_case_ids (get null_feature_cases_map (current_value 1))
+							)
+
+							(if robust_residuals
+								(assign (assoc all_react_context_features react_context_features))
+							)
+
+							;iterate over list of cases that have nulls for this feature and predict each one,
+							;output a list of 1s and 0s where every correctly predicted null is a 1
+							(map
+								(lambda (let
+									(assoc
+										case_id (current_value 1)
+										case_values_map (zip features (retrieve_from_entity (current_value 1) features))
+										interpolated_value 0
+									)
+
+									;grab a random set of context features when computing robust residuals
+									(if robust_residuals
+										(assign (assoc react_context_features (filter (lambda (< (rand) 0.5)) all_react_context_features) ))
+									)
+
+									(declare (assoc
+										candidate_cases_lists
+											(compute_on_contained_entities (append
+												(if focal_case
+													(query_not_in_entity_list (list case_id focal_case))
+													(query_not_in_entity_list (list case_id))
+												)
+												(query_nearest_generalized_distance
+													(get hyperparam_map "k")
+													react_context_features
+													(unzip case_values_map react_context_features)
+													(get hyperparam_map "featureWeights")
+													queryDistanceTypeMap
+													(get hyperparam_map "featureDomainAttributes")
+													(if (get hyperparam_map "useDeviations") (get hyperparam_map "featureDeviations") (get hyperparam_map "nullUncertainties") )
+													(get hyperparam_map "p")
+													(get hyperparam_map "dt")
+													(if valid_weight_feature weight_feature (null))
+													tie_break_random_seed
+													(null) ;radius
+													numericalPrecision
+													feature
+												)
+											))
+									))
+
+									(assign (assoc
+										interpolated_value
+											;no local_cases_map means we use expected feature value
+											(if (size (first candidate_cases_lists))
+												(call InterpolateActionValues (assoc
+													action_feature feature
+													candidate_case_ids (first candidate_cases_lists)
+													candidate_case_weights (get candidate_cases_lists 1)
+													candidate_case_values (last candidate_cases_lists)
+													allow_nulls (true)
+													output_influence_weights (false)
+												))
+
+												;else there's no local model, return expected values
+												(if feature_is_nominal
+													;pull global probability for feature
+													(get (call ComputeModelNominalClassProbabilities (assoc feature feature)) feature)
+
+													;else get continuous expected value
+													(call CalculateFeatureExpectedValue (assoc feature feature allow_nulls (true) ))
+												)
+											)
+									))
+
+									;output a 1 if predicted a null correctly, else a 0
+									(+ (= (null) interpolated_value))
+								))
+								null_case_ids
+							)
+						))
+
+						features_with_nulls
+					)
+			))
+
+			;create a map of feature -> null prediction probability by averaging out all the correctly predicted nulls for each feature
+			(assign (assoc
+				null_prediction_map
+					(zip
+						features_with_nulls
+						(map
+							(lambda (/ (apply "+" (current_value)) (size (current_value)) ) )
+							feature_residuals_lists
+						)
+					)
+			))
+		)
 
 		(accum_to_entities (assoc
 			featureNullAccuracyMap

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -906,6 +906,7 @@
 			null_prediction_map (null)
 		))
 
+		;ComputeNullAccuracies requires null_features_cases_map, features_map, features_with_nulls, and hyperparam_map
 		#ComputeNullAccuracies
 		(seq
 			;iterate over all the features with nulls, and predict each feature's case's list


### PR DESCRIPTION
Adds logic to compute 'missing_value_accracy' in get_prediction_stats when a condition is specified.