### PR TITLE
19155: Adds checks for untrained features

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -948,6 +948,19 @@
 				new_case_threshold "min"
 			)
 
+			(let
+				(assoc
+					errors
+						(call_entity trainee "CheckForUntrainedFeatures" (assoc
+							context_features context_features
+							action_features action_features
+						))
+				)
+				(if (size errors)
+					(conclude (call !return (assoc errors errors)))
+				)
+			)
+
 			;if both action_features and derived_action_features are specified,
 			;ensure that derived_action_features are a subset of action_features, then separate the two into distinct lists
 			#!ValidateDerivedActionFeaturesIsSubset
@@ -1038,6 +1051,19 @@
 				substitute_output (true)
 				input_is_substituted (false)
 				new_case_threshold "min"
+			)
+
+			(let
+				(assoc
+					errors
+						(call_entity trainee "CheckForUntrainedFeatures" (assoc
+							context_features context_features
+							action_features action_features
+						))
+				)
+				(if (size errors)
+					(conclude (call !return (assoc errors errors)))
+				)
 			)
 
 			;determine number of reacts to batch
@@ -2057,6 +2083,19 @@
 				inverse_residuals_as_weights (null)
 			)
 
+			(let
+				(assoc
+					errors
+						(call_entity trainee "CheckForUntrainedFeatures" (assoc
+							context_features context_features
+							action_features action_features
+						))
+				)
+				(if (size errors)
+					(conclude (call !return (assoc errors errors)) )
+				)
+			)
+
 			(if use_case_weights
 				;CreateCaseWeights will find all cases missing weight_feature, then initialize
 				;weight_feature with a value of 1.0 for each
@@ -2319,6 +2358,19 @@
 				sample_model_fraction (null)
 				sub_model_size (null)
 				hyperparameter_param_path (null)
+			)
+
+			(let
+				(assoc
+					errors
+						(call_entity trainee "CheckForUntrainedFeatures" (assoc
+							context_features context_features
+							action_feature action_feature
+						))
+				)
+				(if (size errors)
+					(conclude (call !return (assoc errors errors)))
+				)
 			)
 
 			(declare (assoc invalid_parameters (false)))

--- a/howso.amlg
+++ b/howso.amlg
@@ -948,18 +948,7 @@
 				new_case_threshold "min"
 			)
 
-			(let
-				(assoc
-					errors
-						(call_entity trainee "CheckForUntrainedFeatures" (assoc
-							context_features context_features
-							action_features action_features
-						))
-				)
-				(if (size errors)
-					(conclude (call !return (assoc errors errors)))
-				)
-			)
+			(call !check_features)
 
 			;if both action_features and derived_action_features are specified,
 			;ensure that derived_action_features are a subset of action_features, then separate the two into distinct lists
@@ -1053,18 +1042,7 @@
 				new_case_threshold "min"
 			)
 
-			(let
-				(assoc
-					errors
-						(call_entity trainee "CheckForUntrainedFeatures" (assoc
-							context_features context_features
-							action_features action_features
-						))
-				)
-				(if (size errors)
-					(conclude (call !return (assoc errors errors)))
-				)
-			)
+			(call !check_features)
 
 			;determine number of reacts to batch
 			(declare (assoc
@@ -2083,18 +2061,7 @@
 				inverse_residuals_as_weights (null)
 			)
 
-			(let
-				(assoc
-					errors
-						(call_entity trainee "CheckForUntrainedFeatures" (assoc
-							context_features context_features
-							action_features action_features
-						))
-				)
-				(if (size errors)
-					(conclude (call !return (assoc errors errors)) )
-				)
-			)
+			(call !check_features)
 
 			(if use_case_weights
 				;CreateCaseWeights will find all cases missing weight_feature, then initialize
@@ -2360,18 +2327,7 @@
 				hyperparameter_param_path (null)
 			)
 
-			(let
-				(assoc
-					errors
-						(call_entity trainee "CheckForUntrainedFeatures" (assoc
-							context_features context_features
-							action_feature action_feature
-						))
-				)
-				(if (size errors)
-					(conclude (call !return (assoc errors errors)))
-				)
-			)
+			(call !check_features)
 
 			(declare (assoc invalid_parameters (false)))
 
@@ -3322,6 +3278,21 @@
 			)
 			(assign (assoc invalid_react_parameters (true)))
 		)
+
+	#!check_features
+	(let
+		(assoc
+			errors
+				(call_entity trainee "CheckForUntrainedFeatures" (assoc
+					context_features context_features
+					action_features action_features
+					action_feature action_feature
+				))
+		)
+		(if (size errors)
+			(conclude (call !return (assoc errors errors)) )
+		)
+	)
 
 
 	;Method to update a trainee by overwriting its data and running all version dependent migration scripts.

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -196,6 +196,7 @@
 		"synthesis_validation"
 		"train"
 		"update_cases"
