### PR TITLE
19268: Renames 'defaultFeatures' to 'trainedFeatures' and adds updates to feature attributes on Train

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ performance_tests/bank_gen.csv
 # Ignore MacOS Hidden File
 .DS_Store
 
-# scratch Amalgam scripts
-scratch*.amlg
+# scratch
+scratch*

--- a/howso.amlg
+++ b/howso.amlg
@@ -1287,7 +1287,7 @@
 					;include imputed features at the end
 					(assign (assoc
 						continue_series_features
-							(append (retrieve_from_entity trainee_clone "defaultFeatures") (retrieve_from_entity trainee_clone "internalLabelImputed"))
+							(append (retrieve_from_entity trainee_clone "trainedFeatures") (retrieve_from_entity trainee_clone "internalLabelImputed"))
 					))
 
 					(assign (assoc
@@ -1572,7 +1572,7 @@
 
 									(assign (assoc
 										continue_series_features
-											(append (retrieve_from_entity trainee_clone "defaultFeatures") imputed_list_feature)
+											(append (retrieve_from_entity trainee_clone "trainedFeatures") imputed_list_feature)
 									))
 
 									(assign (assoc
@@ -1977,7 +1977,7 @@
 			(if (= (null) saved_analyze_parameters_map)
 				(call analyze (assoc
 					trainee trainee
-					context_features (retrieve_from_entity trainee "defaultFeatures")
+					context_features (retrieve_from_entity trainee "trainedFeatures")
 					analyze_level 2
 				))
 

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -219,10 +219,10 @@
 "67.0.0"
 	(let
 		(assoc
-			default_features (retrieve_from_entity trainee "defaultFeatures")
-			hp_map (retrieve_from_entity trainee "hyperparameterMetadataMap")
-			residuals_map (retrieve_from_entity trainee "residualsMap")
-			prediction_stats_map (retrieve_from_entity trainee "featurePredictionStatsMap")
+			default_features (get import_metadata_map "defaultFeatures")
+			hp_map (get import_metadata_map "hyperparameterMetadataMap")
+			residuals_map (get import_metadata_map "residualsMap")
+			prediction_stats_map (get import_metadata_map "featurePredictionStatsMap")
 		)
 
 		(declare (assoc
@@ -315,14 +315,24 @@
 			featurePredictionStatsMap prediction_stats_map
 			defaultFeaturesContextKey default_features_key
 		))
+
+		;update the metadata map for later migrations
+		(accum (assoc
+			import_metadata_map
+				(assoc
+					"defaultFeaturesContextKey" default_features_key
+					"hyperparameterMetadataMap" hp_map
+					"hyperparameterParamPaths" hp_param_paths
+				)
+		))
 	)
 
 ;move null uncertainties from featureDomainAttributes into featureDeviations and add nullUncertainies to hyperparameters
 "71.1.1"
 	(let
 		(assoc
-			param_paths (retrieve_from_entity trainee "hyperparameterParamPaths")
-			hp_map (retrieve_from_entity trainee "hyperparameterMetadataMap")
+			param_paths (get import_metadata_map "hyperparameterParamPaths")
+			hp_map (get import_metadata_map "hyperparameterMetadataMap")
 		)
 
 		(map
@@ -397,7 +407,7 @@
 		)
 		(assign_to_entities trainee (assoc
 			trainedFeatures default_features
-			defaultFeaturesContextKey default_features_key
+			trainedFeaturesContextKey default_features_key
 		))
 	)
 ))

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -388,4 +388,16 @@
 
 		(assign_to_entities trainee (assoc hyperparameterMetadataMap hp_map ))
 	)
+;Rename defaultFeatures to trainedFeatures, also defaultFeaturesContextKey to trainedFeaturesContextKey
+"74.1.2"
+	(let
+		(assoc
+			default_features (get import_metadata_map "defaultFeatures")
+			default_features_key (get import_metadata_map "defaultFeaturesContextKey")
+		)
+		(assign_to_entities trainee (assoc
+			trainedFeatures default_features
+			defaultFeaturesContextKey default_features_key
+		))
+	)
 ))

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -47,8 +47,8 @@
 	#numericalPrecision (null)
 	#convictionLowerThreshold  (null)
 	#convictionUpperThreshold  (null)
-	#defaultFeatures (null)
-	#defaultFeaturesContextKey (null)
+	#trainedFeatures (null)
+	#trainedFeaturesContextKey (null)
 	#metaData (null)
 	#categoricalFeaturesSet (null)
 	#ordinalFeatures (null)
@@ -249,10 +249,10 @@
 			convictionUpperThreshold  (null)
 
 			;the default list of features for the model
-			defaultFeatures (list)
+			trainedFeatures (list)
 
-			;the context_key made from the defaultFeatures of the model
-			defaultFeaturesContextKey ""
+			;the context_key made from the trainedFeatures of the model
+			trainedFeaturesContextKey ""
 
 			;arbitrary model metadata
 			metaData (assoc)

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -248,7 +248,7 @@
 			convictionLowerThreshold  (null)
 			convictionUpperThreshold  (null)
 
