### PR TITLE
19156: Generalizes retrieving and organizing details in react_series

### DIFF
--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -115,6 +115,9 @@
 	#tsMinTimeInterval (null)
 	#tsSeriesLimitLength (null)
 	#tsModelFeaturesMap (null)
+
+	#tsSupportedDetails (null)
+
 	#hasStringOrdinals (null)
 	#hasInfluenceWeightEntropies (null)
 	#ordinalStringToOrdinalMap (null)
@@ -445,6 +448,9 @@
 			;flag set to true once a time series model creates its time series feature attributes
 			hasTimeSeriesAttrbutes (false)
 
+			;list of supported details for react series
+			tsSupportedDetails (list "categorical_action_probabilities" "influential_cases")
+
 			;flag set to true if there are features that are dependent on others
 			hasDependentFeatures (false)
 
@@ -482,7 +488,7 @@
 
 			;the features for which a case should be ablated if the predicted value of the feature is within a given absolute threshold.
 			autoAblationTolerancePredictionThresholdMap (null)
-			
+
 			;the features for which a case should be ablated if the predicted value of the feature is within a given relative threshold.
 			autoAblationRelativePredictionThresholdMap (null)
 
@@ -497,7 +503,7 @@
 
 			;the name of the weight feature to use for auto ablation.
 			autoAblationWeightFeature (null)
-			
+
 			;whether this Trainee has had influence weight entropies computed and stored for its trained cases.
 			hasInfluenceWeightEntropies (false)
 

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -115,9 +115,7 @@
 	#tsMinTimeInterval (null)
 	#tsSeriesLimitLength (null)
 	#tsModelFeaturesMap (null)
-
 	#tsSupportedDetails (null)
-
 	#hasStringOrdinals (null)
 	#hasInfluenceWeightEntropies (null)
 	#ordinalStringToOrdinalMap (null)

--- a/trainee_template/derive_utilities.amlg
+++ b/trainee_template/derive_utilities.amlg
@@ -52,7 +52,7 @@
 									;do not derive anything during this react
 									derived_action_features (list)
 									derived_context_features (list)
-									details (if (or output_influential_cases output_cap) details)
+									details (if output_details details)
 									extra_audit_features (append extra_audit_features action_features derived_action_features)
 									substitute_output substitute_output
 									input_is_substituted input_is_substituted
@@ -76,11 +76,22 @@
 							(first (get react_output "action_values"))
 						)
 
-						(if output_influential_cases
-							(accum (assoc influential_cases (get react_output "influential_cases") ))
-						)
-						(if output_cap
-							(accum (assoc local_class_probabilities_map (get react_output "categorical_action_probabilities") ))
+						; (if output_influential_cases
+						; 	(accum (assoc influential_cases (get react_output "influential_cases") ))
+						; )
+						; (if output_cap
+						; 	(accum (assoc local_class_probabilities_map (get react_output "categorical_action_probabilities") ))
+						; )
+						(if output_details
+							(assign (assoc
+								case_detail_values_map
+									(map
+										(lambda
+											(append (current_value) (get react_output (current_index)))
+										)
+										case_detail_values_map
+									)
+							))
 						)
 					)
 				)

--- a/trainee_template/derive_utilities.amlg
+++ b/trainee_template/derive_utilities.amlg
@@ -76,12 +76,6 @@
 							(first (get react_output "action_values"))
 						)
 
-						; (if output_influential_cases
-						; 	(accum (assoc influential_cases (get react_output "influential_cases") ))
-						; )
-						; (if output_cap
-						; 	(accum (assoc local_class_probabilities_map (get react_output "categorical_action_probabilities") ))
-						; )
 						(if output_details
 							(assign (assoc
 								case_detail_values_map

--- a/trainee_template/derive_utilities.amlg
+++ b/trainee_template/derive_utilities.amlg
@@ -76,6 +76,7 @@
 							(first (get react_output "action_values"))
 						)
 
+						;if gathering details, update the case detail values with those from this react
 						(if output_details
 							(assign (assoc
 								case_detail_values_map

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -884,12 +884,17 @@
 		)
 	)
 
-	;Get the appropriate empty data structure for a given detail
-	#GetDetailDataStructure
-	(if (contains_value (list "categorical_action_probabilities") detail)
-		(assoc)
+	;Create an assoc of (detail -> correct empty data structure) for each detail in details
+	#InitializeCaseDetailValuesMap
+	(map
+		(lambda
+			(if (= "categorical_action_probabilities" (current_index))
+				(assoc)
 
-		;default to list
-		(list)
+				;default to list
+				(list)
+			)
+		)
+		(zip details)
 	)
 )

--- a/trainee_template/explanation.amlg
+++ b/trainee_template/explanation.amlg
@@ -883,4 +883,13 @@
 			)
 		)
 	)