+		"validation"
 	)
 
 	;load module entities code directly into trainee template only if modules have not been loaded

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -1,0 +1,53 @@
+;Module for trainee_template.
+;Contains helper methods for validating user-defined parameters
+(null
+
+    ;Verifies that feature parameters do not contain untrained features
+    ; this method checks context_features, action_features, and action feature
+    ; returns a list of strings, one for each invalid parameter
+    #CheckForUntrainedFeatures
+    (seq
+        (if (= errors (null))
+            (declare (assoc errors (list)))
+        )
+
+        (if (size context_features)
+            (let
+                (assoc invalid_features_map (remove (zip context_features) defaultFeatures))
+
+                (if (size invalid_features_map)
+                    (accum (assoc
+                        errors "context_features contains features that are not trained."
+                    ))
+                )
+            )
+        )
+
+        (if (size action_features)
+            (let
+                (assoc invalid_features_map (remove (zip action_features) defaultFeatures))
+
+                (if (size invalid_features_map)
+                    (accum (assoc
+                        errors "action_features contains features that are not trained."
+                    ))
+                )
+            )
+        )
+
+        (if (and (!= (null) action_feature) (!= ".targetless"))
+            (let
+                (assoc invalid_features_map (remove (zip (list action_feature)) defaultFeatures) )
+
+                (if (size invalid_features_map)
+                    (accum (assoc
+                        errors "action_feature is a feature that is not trained."
+                    ))
+                )
+            )
+        )
+
+        errors
+    )
+
+)

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -6,8 +6,8 @@
     ; this method checks context_features, action_features, and action feature
     ; returns a list of strings, one for each invalid parameter
     #CheckForUntrainedFeatures