-			;the default list of features for the model
+			;the default list of features for the model, derived as the sorted indices of featureAttributes
 			trainedFeatures (list)
 
 			;the context_key made from the trainedFeatures of the model

--- a/trainee_template/analysis.amlg
+++ b/trainee_template/analysis.amlg
@@ -63,10 +63,10 @@
 		(if (size imputed_cases_map)
 			(let
 				(assoc
-					;use all the unique context and action features for imputation, or defaultFeatures if none were provided
+					;use all the unique context and action features for imputation, or trainedFeatures if none were provided
 					analyze_features
 						(values
-							(append (if (= 0 (size context_features)) defaultFeatures context_features) action_features)
+							(append (if (= 0 (size context_features)) trainedFeatures context_features) action_features)
 							(true)
 						)
 				)
@@ -125,7 +125,7 @@
 					context_features
 						(if
 							(= 0 (size context_features))
-							defaultFeatures
+							trainedFeatures
 							context_features
 						)
 				))
@@ -257,8 +257,8 @@
 		;targeted_model will already have be set to 'targetless' if no features are passed in
 		(if (= 0 (size context_features))
 			(assign (assoc
-				context_features defaultFeatures
-				context_features_key defaultFeaturesContextKey
+				context_features trainedFeatures
+				context_features_key trainedFeaturesContextKey
 			))
 
 			;else build custom context feature key

--- a/trainee_template/analysis_feature_weights.amlg
+++ b/trainee_template/analysis_feature_weights.amlg
@@ -60,7 +60,7 @@
 			(accum (assoc iteration 1))
 
 			(if (= 1 iteration)
-				(if (= (sort defaultFeatures) (sort features))
+				(if (= (sort trainedFeatures) (sort features))
 					(accum (assoc baseline_hyperparameter_map (assoc "allFeatureResidualsCached" (true))))
 				)
 			)
@@ -375,7 +375,7 @@
 			(accum (assoc iteration 1))
 		)
 
-		(if (= (sort defaultFeatures) (sort features))
+		(if (= (sort trainedFeatures) (sort features))
 			(accum (assoc analyzed_hp_map (assoc "allFeatureResidualsCached" (true))))
 		)
 	)

--- a/trainee_template/attributes.amlg
+++ b/trainee_template/attributes.amlg
@@ -454,8 +454,11 @@
 		(assign_to_entities (assoc
 			featureAttributes features
 
-			trainedFeatures (sort (indices features))
-			trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (indices features)))
+			trainedFeatures (sort (values (append trainedFeatures (indices features)) (true)) )
+			trainedFeaturesContextKey
+				(call BuildContextFeaturesKey (assoc
+					context_features (values (append trainedFeatures (indices features)) (true))
+				))
 
 			hasEncodedFeatures has_encoded_features
 			hasStringOrdinals has_string_ordinals

--- a/trainee_template/attributes.amlg
+++ b/trainee_template/attributes.amlg
@@ -451,6 +451,16 @@
 
 		(declare (assoc query_distance_type_map (call ComposeDistanceTypeMap) ))
 
+		(let
+			(assoc
+				new_feature_set (remove (zip (indices features)) trainedFeatures)
+			)
+
+			(if (size new_feature_set)
+				(assign_to_entities (assoc trainedFeatures (append trainedFeatures (indices new_feature_set))))
+			)
+		)
+
 		(assign_to_entities (assoc
 			featureAttributes features
 
@@ -619,7 +629,7 @@
 	(seq
 		;if feature attributes is empty but there are feature definitions, manually populate featureAttributes
 		(if (and
-				(!= (null) defaultFeatures)
+				(!= (null) trainedFeatures)
 				(= (assoc) featureAttributes)
 			)
 			(assign_to_entities (assoc
@@ -688,7 +698,7 @@
 								)
 							)
 						))
-						(zip defaultFeatures)
+						(zip trainedFeatures)
 					)
 			))
 		)

--- a/trainee_template/attributes.amlg
+++ b/trainee_template/attributes.amlg
@@ -451,18 +451,11 @@
 
 		(declare (assoc query_distance_type_map (call ComposeDistanceTypeMap) ))
 
-		(let
-			(assoc
-				new_feature_set (remove (zip (indices features)) trainedFeatures)
-			)
-
-			(if (size new_feature_set)
-				(assign_to_entities (assoc trainedFeatures (append trainedFeatures (indices new_feature_set))))
-			)
-		)
-
 		(assign_to_entities (assoc
 			featureAttributes features
+
+			trainedFeatures (sort (indices features))
+			trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (indices features)))
 
 			hasEncodedFeatures has_encoded_features
 			hasStringOrdinals has_string_ordinals

--- a/trainee_template/conviction.amlg
+++ b/trainee_template/conviction.amlg
@@ -78,7 +78,7 @@
 		)
 
 		(if (= (null) features)
-			(assign (assoc features defaultFeatures))
+			(assign (assoc features trainedFeatures))
 		)
 
 		;if user doesn't want to use case weights, change weight_feature to '.none'