+
+	;Get the appropriate empty data structure for a given detail
+	#GetDetailDataStructure
+	(if (contains_value (list "categorical_action_probabilities") detail)
+		(assoc)
+
+		;default to list
+		(list)
+	)
 )

--- a/trainee_template/explanation_cases.amlg
+++ b/trainee_template/explanation_cases.amlg
@@ -817,13 +817,14 @@
 	;and more than a total of 1.0 influence weight between them all. This method accumulates the weights among all duplicate cases to create
 	;a single list of unique cases, and then normalizes the influence weights so they sum up to 1.0
 	#!NormalizeReactSeriesInfluentialCases
-	(if (size influential_cases)
+	(if (size (get case_detail_values_map "influential_cases"))
 		(let
 			(assoc
+				influential_cases (get case_detail_values_map "influential_cases")
 				case_id_list
 					(map
 						(lambda (concat (get (current_value) internalLabelSession) (get (current_value) internalLabelSessionTrainingIndex)) )
-						influential_cases
+						(get case_detail_values_map "influential_cases")
 					)
 			)
 
@@ -869,6 +870,10 @@
 						)
 						influential_cases
 					)
+			))
+
+			(assign (assoc
+				case_detail_values_map (set case_detail_values_map "influential_cases" influential_cases)
 			))
 		)
 	)

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -729,22 +729,7 @@
 						(call !NormalizeReactSeriesInfluentialCases)
 					)
 
-					;update all_influential_cases on the last iteration so it can be output when react_series returns
-					; (if (and done (size influential_cases))
-					; 	;wrap the influential cases in a list so it's accumulated as a list of lists of assocs (a list per row)
-					; 	(accum (assoc all_influential_cases (list influential_cases) ))
-					; )
-
-					; (if (and done (size local_class_probabilities_map))
-					; 	(accum (assoc all_categorical_action_probabilities (list local_class_probabilities_map)))
-					; )
-
-					;store into previous_result as a tuple of [series_data, all_categorical_action_probabilities, all_influential_cases]
-					; (list
-					; 	series_data
-					; 	(append all_categorical_action_probabilities (list local_class_probabilities_map))
-					; 	(append all_influential_cases (list influential_cases))
-					; )
+					;update series_detail_values_map on the last iteration so it can be output when react_series returns
 					(if done
 						(assign (assoc
 							series_detail_values_map
@@ -757,6 +742,7 @@
 						))
 					)
 
+					;store accumulated data into previous_result as an assoc
 					(append
 						(assoc "series_data" series_data)
 						(if output_details
@@ -959,20 +945,8 @@
 						;ensure features are output in the payload
 						"action_features" output_features
 					)
-					; (if output_influential_cases
-					; 	(assoc "influential_cases" all_influential_cases)
-					; 	(assoc)
-					; )
-					; (if output_cap
-					; 	(assoc
-					; 		"categorical_action_probabilities" all_categorical_action_probabilities
-					; 		"aggregated_categorical_action_probabilities" aggregated_categorical_action_probabilities
-					; 	)
-					; 	(assoc)
-					; )
 					(if output_details
 						series_detail_values_map
-
 						(assoc)
 					)
 				)
@@ -1319,12 +1293,6 @@
 		;overwrite the last row in series data with the values from the updated current case
 		(assign "series_data" (list last_series_index) (unzip current_case_map features))
 