-    (seq
-        (declare (assoc errors (list) ))
+    (declare
+        (assoc errors (list) )
 
         (if (size context_features)
             (if (size (remove (zip context_features) defaultFeatures))

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -7,29 +7,43 @@
     ; returns a list of strings, one for each invalid parameter
     #CheckForUntrainedFeatures
     (declare
-        (assoc errors (list) )
-
-        (if (size context_features)
-            (if (size (remove (zip context_features) defaultFeatures))
-                (accum (assoc
-                    errors "context_features contains features that are not trained."
-                ))
-            )
+        (assoc
+            errors (list)
+            context_features (list)
+            action_features (list)
+            action_feature (null)
         )
 
-        (if (size action_features)
-            (if (size (remove (zip action_features) defaultFeatures))
-                (accum (assoc
-                    errors "action_features contains features that are not trained."
-                ))
-            )
-        )
+        (declare (assoc all_features (append context_features action_features action_feature) ))
 
-        (if (and (!= (null) action_feature) (!= ".targetless"))
-            (if (size (remove (zip (list action_feature)) defaultFeatures))
-                (accum (assoc
-                    errors "action_feature is a feature that is not trained."
-                ))
+        (if (size all_features)
+            (if (size (remove (zip all_features) defaultFeatures))
+                ;if there is an untrained feature in all_features, check each parameter to give the correct
+                (seq
+                    (if (size context_features)
+                        (if (size (remove (zip context_features) defaultFeatures))
+                            (accum (assoc
+                                errors "context_features contains features that are not trained."
+                            ))
+                        )
+                    )
+
+                    (if (size action_features)
+                        (if (size (remove (zip action_features) defaultFeatures))
+                            (accum (assoc
+                                errors "action_features contains features that are not trained."
+                            ))
+                        )
+                    )
+
+                    (if (and (!= (null) action_feature) (!= ".targetless"))
+                        (if (not (contains_value defaultFeatures action_feature))
+                            (accum (assoc
+                                errors "action_feature is a feature that is not trained."
+                            ))
+                        )
+                    )
+                )
             )
         )
 

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -39,7 +39,7 @@
                     )
                 )
 
-                (if (and (!= (null) action_feature) (!= ".targetless"))
+                (if (and (!= (null) action_feature) (!= action_feature ".targetless"))
                     (if (not (contains_value defaultFeatures action_feature))
                         (accum (assoc
                             errors "action_feature is a feature that is not trained."

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -7,9 +7,7 @@
     ; returns a list of strings, one for each invalid parameter
     #CheckForUntrainedFeatures
     (seq
-        (if (= errors (null))
-            (declare (assoc errors (list)))
-        )
+        (declare (assoc errors (list) ))
 
         (if (size context_features)
             (if (size (remove (zip context_features) defaultFeatures))

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -14,34 +14,36 @@
             action_feature (null)
         )
 
-        (declare (assoc all_features (append context_features action_features action_feature) ))
-
-        (if (size all_features)
-            (if (size (remove (zip all_features) defaultFeatures))
-                ;if there is an untrained feature in all_features, check each parameter to give the correct
-                (seq
-                    (if (size context_features)
-                        (if (size (remove (zip context_features) defaultFeatures))
-                            (accum (assoc
-                                errors "context_features contains features that are not trained."
-                            ))
-                        )
+        (if
+            (size
+                (remove
+                    (zip (append context_features action_features action_feature))
+                    defaultFeatures
+                )
+            )
+            ;if there is an untrained feature in all_features, check each parameter to give the correct
+            (seq
+                (if (size context_features)
+                    (if (size (remove (zip context_features) defaultFeatures))
+                        (accum (assoc
+                            errors "context_features contains features that are not trained."
+                        ))
                     )
+                )
 
-                    (if (size action_features)
-                        (if (size (remove (zip action_features) defaultFeatures))
-                            (accum (assoc
-                                errors "action_features contains features that are not trained."
-                            ))
-                        )
+                (if (size action_features)
+                    (if (size (remove (zip action_features) defaultFeatures))
+                        (accum (assoc
+                            errors "action_features contains features that are not trained."
+                        ))
                     )
+                )
 
-                    (if (and (!= (null) action_feature) (!= ".targetless"))
-                        (if (not (contains_value defaultFeatures action_feature))
-                            (accum (assoc
-                                errors "action_feature is a feature that is not trained."
-                            ))
-                        )
+                (if (and (!= (null) action_feature) (!= ".targetless"))
+                    (if (not (contains_value defaultFeatures action_feature))
+                        (accum (assoc
+                            errors "action_feature is a feature that is not trained."
+                        ))
                     )
                 )
             )

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -12,38 +12,26 @@
         )
 
         (if (size context_features)
-            (let
-                (assoc invalid_features_map (remove (zip context_features) defaultFeatures))
-
-                (if (size invalid_features_map)
-                    (accum (assoc
-                        errors "context_features contains features that are not trained."
-                    ))
-                )
+            (if (size (remove (zip context_features) defaultFeatures))
+                (accum (assoc
+                    errors "context_features contains features that are not trained."
+                ))
             )
         )
 
         (if (size action_features)
-            (let
-                (assoc invalid_features_map (remove (zip action_features) defaultFeatures))
-
-                (if (size invalid_features_map)
-                    (accum (assoc
-                        errors "action_features contains features that are not trained."
-                    ))
-                )
+            (if (size (remove (zip action_features) defaultFeatures))
+                (accum (assoc
+                    errors "action_features contains features that are not trained."
+                ))
             )
         )
 
         (if (and (!= (null) action_feature) (!= ".targetless"))
-            (let
-                (assoc invalid_features_map (remove (zip (list action_feature)) defaultFeatures) )
-
-                (if (size invalid_features_map)
-                    (accum (assoc
-                        errors "action_feature is a feature that is not trained."
-                    ))
-                )
+            (if (size (remove (zip (list action_feature)) defaultFeatures))
+                (accum (assoc
+                    errors "action_feature is a feature that is not trained."
+                ))
             )
         )
 

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -243,6 +243,38 @@
 		obs (get result (list "warnings" 0 "detail"))
 	))
 
+	(call exit_if_failures (assoc msg "react_into_trainee warnings" ))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "analyze" (assoc
+				trainee "iris"
+				context_features (list "fake_feature1" "fake_feature2")
+				action_features (list "fake_feature3")
+			))
+	))
+
+	(call assert_same (assoc
+		exp 2
+		obs (size (get result "errors"))
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "batch_react" (assoc
+				trainee "iris"
+				context_features (list "fake_feature1" "fake_feature2")
+				action_features (list "fake_feature3")
+				desired_conviction 5
+				num_cases_to_generate 4
+			))
+	))
+
+	(call assert_same (assoc
+		exp 2
+		obs (size (get result "errors"))
+	))
+
 
 	(call exit_if_failures (assoc msg unit_test_name ))
 )

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -245,6 +245,7 @@
 
 	(call exit_if_failures (assoc msg "react_into_trainee warnings" ))
 
+	(print "Errors when specifying untrained features: ")
 	(assign (assoc
 		result
 			(call_entity "howso" "analyze" (assoc


### PR DESCRIPTION
Many methods returned '.nas' if called with parameters specifying features that do not exist in the Trainee. This PR adds checks to some of these methods that validate the context/action features parameters.

In the case an untrained feature is specified, the function returns early specifying an error that details the exact parameter containing the untrained feature.

I've chosen to add this method in a new Trainee module named 'validation'. This may seem premature, but I know we have future plans to add increased validation within howso-engine, so this doesn't seem inappropriate to me.