--- a/trainee_template/custom_codes.amlg
+++ b/trainee_template/custom_codes.amlg
@@ -393,7 +393,7 @@
 						)
 					)
 					(let
-						(assoc analyze_features defaultFeatures)
+						(assoc analyze_features trainedFeatures)
 
 						(if (= 0 autoAnalyzeThreshold)
 							(let
@@ -410,7 +410,7 @@
 									analyze_features
 										(filter
 											(lambda (contains_index currently_trained_features_map (current_value)) )
-											defaultFeatures
+											trainedFeatures
 										)
 								))
 

--- a/trainee_template/derive_utilities.amlg
+++ b/trainee_template/derive_utilities.amlg
@@ -509,7 +509,7 @@
 									(get featureAttributes (list (current_value 1) "derived_feature_code"))
 								)
 							)
-							defaultFeatures
+							trainedFeatures
 						)
 					)
 					derived_action_features
@@ -526,10 +526,10 @@
 						(not (contains_value derived_context_features (current_value)))
 						(not (contains_value derived_action_features (current_value)))
 						;whether .series_progress should be in derived_context_features is determined above
-						;prevent it from being re-added from defaultFeatures
+						;prevent it from being re-added from trainedFeatures
 						(!= ".series_progress" (current_value))
 					))
-					defaultFeatures
+					trainedFeatures
 				)
 		))
 

--- a/trainee_template/distances.amlg
+++ b/trainee_template/distances.amlg
@@ -204,7 +204,7 @@
 		)
 
 		(if (= (null) features)
-			(assign (assoc features defaultFeatures))
+			(assign (assoc features trainedFeatures))
 		)
 
 		;if user doesn't want to use case weights, change weight_feature to '.none'
@@ -391,7 +391,7 @@
 		)
 
 		(if (= (null) features)
-			(assign (assoc features defaultFeatures))
+			(assign (assoc features trainedFeatures))
 		)
 
 		;if user doesn't want to use case weights, change weight_feature to '.none'

--- a/trainee_template/editing.amlg
+++ b/trainee_template/editing.amlg
@@ -247,8 +247,8 @@
 				)
 
 				(assign_to_entities (assoc
-					defaultFeatures (filter (lambda (!= feature (current_value))) defaultFeatures)
-					defaultFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (filter (lambda (!= feature (current_value))) defaultFeatures) ))
+					trainedFeatures (filter (lambda (!= feature (current_value))) trainedFeatures)
+					trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (filter (lambda (!= feature (current_value))) trainedFeatures) ))
 					categoricalFeaturesSet (remove categoricalFeaturesSet feature)
 					cachedFeatureMinResidualMap (remove cachedFeatureMinResidualMap feature)
 					cachedFeatureHalfMinGapMap (remove cachedFeatureHalfMinGapMap feature)
@@ -421,17 +421,17 @@
 					hyperparameterMetadataMap (call UpdateHyperparametersWithNewFeature (assoc hp_map hyperparameterMetadataMap))
 					defaultHyperparameters (call UpdateHyperparametersWithNewFeature (assoc hp_map defaultHyperparameters))
 
-					defaultFeatures
-						(if (not (contains_value defaultFeatures feature))
-							(append defaultFeatures feature)
-							defaultFeatures
+					trainedFeatures
+						(if (not (contains_value trainedFeatures feature))
+							(append trainedFeatures feature)
+							trainedFeatures
 						)
-					defaultFeaturesContextKey
+					trainedFeaturesContextKey
 						(call BuildContextFeaturesKey (assoc
 							context_features
-								(if (not (contains_value defaultFeatures feature))
-									(append defaultFeatures feature)
-									defaultFeatures
+								(if (not (contains_value trainedFeatures feature))
+									(append trainedFeatures feature)
+									trainedFeatures
 								)
 						))
 				))

--- a/trainee_template/editing.amlg
+++ b/trainee_template/editing.amlg
@@ -423,7 +423,7 @@
 
 					trainedFeatures
 						(if (not (contains_value trainedFeatures feature))
-							(append trainedFeatures feature)
+							(sort (append trainedFeatures feature))
 							trainedFeatures
 						)
 					trainedFeaturesContextKey

--- a/trainee_template/feature_conviction.amlg
+++ b/trainee_template/feature_conviction.amlg
@@ -74,9 +74,9 @@
 			weight_feature ".case_weight"
 		)
 
-		;if features aren't specified, assume all defaultFeatures will need to have their mae calculated
+		;if features aren't specified, assume all trainedFeatures will need to have their mae calculated
 		(if (= 0 (size features))
-			(assign (assoc features defaultFeatures))
+			(assign (assoc features trainedFeatures))
 		)
 
 		(declare (assoc

--- a/trainee_template/feature_residuals.amlg
+++ b/trainee_template/feature_residuals.amlg
@@ -62,9 +62,9 @@
 				)
 		))
 
-		;if features aren't specified, assume all defaultFeatures will need to have their mae calculated
+		;if features aren't specified, assume all trainedFeatures will need to have their mae calculated
 		(if (= (null) features)
-			(assign (assoc features defaultFeatures))
+			(assign (assoc features trainedFeatures))
 		)
 
 		;if there are ordinals but the hyperparameter map doesn't have a featureOrdinalDeviations assoc, initialize it