-		; (if output_influential_cases
-		; 	(accum (assoc influential_cases (get react_output "influential_cases") ))
-		; )
-		; (if output_cap
-		; 	(accum (assoc local_class_probabilities_map (get react_output "categorical_action_probabilities") ))
-		; )
 		(if output_details
 			(assign (assoc
 				case_detail_values_map
@@ -1418,8 +1386,7 @@
 											(assign (assoc
 												done (true)
 												series_data (trunc series_data)
-												; influential_cases (list)
-												; local_class_probabilities_map (assoc)
+												;reset case detail values
 												case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
 											))
 
@@ -1435,8 +1402,7 @@
 														last_series_index (- num_existing_series_rows 1)
 														first_generated_row (true)
 														current_case_map (assoc)
-														; influential_cases (list)
-														; local_class_probabilities_map (assoc)
+														;reset case detail values
 														case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
 													))
 
@@ -1446,8 +1412,7 @@
 														last_series_index -1
 														first_generated_row (true)
 														current_case_map (assoc)
-														; influential_cases (list)
-														; local_class_probabilities_map (assoc)
+														;reset case detail values
 														case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
 													))
 												)

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -482,8 +482,6 @@
 						(assign (assoc
 							series_data (append (get accumulated_data "series_data") new_row)
 						))
-						; all_categorical_action_probabilities (get accumulated_data_pair "categorical_action_probabilities")
-						; all_influential_cases (get accumulated_data "influential_cases")
 						(if output_details
 							(assign (assoc
 								series_detail_values_map
@@ -735,7 +733,12 @@
 							series_detail_values_map
 								(map
 									(lambda
-										(append (current_value) (list (get case_detail_values_map (current_index 1))) )
+										(if (size (get case_detail_values_map (current_index)))
+											(append (current_value) (list (get case_detail_values_map (current_index 1))) )
+
+											;don't append if the case detail value is empty
+											(current_value)
+										)
 									)
 									series_detail_values_map
 								)

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -64,7 +64,7 @@
 
 		(declare (assoc
 			warnings (assoc)
-			requested_details (filter (lambda (get details (current_value))) (indices details))
+			requested_details (indices (filter (lambda (current_value)) details))
 			output_details (contains_value (values details) (true))
 		))
 
@@ -161,14 +161,17 @@
 						"series" (map (lambda (get (current_value) "series")) series_output)
 					)
 					(if output_details
+						;map over the requested details to build a list of lists for each series
 						(map
 							(lambda
+								;map over each series output (current_value) and pull the current detail (current_index 1)
 								(map (lambda (get (current_value) (current_index 1))) series_output)
 							)
 							(zip requested_details)
 						)
 						(assoc)
 					)
+					;aggregated_caps must be manually added because they will not be in requested_details
 					(if (and output_details (contains_value requested_details "categorical_action_probabilities"))
 						(assoc
 							"aggregated_categorical_action_probabilities" (map (lambda (get (current_value) "aggregated_categorical_action_probabilities")) series_output)
@@ -342,18 +345,12 @@
 		)
 
 		(declare (assoc
-			requested_details (filter (lambda (get details (current_value))) (indices details))
+			requested_details (indices (filter (lambda (current_value)) details))
 			output_details (contains_value (values details) (true))
 		))
 
 		(let
-			(assoc
-				invalid_ts_details
-					(filter
-						(lambda (not (contains_value tsSupportedDetails (current_value))) )
-						requested_details
-					)
-			)
+			(assoc invalid_ts_details (indices (remove (zip requested_details) tsSupportedDetails) ) )
 
 			(if (size invalid_ts_details)
 				(accum (assoc
@@ -371,7 +368,7 @@
 
 		(if output_details
 			(declare (assoc
-				case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
+				case_detail_values_map (call InitializeCaseDetailValuesMap (assoc details requested_details))
 				series_detail_values_map (map (lambda (list)) (zip requested_details))
 			))
 		)
@@ -1330,7 +1327,7 @@
 				(if derivation_failed
 					(assign (assoc
 						series_data (trunc series_data)
-						case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
+						case_detail_values_map (call InitializeCaseDetailValuesMap (assoc details requested_details))
 						done (true)
 					))
 				)
@@ -1390,7 +1387,7 @@
 												done (true)
 												series_data (trunc series_data)
 												;reset case detail values
-												case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
+												case_detail_values_map (call InitializeCaseDetailValuesMap (assoc details requested_details))
 											))
 
 											;else reset series_data and initial features and progress and index, to regenerate the series from the start
@@ -1406,7 +1403,7 @@
 														first_generated_row (true)
 														current_case_map (assoc)
 														;reset case detail values
-														case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
+														case_detail_values_map (call InitializeCaseDetailValuesMap (assoc details requested_details))
 													))
 
 													(assign (assoc
@@ -1416,7 +1413,7 @@
 														first_generated_row (true)
 														current_case_map (assoc)
 														;reset case detail values
-														case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
+														case_detail_values_map (call InitializeCaseDetailValuesMap (assoc details requested_details))
 													))
 												)
 											)

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -160,17 +160,6 @@
 						"action_features" output_features
 						"series" (map (lambda (get (current_value) "series")) series_output)
 					)
