### PR TITLE
19079: Fixes an issue in Discriminative Reacts with multiple action features where the first is also a context feature

### DIFF
--- a/trainee_template/react_discriminative.amlg
+++ b/trainee_template/react_discriminative.amlg
@@ -317,9 +317,10 @@
 				(while (< (current_index) (size ordered_action_features))
 					(if (> (current_index) 0)
 						(seq
-							(assign (assoc
-								context_features_param (append context_features_param action_feature)
-								context_values_param (append context_values_param action_value)
+							;grow context with last action feature and value
+							(accum (assoc
+								context_features_param action_feature
+								context_values_param action_value
 							))
 
 

--- a/trainee_template/react_discriminative.amlg
+++ b/trainee_template/react_discriminative.amlg
@@ -317,20 +317,6 @@
 				(while (< (current_index) (size ordered_action_features))
 					(if (> (current_index) 0)
 						(seq
-							;get the hyperparameter map for the next action feature
-							(assign (assoc
-								hyperparam_map
-									(call GetHyperparameters (assoc
-										feature (get ordered_action_features (current_index 2))
-										context_features context_features_param
-										mode
-											(if (or force_targetless (!= (current_index 2) (- (size action_features) 1)))
-												"robust"
-												"full"
-											)
-										weight_feature weight_feature
-									))
-							))
 							(assign (assoc
 								context_features_param (append context_features_param action_feature)
 								context_values_param (append context_values_param action_value)
@@ -360,6 +346,22 @@
 
 					(assign (assoc
 						action_feature (get ordered_action_features (current_index 1))
+
+						;get hyperparameters for the action feature if available
+						hyperparam_map
+							(call GetHyperparameters (assoc
+								feature (get ordered_action_features (current_index 2))
+								context_features context_features_param
+								mode
+									(if (or force_targetless (!= (current_index 2) (- (size action_features) 1)))
+										"robust"
+										"full"
+									)
+								weight_feature weight_feature
+							))
+					))
+
+					(assign (assoc
 						action_value
 							(call GenerateReaction (assoc
 								allow_nulls allow_nulls


### PR DESCRIPTION
In Discriminative Reacts with multiple action features where the first is also a context feature, the hyperparameters used to compute the action value for the *second* action feature are computed using Hyperparameters selected for the *first* action feature.

This behavior takes place because hyperparameters are initially selected for the first action feature - before it is checked if there is overlap between context/action features.

My solution here is to select hyperparameters on **every** iteration of the multiple action feature discriminative react flow **rather than just every iteration after the first**.
This will add one more GetHyperparameters call to discriminative reacts with multiple action features, but it seems like the least destructive change.