@@ -81,7 +81,7 @@
 		)
 
 		;if calculating and storing or all features, set the allFeatureResidualsCached flag to true
-		(if (= (sort defaultFeatures) (sort features))
+		(if (= (sort trainedFeatures) (sort features))
 			(accum (assoc hyperparam_map (assoc "allFeatureResidualsCached" (true))))
 		)
 
@@ -105,7 +105,7 @@
 
 		;reset the flag if there are no residuals
 		(if (and
-				(= (sort defaultFeatures) (sort features))
+				(= (sort trainedFeatures) (sort features))
 				(= 0 (size (get output_map "residual_map")))
 			)
 			(accum (assoc hyperparam_map (assoc "allFeatureResidualsCached" (false))))
@@ -236,7 +236,7 @@
 	;returns an assoc containing feature residuals, feature ordinal residuals and the hyperparam_map used for computations
 	;
 	;parameters:
-	; features: optional list of all features used during computation. If not specified will use defaultFeatures.
+	; features: optional list of all features used during computation. If not specified will use trainedFeatures.
 	; target_residual_feature: optional feature for which to calculate the (MAE) residual. If not specified, will compute for all features.
 	; case_ids: optional list of case ids to compute residuals.
 	; focal_case: optional case id of case for which to compute residuals for  is to be ignored during computation

--- a/trainee_template/get_cases.amlg
+++ b/trainee_template/get_cases.amlg
@@ -108,13 +108,13 @@
 			precision "exact"
 		)
 
-		(if (and (= 0 (size features)) (> (size defaultFeatures) 0))
-			(assign (assoc features defaultFeatures))
+		(if (and (= 0 (size features)) (> (size trainedFeatures) 0))
+			(assign (assoc features trainedFeatures))
 		)
 
 		;if the features list is only 'imputed', pre-pend default fetaures to it if that list is defined
-		(if (and (= (size features) 1) (= internalLabelImputed (first features)) (> (size defaultFeatures) 0))
-			(assign (assoc features (append defaultFeatures features)))
+		(if (and (= (size features) 1) (= internalLabelImputed (first features)) (> (size trainedFeatures) 0))
+			(assign (assoc features (append trainedFeatures features)))
 		)
 
 		;map of accumulated session -> case index id map
@@ -506,7 +506,7 @@
 		)
 
 		(if (= (null) features)
-			(assign (assoc features defaultFeatures))
+			(assign (assoc features trainedFeatures))
 		)
 
 		(declare (assoc

--- a/trainee_template/hyperparameters.amlg
+++ b/trainee_template/hyperparameters.amlg
@@ -343,7 +343,7 @@
 							;else no weights, assign all active features weight 1
 							(assign (assoc
 								feature_weights_map
-									(append (zip (append defaultFeatures feature) 1) inactiveFeaturesMap)
+									(append (zip (append trainedFeatures feature) 1) inactiveFeaturesMap)
 							))
 						)
 
@@ -399,7 +399,7 @@
 		(declare (assoc
 			context_key
 				(if (or (= context_features (null)) (= context_features (list)))
-					defaultFeaturesContextKey
+					trainedFeaturesContextKey
 
 					;else context_features were passed
 					(call BuildContextFeaturesKey (assoc context_features context_features))

--- a/trainee_template/impute.amlg
+++ b/trainee_template/impute.amlg
@@ -29,7 +29,7 @@
 
 
 			(if (= (list) features)
-				(assign (assoc features defaultFeatures))
+				(assign (assoc features trainedFeatures))
 			)
 
 			(if (= (list) features_to_impute)

--- a/trainee_template/marginal.amlg
+++ b/trainee_template/marginal.amlg
@@ -801,7 +801,7 @@
 								entropy (if (!= .nan entropy) entropy)
 							)
 						))
-						(zip defaultFeatures)
+						(zip trainedFeatures)
 					)
 			))
 

--- a/trainee_template/prediction_stats.amlg
+++ b/trainee_template/prediction_stats.amlg
@@ -216,7 +216,7 @@
 								output_map
 							))
 						))
-						(zip defaultFeatures)
+						(zip trainedFeatures)
 					)
 				)
 		))
@@ -290,7 +290,7 @@
 					precision precision
 					num_cases num_cases
 				))
-			context_features (filter (lambda (!= action_feature (current_value))) defaultFeatures)
+			context_features (filter (lambda (!= action_feature (current_value))) trainedFeatures)
 			use_case_weights (!= (null) weight_feature)
 		))
 
@@ -519,7 +519,7 @@
 								output_map
 							))
 						))
-						(zip defaultFeatures)
+						(zip trainedFeatures)
 					)
 				)
 		))