-					; (if output_influential_cases
-					; 	(assoc "influential_cases" (map (lambda (get (current_value) "influential_cases")) series_output))
-					; 	(assoc)
-					; )
-					; (if output_cap
-					; 	(assoc
-					; 		"categorical_action_probabilities" (map (lambda (get (current_value) "categorical_action_probabilities")) series_output)
-					; 		"aggregated_categorical_action_probabilities" (map (lambda (get (current_value) "aggregated_categorical_action_probabilities")) series_output)
-					; 	)
-					; 	(assoc)
-					; )
 					(if output_details
 						(map
 							(lambda
@@ -178,6 +167,7 @@
 							)
 							(zip requested_details)
 						)
+						(assoc)
 					)
 					(if (and output_details (contains_value requested_details "categorical_action_probabilities"))
 						(assoc
@@ -345,13 +335,12 @@
 				))
 		))
 
-			; output_influential_cases (get details "influential_cases")
-			; influential_cases (list)
-			; all_influential_cases (list)
-			; output_cap (get details "categorical_action_probabilities")
-			; local_class_probabilities_map (assoc)
-			; all_categorical_action_probabilities (list)
-			; aggregated_categorical_action_probabilities (assoc)
+		;if this method is being called from batch_react_series, warnings will already have been declared in BatchReact
+		;otherwise declare warnings here if this is being called from the single react_series call
+		(if (= (null) warnings)
+			(declare (assoc warnings (assoc) ))
+		)
+
 		(declare (assoc
 			requested_details (filter (lambda (get details (current_value))) (indices details))
 			output_details (contains_value (values details) (true))
@@ -406,11 +395,6 @@
 			))
 		)
 
-		;if this method is being called from batch_react_series, warnings will already have been declared in BatchReact
-		;otherwise declare warnings here if this is being called from the single react_series call
-		(if (= (null) warnings)
-			(declare (assoc warnings (assoc) ))
-		)
 
 		;if initial features are provided, ensure there aren't any that do not appear in features. any extra features are deleted and ignored.
 		#!InitializeInitialSeriesFeatures
@@ -761,20 +745,27 @@
 					; 	(append all_categorical_action_probabilities (list local_class_probabilities_map))
 					; 	(append all_influential_cases (list influential_cases))
 					; )
