### PR TITLE
19322: Fixes an issue where untrained features are not added to the list of inactive features

### DIFF
--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -555,6 +555,7 @@
 								(=
 									(contained_entities (list
 										(query_exists internalLabelSession)
+										(query_exists feature)
 										(query_not_equals feature (null))
 										(query_count)
 									))


### PR DESCRIPTION
Untrained features defined in feature attributes were not added to the inactiveFeatures map properly because the query to select said features assumed the features exist in all the cases.