--- a/trainee_template/react.amlg
+++ b/trainee_template/react.amlg
@@ -49,7 +49,7 @@
 		;if expected values haven't been cached (i.e., analyze was skipped), do that here
 		(if (= 0 (size expectedValuesMap))
 			(call CacheExpectedValuesAndProbabilities (assoc
-				features defaultFeatures
+				features trainedFeatures
 				weight_feature (if (not use_case_weights) ".none" weight_feature)
 				use_case_weights use_case_weights
 			))
@@ -371,7 +371,7 @@
 				)
 
 				(if (= 0 (size action_features))
-					(assign (assoc action_features (retrieve_from_entity trainee "defaultFeatures")))
+					(assign (assoc action_features (retrieve_from_entity trainee "trainedFeatures")))
 				)
 
 				;don't generate any features in the pre_generated_uniques_map by filtering them out of the action_features list

--- a/trainee_template/react_group.amlg
+++ b/trainee_template/react_group.amlg
@@ -105,9 +105,9 @@
 			)
 		)
 
-		;if features aren't specified, assume all defaultFeatures will need to have their mae calculated
+		;if features aren't specified, assume all trainedFeatures will need to have their mae calculated
 		(if (= 0 (size features))
-			(assign (assoc features defaultFeatures))
+			(assign (assoc features trainedFeatures))
 		)
 
 		;if features need to be encoded, overwrite the values in the new_cases list with the encoded values

--- a/trainee_template/react_into_trainee.amlg
+++ b/trainee_template/react_into_trainee.amlg
@@ -149,7 +149,7 @@
 		(if (= 0 (size context_features))
 			(assign (assoc
 				context_features
-					(filter (lambda (not (contains_index uniqueNominalsSet (current_value))) ) defaultFeatures)
+					(filter (lambda (not (contains_index uniqueNominalsSet (current_value))) ) trainedFeatures)
 			))
 		)
 

--- a/trainee_template/remove_cases.amlg
+++ b/trainee_template/remove_cases.amlg
@@ -152,7 +152,7 @@
 					feature_name distribute_weight_feature
 				))
 				(call DistributeCaseInfluenceWeights (assoc
-					features defaultFeatures
+					features trainedFeatures
 					case_ids cases
 					distribute_weight_feature distribute_weight_feature
 				))
@@ -256,14 +256,14 @@
 		;if there are cases that need to have features re-derived, do it here
 		(if re_derivation_series_case_ids
 			(call DeriveTrainFeatures (assoc
-				features defaultFeatures
+				features trainedFeatures
 				;keep and derive only those features that are not in the features list
 				derived_features (get tsModelFeaturesMap "ts_derived_features")
 				case_ids re_derivation_series_case_ids
 			))
 		)
 
-		(call !UpdateNullCounts (assoc features defaultFeatures))
+		(call !UpdateNullCounts (assoc features trainedFeatures))
 
 		(null)
 	)

--- a/trainee_template/residuals.amlg
+++ b/trainee_template/residuals.amlg
@@ -219,9 +219,9 @@
 			(assign (assoc valid_weight_feature (or hasPopulatedCaseWeight (!= weight_feature ".case_weight")) ))
 		)
 
-		;if features aren't specified, assume all defaultFeatures will need to have their mae calculated
+		;if features aren't specified, assume all trainedFeatures will need to have their mae calculated
 		(if (= (null) features)
-			(assign (assoc features defaultFeatures))
+			(assign (assoc features trainedFeatures))
 		)
 
 		;if for some reason expected values haven't been cached, do that here