-					(assign (assoc
-						series_detail_values_map
+					(if done
+						(assign (assoc
+							series_detail_values_map
+								(map
+									(lambda
+										(append (current_value) (list (get case_detail_values_map (current_index 1))) )
+									)
+									series_detail_values_map
+								)
+						))
+					)
+
+					(append
+						(assoc "series_data" series_data)
+						(if output_details
 							(map
 								(lambda
 									(append (current_value) (list (get case_detail_values_map (current_index 1))) )
 								)
 								series_detail_values_map
 							)
-					))
-
-					(append
-						(assoc "series_data" series_data)
-						(if output_details
-							series_detail_values_map
 
 							;else empty list
 							(assoc)
@@ -1368,8 +1359,6 @@
 				(if derivation_failed
 					(assign (assoc
 						series_data (trunc series_data)
-						; influential_cases (list)
-						; local_class_probabilities_map (assoc)
 						case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
 						done (true)
 					))

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -64,8 +64,8 @@
 
 		(declare (assoc
 			warnings (assoc)
-			output_influential_cases (get details "influential_cases")
-			output_cap (get details "categorical_action_probabilities")
+			requested_details (filter (lambda (get details (current_value))) (indices details))
+			output_details (contains_value (values details) (true))
 		))
 
 		(declare (assoc
@@ -160,13 +160,27 @@
 						"action_features" output_features
 						"series" (map (lambda (get (current_value) "series")) series_output)
 					)
-					(if output_influential_cases
-						(assoc "influential_cases" (map (lambda (get (current_value) "influential_cases")) series_output))
-						(assoc)
+					; (if output_influential_cases
+					; 	(assoc "influential_cases" (map (lambda (get (current_value) "influential_cases")) series_output))
+					; 	(assoc)
+					; )
+					; (if output_cap
+					; 	(assoc
+					; 		"categorical_action_probabilities" (map (lambda (get (current_value) "categorical_action_probabilities")) series_output)
+					; 		"aggregated_categorical_action_probabilities" (map (lambda (get (current_value) "aggregated_categorical_action_probabilities")) series_output)
+					; 	)
+					; 	(assoc)
+					; )
+					(if output_details
+						(map
+							(lambda
+								(map (lambda (get (current_value) (current_index 1))) series_output)
+							)
+							(zip requested_details)
+						)
 					)
-					(if output_cap
+					(if (and output_details (contains_value requested_details "categorical_action_probabilities"))
 						(assoc
-							"categorical_action_probabilities" (map (lambda (get (current_value) "categorical_action_probabilities")) series_output)
 							"aggregated_categorical_action_probabilities" (map (lambda (get (current_value) "aggregated_categorical_action_probabilities")) series_output)
 						)
 						(assoc)
@@ -329,14 +343,50 @@
 						derived_context_features
 					)
 				))
-			output_influential_cases (get details "influential_cases")
-			influential_cases (list)
-			all_influential_cases (list)
-			output_cap (get details "categorical_action_probabilities")
-			local_class_probabilities_map (assoc)
-			all_categorical_action_probabilities (list)
-			aggregated_categorical_action_probabilities (assoc)
 		))
+
+			; output_influential_cases (get details "influential_cases")
+			; influential_cases (list)
+			; all_influential_cases (list)
+			; output_cap (get details "categorical_action_probabilities")
+			; local_class_probabilities_map (assoc)
+			; all_categorical_action_probabilities (list)
+			; aggregated_categorical_action_probabilities (assoc)
+		(declare (assoc
+			requested_details (filter (lambda (get details (current_value))) (indices details))
+			output_details (contains_value (values details) (true))
+		))
+
+		(let
+			(assoc
+				invalid_ts_details
+					(filter
+						(lambda (not (contains_value tsSupportedDetails (current_value))) )
+						requested_details
+					)
+			)
+
+			(if (size invalid_ts_details)
+				(accum (assoc
+					warnings
+						(associate
+							(concat
+								"The following details are not officially supported for react series: "
+								(apply "concat" (map (lambda (concat (current_value) ",") ) invalid_ts_details) )
+								". Behavior is undefined."
+							)
+						)
+				))
+			)
+		)
+
+		(if output_details
+			(declare (assoc
+				case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
+				series_detail_values_map (map (lambda (list)) (zip requested_details))
+			))
+		)
+
 
 		(let
 			(assoc context_map (zip user_specified_context_features))
@@ -441,15 +491,26 @@
 				(accum (assoc series_data new_row))
 
 				;else there is a previous_result, accumulate new_row to it
-				(if (or output_influential_cases output_cap)
+				(if output_details
 					(let
 						;previous_result is a pair of [series_data, all_influential_cases]
-						(assoc accumulated_data_pair (previous_result 1) )
+						(assoc accumulated_data (previous_result 1) )
 						(assign (assoc
-							series_data (append (first accumulated_data_pair) new_row)
-							all_categorical_action_probabilities (get accumulated_data_pair 1)
-							all_influential_cases (last accumulated_data_pair)
+							series_data (append (get accumulated_data "series_data") new_row)
 						))
+						; all_categorical_action_probabilities (get accumulated_data_pair "categorical_action_probabilities")
+						; all_influential_cases (get accumulated_data "influential_cases")
+						(if output_details
+							(assign (assoc
+								series_detail_values_map
+									(map
+										(lambda
+											(get accumulated_data (current_index))
+										)
+										series_detail_values_map
+									)
+							))
+						)
 					)
 
 					;else when not outputting explanations, previous_result is just the series_data itself
@@ -678,25 +739,46 @@
 
 			;return series_data so it's stored as previous_result for accumulation in the next iteration of the while loop
 			;and explanation details if requested
-			(if (or output_influential_cases output_cap)
+			(if output_details
 				(seq
-					(call !NormalizeReactSeriesInfluentialCases)
+					(if (contains_index case_detail_values_map "influential_cases")
+						(call !NormalizeReactSeriesInfluentialCases)
+					)
 
 					;update all_influential_cases on the last iteration so it can be output when react_series returns
-					(if (and done (size influential_cases))
-						;wrap the influential cases in a list so it's accumulated as a list of lists of assocs (a list per row)
-						(accum (assoc all_influential_cases (list influential_cases) ))
-					)
+					; (if (and done (size influential_cases))
+					; 	;wrap the influential cases in a list so it's accumulated as a list of lists of assocs (a list per row)
+					; 	(accum (assoc all_influential_cases (list influential_cases) ))
+					; )
 
-					(if (and done (size local_class_probabilities_map))
-						(accum (assoc all_categorical_action_probabilities (list local_class_probabilities_map)))
-					)
+					; (if (and done (size local_class_probabilities_map))
+					; 	(accum (assoc all_categorical_action_probabilities (list local_class_probabilities_map)))
+					; )
 
 					;store into previous_result as a tuple of [series_data, all_categorical_action_probabilities, all_influential_cases]
-					(list
-						series_data
-						(append all_categorical_action_probabilities (list local_class_probabilities_map))
-						(append all_influential_cases (list influential_cases))
+					; (list
+					; 	series_data
+					; 	(append all_categorical_action_probabilities (list local_class_probabilities_map))
+					; 	(append all_influential_cases (list influential_cases))
+					; )
+					(assign (assoc
+						series_detail_values_map
+							(map
+								(lambda
+									(append (current_value) (list (get case_detail_values_map (current_index 1))) )
+								)
+								series_detail_values_map
+							)
+					))
+
+					(append
+						(assoc "series_data" series_data)
+						(if output_details
+							series_detail_values_map
+
+							;else empty list
+							(assoc)
+						)
 					)
 				)
 
@@ -818,10 +900,10 @@
 			)
 		)
 
-		(if output_cap
+		(if (and output_details (contains_index series_detail_values_map "categorical_action_probabilities"))
 			(let
 				(assoc
-					series_len (size all_categorical_action_probabilities)
+					series_len (size (get series_detail_values_map "categorical_action_probabilities"))
 					aggregated_cap_map
 						(reduce
 							(lambda
@@ -844,12 +926,12 @@
 									(current_value)
 								)
 							)
-							all_categorical_action_probabilities
+							(get series_detail_values_map "categorical_action_probabilities")
 						)
 				)
 
 				;normalize the aggregated caps by the series length to output a single assoc for the entire series
-				(assign (assoc
+				(declare (assoc
 					aggregated_categorical_action_probabilities
 						(map
 							(lambda (map
@@ -858,6 +940,11 @@
 							))
 							aggregated_cap_map
 						)
+				))
+
+				(assign (assoc
+					series_detail_values_map
+						(append series_detail_values_map (assoc "aggregated_categorical_action_probabilities" aggregated_categorical_action_probabilities))
 				))
 			)
 		)
@@ -881,15 +968,20 @@
 						;ensure features are output in the payload
 						"action_features" output_features
 					)
-					(if output_influential_cases
-						(assoc "influential_cases" all_influential_cases)
-						(assoc)
-					)
-					(if output_cap
-						(assoc
-							"categorical_action_probabilities" all_categorical_action_probabilities
-							"aggregated_categorical_action_probabilities" aggregated_categorical_action_probabilities
-						)
+					; (if output_influential_cases
+					; 	(assoc "influential_cases" all_influential_cases)
+					; 	(assoc)
+					; )
+					; (if output_cap
+					; 	(assoc
+					; 		"categorical_action_probabilities" all_categorical_action_probabilities
+					; 		"aggregated_categorical_action_probabilities" aggregated_categorical_action_probabilities
+					; 	)
+					; 	(assoc)
+					; )
+					(if output_details
+						series_detail_values_map
+
 						(assoc)
 					)
 				)
@@ -1207,7 +1299,7 @@
 					;do not derive anything during this react
 					derived_action_features (list)
 					derived_context_features (list)
-					details (if (or output_influential_cases output_cap) details)
+					details (if output_details details)
 					extra_audit_features (append extra_audit_features derived_action_features)
 					ignore_case ignore_case
 					case_indices case_indices
@@ -1236,11 +1328,22 @@
 		;overwrite the last row in series data with the values from the updated current case
 		(assign "series_data" (list last_series_index) (unzip current_case_map features))
 
-		(if output_influential_cases
-			(accum (assoc influential_cases (get react_output "influential_cases") ))
-		)
-		(if output_cap
-			(accum (assoc local_class_probabilities_map (get react_output "categorical_action_probabilities") ))
+		; (if output_influential_cases
+		; 	(accum (assoc influential_cases (get react_output "influential_cases") ))
+		; )
+		; (if output_cap
+		; 	(accum (assoc local_class_probabilities_map (get react_output "categorical_action_probabilities") ))
+		; )
+		(if output_details
+			(assign (assoc
+				case_detail_values_map
+					(map
+						(lambda
+							(append (current_value) (get react_output (current_index)))
+						)
+						case_detail_values_map
+					)
+			))
 		)
 
 		(if (size derived_action_features)
@@ -1265,8 +1368,9 @@
 				(if derivation_failed
 					(assign (assoc
 						series_data (trunc series_data)
-						influential_cases (list)
-						local_class_probabilities_map (assoc)
+						; influential_cases (list)
+						; local_class_probabilities_map (assoc)
+						case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
 						done (true)
 					))
 				)
@@ -1325,8 +1429,9 @@
 											(assign (assoc
 												done (true)
 												series_data (trunc series_data)
-												influential_cases (list)
-												local_class_probabilities_map (assoc)
+												; influential_cases (list)
+												; local_class_probabilities_map (assoc)
+												case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
 											))
 
 											;else reset series_data and initial features and progress and index, to regenerate the series from the start
@@ -1341,8 +1446,9 @@
 														last_series_index (- num_existing_series_rows 1)
 														first_generated_row (true)
 														current_case_map (assoc)
-														influential_cases (list)
-														local_class_probabilities_map (assoc)
+														; influential_cases (list)
+														; local_class_probabilities_map (assoc)
+														case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
 													))
 
 													(assign (assoc
@@ -1351,8 +1457,9 @@
 														last_series_index -1
 														first_generated_row (true)
 														current_case_map (assoc)
-														influential_cases (list)
-														local_class_probabilities_map (assoc)
+														; influential_cases (list)
+														; local_class_probabilities_map (assoc)
+														case_detail_values_map (map (lambda (call GetDetailDataStructure (assoc detail (current_index 1) ))) (zip requested_details))
 													))
 												)
 											)

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -165,7 +165,10 @@
 						(map
 							(lambda
 								;map over each series output (current_value) and pull the current detail (current_index 1)
-								(map (lambda (get (current_value) (current_index 1))) series_output)
+								(let
+									(assoc detail (current_index 1))
+									(map (lambda (get (current_value) detail)) series_output)
+								)
 							)
 							(zip requested_details)
 						)
@@ -745,16 +748,11 @@
 					;store accumulated data into previous_result as an assoc
 					(append
 						(assoc "series_data" series_data)
-						(if output_details
-							(map
-								(lambda
-									(append (current_value) (list (get case_detail_values_map (current_index 1))) )
-								)
-								series_detail_values_map
+						(map
+							(lambda
+								(append (current_value) (list (get case_detail_values_map (current_index 1))) )
 							)
-
-							;else empty list
-							(assoc)
+							series_detail_values_map
 						)
 					)
 				)

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -362,7 +362,7 @@
 							(concat
 								"The following details are not officially supported for react series: "
 								(apply "concat" (map (lambda (concat (current_value) ",") ) invalid_ts_details) )
-								". Behavior is undefined."
+								". Behavior is experimental."
 							)
 						)
 				))

--- a/trainee_template/synthesis_utilities.amlg
+++ b/trainee_template/synthesis_utilities.amlg
@@ -105,7 +105,19 @@
 				)
 
 				;overwrite local_class_probabilities_map with the one that was actually used to select a value
-				(if output_cap (assign (assoc local_class_probabilities_map class_probabilities_map)) )
+				(if (and output_details (contains_index case_detail_values_map "categorical_action_probabilities"))
+					(assign (assoc
+						case_detail_values_map
+							(set
+								case_detail_values_map
+								"categorical_action_probabilities"
+								(append
+									(get case_detail_values_map "categorical_action_probabilities")
+									(associate feature class_probabilities_map)
+								)
+							)
+					))
+				)
 
 				(if (= (false) allow_nulls)
 					(seq


### PR DESCRIPTION
Generalizing the logic that organizes and returns the requested details in react_series flows. Ideally, this should make supporting more details for react_series easier moving forward.

I've also added a Trainee attribute that specifies the officially supported details for react_series. My changes here kind of open the flood gates to users trying any detail in react series, and it just may work. I think we should consider constraining the details that can be pushed through react_series, but for now I have it just giving a warning when a non-officially supported detail is requested.