### PR TITLE
19243: Removes React features parameter validation

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -948,8 +948,6 @@
 				new_case_threshold "min"
 			)
 
-			(call !check_features)
-
 			;if both action_features and derived_action_features are specified,
 			;ensure that derived_action_features are a subset of action_features, then separate the two into distinct lists
 			#!ValidateDerivedActionFeaturesIsSubset
@@ -1041,8 +1039,6 @@
 				input_is_substituted (false)
 				new_case_threshold "min"
 			)
-
-			(call !check_features)
 
 			;determine number of reacts to batch
 			(declare (assoc
@@ -2061,7 +2057,7 @@
 				inverse_residuals_as_weights (null)
 			)
 
-			(call !check_features)
+			(call !validate_features)
 
 			(if use_case_weights
 				;CreateCaseWeights will find all cases missing weight_feature, then initialize
@@ -2326,8 +2322,6 @@
 				sub_model_size (null)
 				hyperparameter_param_path (null)
 			)
-
-			(call !check_features)
 
 			(declare (assoc invalid_parameters (false)))
 
@@ -3279,7 +3273,7 @@
 			(assign (assoc invalid_react_parameters (true)))
 		)
 
-	#!check_features
+	#!validate_features
 	(let
 		(assoc
 			errors

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -2,54 +2,54 @@
 ;Contains helper methods for validating user-defined parameters
 (null
 
-    ;Verifies that feature parameters do not contain untrained features
-    ; this method checks context_features, action_features, and action feature
-    ; returns a list of strings, one for each invalid parameter
-    #CheckForUntrainedFeatures
-    (declare
-        (assoc
-            errors (list)
-            context_features (list)
-            action_features (list)
-            action_feature (null)
-        )
+	;Verifies that feature parameters do not contain untrained features
+	; this method checks context_features, action_features, and action feature
+	; returns a list of strings, one for each invalid parameter
+	#CheckForUntrainedFeatures
+	(declare
+		(assoc
+			errors (list)
+			context_features (list)
+			action_features (list)
+			action_feature (null)
+		)
 
-        (if
-            (size
-                (remove
-                    (zip (append context_features action_features action_feature))
-                    defaultFeatures
-                )
-            )
-            ;if there is an untrained feature in all_features, check each parameter to give the correct
-            (seq
-                (if (size context_features)
-                    (if (size (remove (zip context_features) defaultFeatures))
-                        (accum (assoc
-                            errors "context_features contains features that are not trained."
-                        ))
-                    )
-                )
+		(if
+			(size
+				(remove
+					(zip (append context_features action_features action_feature))
+					defaultFeatures
+				)
+			)
+			;if there is an untrained feature in all_features, check each parameter to give the correct
+			(seq
+				(if (size context_features)
+					(if (size (remove (zip context_features) defaultFeatures))
+						(accum (assoc
+							errors "context_features contains features that are not trained."
+						))
+					)
+				)
 
-                (if (size action_features)
-                    (if (size (remove (zip action_features) defaultFeatures))
-                        (accum (assoc
-                            errors "action_features contains features that are not trained."
-                        ))
-                    )
-                )
+				(if (size action_features)
+					(if (size (remove (zip action_features) defaultFeatures))
+						(accum (assoc
+							errors "action_features contains features that are not trained."
+						))
+					)
+				)
 
-                (if (and (!= (null) action_feature) (!= action_feature ".targetless"))
-                    (if (not (contains_value defaultFeatures action_feature))
-                        (accum (assoc
-                            errors "action_feature is a feature that is not trained."
-                        ))
-                    )
-                )
-            )
-        )
+				(if (and (!= (null) action_feature) (!= action_feature ".targetless"))
+					(if (not (contains_value defaultFeatures action_feature))
+						(accum (assoc
+							errors "action_feature is a feature that is not trained."
+						))
+					)
+				)
+			)
+		)
 
-        errors
-    )
+		errors
+	)
 
 )

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -260,22 +260,5 @@
 		obs (size (get result "errors"))
 	))
 
-	(assign (assoc
-		result
-			(call_entity "howso" "batch_react" (assoc
-				trainee "iris"
-				context_features (list "fake_feature1" "fake_feature2")
-				action_features (list "fake_feature3")
-				desired_conviction 5
-				num_cases_to_generate 4
-			))
-	))
-
-	(call assert_same (assoc
-		exp 2
-		obs (size (get result "errors"))
-	))
-
-
 	(call exit_if_failures (assoc msg unit_test_name ))
 )


### PR DESCRIPTION
Temporarily removing features parameter validation on React. We plan to re-add it once we secure a better path for RL.

Also "sneaking" in some spaces=>tabs and a rename in this.