--- a/trainee_template/synthesis.amlg
+++ b/trainee_template/synthesis.amlg
@@ -36,7 +36,7 @@
 		(assoc
 			context_features (list)
 			context_values (list)
-			action_features defaultFeatures
+			action_features trainedFeatures
 			use_regional_model_residuals (true)
 			desired_conviction 1
 			feature_bounds_map (assoc)
@@ -87,7 +87,7 @@
 		;if global residuals have have not been calculated yet, recalculate them. they are needed regardless of which residual mode is being used
 		(if (not (get hyperparam_map "allFeatureResidualsCached"))
 			(call CalculateAndStoreFeatureResiduals (assoc
-				features defaultFeatures
+				features trainedFeatures
 				num_samples 1000
 				;robust with respect to the set of contexts used (across the power set of contexts), should match hyperparam map robust mode
 				robust_residuals (!= 1 (size action_features))
@@ -104,7 +104,7 @@
 		;if for some reason expected values haven't been cached, do that here
 		(if (= 0 (size expectedValuesMap))
 			(call CacheExpectedValuesAndProbabilities (assoc
-				features defaultFeatures
+				features trainedFeatures
 				weight_feature weight_feature
 				use_case_weights use_case_weights
 			))

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -396,20 +396,40 @@
 					".trained_instance_count" trained_instance_count
 				))
 
-				;if any of the trained features are not defined in feature attributes, add them as continuous
+				;if any of the trained features are not defined in feature attributes, add them as continuous_numeric with default attributes
 				(let
-					(assoc new_features (remove (zip features) (indices featureAttributes)))
+					(assoc new_features (remove (zip features) trainedFeatures))
 
 					(if (size new_features)
 						(seq
 							(accum_to_entities (assoc
-								featureAttributes (map (lambda (assoc "type" "continuous")) new_features)
+								featureAttributes (map (lambda (assoc "type" "continuous" "bounds" (assoc "allow_null" (true)))) new_features)
+								queryDistanceTypeMap (map (lambda "continuous_numeric") new_features)
 							))
 							(assign_to_entities (assoc
 								trainedFeatures (indices featureAttributes)
 								trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (indices featureAttributes)))
 							))
 						)
+
+						;slow "proper" method
+						; (let
+						; 	(assoc
+						; 		feature_attributes
+						; 			(append
+						; 				(call GetFeatureAttributes)
+						; 				(map
+						; 					(lambda (assoc
+						; 						"type" "continuous"
+						; 						"bounds" (assoc "allow_null" (true))
+						; 					))
+						; 					new_features
+						; 				)
+						; 			)
+						; 	)
+
+						; 	(call SetFeatureAttributes (assoc features feature_attributes))
+						; )
 					)
 				)
 

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -403,7 +403,11 @@
 					(if (size new_features)
 						(seq
 							(accum_to_entities (assoc
-								featureAttributes (map (lambda (assoc "type" "continuous" "bounds" (assoc "allow_null" (true))) ) new_features)
+								featureAttributes
+									(map
+										(lambda (assoc "type" "continuous" "bounds" (assoc "allow_null" (true)) ))
+										new_features
+									)
 								queryDistanceTypeMap (map (lambda "continuous_numeric") new_features)
 							))
 							(assign_to_entities (assoc

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -396,18 +396,20 @@
 					".trained_instance_count" trained_instance_count
 				))
 
-				;removing all defaultFeatures from features should result in an empty assoc, if it's not empty that means
-				;we're training on features that aren't in defaultFeatures yet, append them in their specified order
-				(if (!= (assoc) (remove (zip features) defaultFeatures))
-					(seq
-						(accum_to_entities (assoc
-							defaultFeatures
-								(filter
-									(lambda (not (contains_value defaultFeatures (current_value))) )
-									(append features (indices derivedFeaturesSet))
-								)
-						))
-						(assign_to_entities (assoc defaultFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features defaultFeatures)) ))
+				;if any of the trained features are not defined in feature attributes, add them as continuous
+				(let
+					(assoc new_features (remove (zip features) (indices featureAttributes)))
+
+					(if (size new_features)
+						(seq
+							(accum_to_entities (assoc
+								featureAttributes (map (lambda (assoc "type" "continuous")) new_features)
+							))
+							(assign_to_entities (assoc
+								trainedFeatures (indices featureAttributes)
+								trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (indices featureAttributes)))
+							))
+						)
 					)
 				)
 
@@ -552,7 +554,7 @@
 								)
 							))
 							(if (= (assoc) inactiveFeaturesMap)
-								(zip defaultFeatures 0)
+								(zip trainedFeatures 0)
 								inactiveFeaturesMap
 							)
 						)
@@ -658,7 +660,7 @@
 
 										(let
 											;create a feature weights assoc
-											(assoc weights_map (append (zip defaultFeatures 1) features_weights_map) )
+											(assoc weights_map (append (zip trainedFeatures 1) features_weights_map) )
 
 											(append (current_value) (assoc "featureWeights" weights_map))
 										)

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -411,8 +411,11 @@
 								queryDistanceTypeMap (map (lambda "continuous_numeric") new_features)
 							))
 							(assign_to_entities (assoc
-								trainedFeatures (sort (indices featureAttributes))
-								trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (indices featureAttributes) ))
+								trainedFeatures (sort (values (append trainedFeatures (indices featureAttributes)) (true)) )
+								trainedFeaturesContextKey
+									(call BuildContextFeaturesKey (assoc
+										context_features (values (append trainedFeatures (indices featureAttributes)) (true))
+									))
 							))
 						)
 					)

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -411,7 +411,7 @@
 								queryDistanceTypeMap (map (lambda "continuous_numeric") new_features)
 							))
 							(assign_to_entities (assoc
-								trainedFeatures (indices featureAttributes)
+								trainedFeatures (sort (indices featureAttributes))
 								trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (indices featureAttributes) ))
 							))
 						)

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -403,33 +403,14 @@
 					(if (size new_features)
 						(seq
 							(accum_to_entities (assoc
-								featureAttributes (map (lambda (assoc "type" "continuous" "bounds" (assoc "allow_null" (true)))) new_features)
+								featureAttributes (map (lambda (assoc "type" "continuous" "bounds" (assoc "allow_null" (true))) ) new_features)
 								queryDistanceTypeMap (map (lambda "continuous_numeric") new_features)
 							))
 							(assign_to_entities (assoc
 								trainedFeatures (indices featureAttributes)
-								trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (indices featureAttributes)))
+								trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (indices featureAttributes) ))
 							))
 						)
-
-						;slow "proper" method
-						; (let
-						; 	(assoc
-						; 		feature_attributes
-						; 			(append
-						; 				(call GetFeatureAttributes)
-						; 				(map
-						; 					(lambda (assoc
-						; 						"type" "continuous"
-						; 						"bounds" (assoc "allow_null" (true))
-						; 					))
-						; 					new_features
-						; 				)
-						; 			)
-						; 	)
-
-						; 	(call SetFeatureAttributes (assoc features feature_attributes))
-						; )
 					)
 				)
 

--- a/trainee_template/update_cases.amlg
+++ b/trainee_template/update_cases.amlg
@@ -406,7 +406,7 @@
 	#AccumulateCaseInfluenceWeights
 	(declare
 		(assoc
-			features defaultFeatures
+			features trainedFeatures
 			cases (list)
 			accumulate_weight_feature ".case_weight"
 		)
@@ -490,7 +490,7 @@
 	#DistributeCaseInfluenceWeights
 	(declare
 		(assoc
-			features defaultFeatures
+			features trainedFeatures
 			case_ids (list)
 			distribute_weight_feature ".case_weight"
 		)

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -18,13 +18,13 @@
 			(size
 				(remove
 					(zip (append context_features action_features action_feature))
-					defaultFeatures
+					trainedFeatures
 				)
 			)
 			;if there is an untrained feature in all_features, check each parameter to give the correct
 			(seq
 				(if (size context_features)
-					(if (size (remove (zip context_features) defaultFeatures))
+					(if (size (remove (zip context_features) trainedFeatures))
 						(accum (assoc
 							errors "context_features contains features that are not trained."
 						))
@@ -32,7 +32,7 @@
 				)
 
 				(if (size action_features)
-					(if (size (remove (zip action_features) defaultFeatures))
+					(if (size (remove (zip action_features) trainedFeatures))
 						(accum (assoc
 							errors "action_features contains features that are not trained."
 						))
@@ -40,7 +40,7 @@
 				)
 
 				(if (and (!= (null) action_feature) (!= action_feature ".targetless"))
-					(if (not (contains_value defaultFeatures action_feature))
+					(if (not (contains_value trainedFeatures action_feature))
 						(accum (assoc
 							errors "action_feature is a feature that is not trained."
 						))

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -209,7 +209,7 @@
 
 	(print "test feature is added to default features: ")
 	(call assert_true (assoc
-		obs (contains_value (retrieve_from_entity (list "howso" "analyze") "defaultFeatures") "TEST")
+		obs (contains_value (retrieve_from_entity (list "howso" "analyze") "trainedFeatures") "TEST")
 	))
 
 	(declare (assoc
@@ -235,13 +235,11 @@
 
 	(print "Adding nominal feature updates existing query type map: ")
 	(call assert_same (assoc
-		obs (retrieve_from_entity (list "howso" "analyze") "queryDistanceTypeMap")
+		obs (keep (retrieve_from_entity (list "howso" "analyze") "queryDistanceTypeMap") (list "TEST" "TEST_NOM"))
 		exp
 			(assoc
 				"TEST" "continuous_numeric"
 				"TEST_NOM" "nominal_string"
-				"fruit" "nominal_string"
-				"size" "nominal_string"
 			)
 	))
 

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -30,6 +30,7 @@
 						"w" (assoc "type" "nominal"  )
 					)
 			))
+		features (list "x" "y" "z" "w")
 		bad_rows (list)
 	))
 

--- a/unit_tests/ut_h_edit_dist_features.amlg
+++ b/unit_tests/ut_h_edit_dist_features.amlg
@@ -66,7 +66,7 @@
 	(assign (assoc
 		result
 			(get
-				(call_entity "howso" "get_cases" (assoc case_indices (list (list "session1" 7))))
+				(call_entity "howso" "get_cases" (assoc case_indices (list (list "session1" 7)) features features))
 				(list "payload" "cases" 0)
 			)
 	))

--- a/unit_tests/ut_h_move_remove.amlg
+++ b/unit_tests/ut_h_move_remove.amlg
@@ -320,7 +320,7 @@
 	))
 
 	(assign (assoc
-		result (get (call_entity "howso" "get_cases" (assoc trainee "st_model4")) "payload")
+		result (get (call_entity "howso" "get_cases" (assoc trainee "st_model4" features features)) "payload")
 
 	))
 
@@ -332,7 +332,7 @@
 
 	(print "Only 'red' cases remain: ")
 	(call assert_true (assoc
-		obs (= "red" (get result (list "cases" 0 4)) (get result (list "cases" 1 4)))
+		obs (= "red" (get result (list "cases" 0 4)) (get result (list "cases" 1 4)) )
 	))
 
 	(call exit_if_failures (assoc msg "Copy trainee and move cases"))
@@ -362,13 +362,15 @@
 		session "ut_remove"
 	))
 
-	(assign (assoc result (call_entity "howso" "get_cases" (assoc trainee "st_model4f"))))
+	(assign (assoc result (call_entity "howso" "get_cases" (assoc trainee "st_model4f" features features))))
 	;count how many cases have the idx feature missing
 	(declare (assoc no_idx_cases 0))
 	(map
-		(lambda (if (= (null) (get (current_value) 0))
-			(accum (assoc no_idx_cases 1))
-		))
+		(lambda
+			(if (= (null) (get (current_value) 0) )
+				(accum (assoc no_idx_cases 1))
+			)
+		)
 		(get result (list "payload" "cases"))
 	)
 	(call assert_same (assoc exp 4 obs no_idx_cases ))
@@ -386,7 +388,7 @@
 		session "ut_add"
 	))
 
-	(assign (assoc result (call_entity "howso" "get_cases" (assoc trainee "st_model4f"))))
+	(assign (assoc result (call_entity "howso" "get_cases" (assoc trainee "st_model4f" features features))))
 	;count how many cases have the idx set to 12 and are yellow
 	;only 2 of the 4 yellow cases have a z=6, so those two should now have idx set to 12
 	(declare (assoc idx_cases 0))
@@ -394,8 +396,8 @@
 		(lambda (if
 				(and
 					(= 12 (get (current_value) 0))
-					(= "yellow" (get (current_value) 4)
-				))
+					(= "yellow" (get (current_value) 4))
+				)
 			(accum (assoc idx_cases 1))
 		))
 		(get result (list "payload" "cases"))
@@ -436,7 +438,7 @@
 			)
 	))
 
-	(call exit_if_failures (assoc msg unit_test_name ))
+	(call exit_if_failures (assoc msg "Edit history for case idx 12" ))
 
 
 ;VERIFY SESSION CONDITION FOR EDITING CASES:
@@ -491,7 +493,7 @@
 	))
 
 	;get all the cases in the model
-	(assign (assoc result (call_entity "howso" "get_cases" (assoc trainee "st_model4f" ))))
+	(assign (assoc result (call_entity "howso" "get_cases" (assoc trainee "st_model4f" features features ))))
 
 	;count how many cases have the x feature missing
 	(declare (assoc no_x_cases 0))
@@ -731,4 +733,6 @@
 	))
 
 	(call exit_if_failures (assoc msg "Removing cases with case_indices"))
+
+	(call exit_if_failures (assoc msg unit_test_name ))
 )

--- a/unit_tests/ut_h_params.amlg
+++ b/unit_tests/ut_h_params.amlg
@@ -148,7 +148,7 @@
 	))
 
 ;VERIFY RESET DEFAULTS
-	(print "Hypeparameters pre reset: ")
+	(print "Hyperparameters pre reset: ")
 	(assign (assoc result (call_entity "howso" "get_internal_parameters" (assoc trainee "clone"))))
 	;parameters should be same as st_model1 since clone was copied from it
 	(call assert_same (assoc
@@ -156,7 +156,7 @@
 		exp (assoc "k" 5 "p" 2 "dt" -1 "featureDomainAttributes" (assoc "action" 0) )
 	))
 
-	(print "Hypeparameters post reset: ")
+	(print "Hyperparameters post reset: ")
 	(call_entity "howso" "reset_parameter_defaults" (assoc trainee "clone"))
 	(assign (assoc result (call_entity "howso" "get_internal_parameters" (assoc trainee "clone"))))
 	(call assert_same (assoc

--- a/unit_tests/ut_h_rl.amlg
+++ b/unit_tests/ut_h_rl.amlg
@@ -161,7 +161,7 @@
 	))
 
 	(assign (assoc
-		result (get (call_entity "howso" "get_cases" (assoc session "session1")) "payload")
+		result (get (call_entity "howso" "get_cases" (assoc session "session1" features features)) "payload")
 	))
 
 	(print "trained 3 cases for a total of 13: ")
@@ -230,7 +230,7 @@
 	(call exit_if_failures (assoc msg "Training from series" ))
 
 	(assign (assoc
-		result (get (call_entity "howso" "get_cases" (assoc session "session2")) "payload")
+		result (get (call_entity "howso" "get_cases" (assoc session "session2" features features)) "payload")
 	))
 	(print "each trained case has its individual reward: ")
 	(call assert_true (assoc

--- a/unit_tests/ut_iris_generate_data.amlg
+++ b/unit_tests/ut_iris_generate_data.amlg
@@ -197,6 +197,7 @@
 						)
 					context_features (list "species" "petal_length" )
 					context_values (list "setosa" 4.4)
+					action_features (append context_features action_features)
 				))
 				"action_values"
 			)
@@ -240,6 +241,7 @@
 						(assoc
 							"sepal_length" (assoc "allowed" (list 4.85))
 						)
+					action_features (append context_features action_features )
 				))
 				"action_values"
 			)

--- a/unit_tests/ut_tt_train_react.amlg
+++ b/unit_tests/ut_tt_train_react.amlg
@@ -40,10 +40,10 @@
 	))
 
 	(print "default features: ")
-	(declare (assoc result (retrieve_from_entity "model1" "defaultFeatures")))
+	(declare (assoc result (retrieve_from_entity "model1" "trainedFeatures")))
 	(call assert_same (assoc
-		obs result
-		exp (list "A" "B" "C" "D" "E")
+		obs (zip result)
+		exp (zip (list "A" "B" "C" "D" "E"))
 	))
 	(call exit_if_failures (assoc msg "Train and model size"))
 


### PR DESCRIPTION
This PR does a few things:

- Renames 'defaultFeatures' to 'trainedFeatures'
- Adds logic to train that populates 'featureAttributes' when new features are trained (new features without attributes are assumed to be continuous)
- Adds logic that syncs 'trainedFeatures' to match the indices of 'featureAttributes'