### PR TITLE
19325: Fixes an issue where an untrained feature is specified as a context in a React with local case residual convictions requested.

### DIFF
--- a/trainee_template/explanation_residuals.amlg
+++ b/trainee_template/explanation_residuals.amlg
@@ -260,13 +260,7 @@
 							)
 						)
 				))
-				(assign (assoc
-					case_residuals_map
-						(filter
-							(lambda (!= .nan (current_value)))
-							case_residuals_map
-						)
-				))
+				(assign (assoc case_residuals_map (filter case_residuals_map) ))
 			)
 		)
 

--- a/trainee_template/explanation_residuals.amlg
+++ b/trainee_template/explanation_residuals.amlg
@@ -629,6 +629,23 @@
 					))
 				)
 
+				;replace .nan with 0 (as is done for inactive features), typically from untrained features
+				(if (contains_value local_convictions_map .nan)
+					(assign (assoc
+						local_convictions_map
+							(map
+								(lambda
+									(if (!= .nan (current_value))
+										(current_value)
+
+										0
+									)
+								)
+								local_convictions_map
+							)
+					))
+				)
+
 				(accum (assoc
 					output (assoc "local_case_feature_residual_convictions" (append local_convictions_map inactive_features_zeros_map) )
 				))

--- a/trainee_template/explanation_residuals.amlg
+++ b/trainee_template/explanation_residuals.amlg
@@ -245,6 +245,31 @@
 			local_null_conviction_ratios_map (null)
 		))
 
+		;if case_residuals_map contains any .nan's, add those features to the inactive_features_zeros_map
+		(if (contains_value case_residuals_map .nan)
+			(seq
+				(accum (assoc
+					inactive_features_zeros_map
+						(map
+							(lambda 0)
+
+							;map of the features to .nans
+							(filter
+								(lambda (= .nan (current_value)))
+								case_residuals_map
+							)
+						)
+				))
+				(assign (assoc
+					case_residuals_map
+						(filter
+							(lambda (!= .nan (current_value)))
+							case_residuals_map
+						)
+				))
+			)
+		)
+
 		;replace case residual nulls with computed values if nulls aren't allowed
 		(if (and (contains_value case_residuals (null)) (not allow_nulls) )
 			(let
@@ -625,23 +650,6 @@
 								)
 								local_convictions_map
 								local_null_conviction_ratios_map
-							)
-					))
-				)
-
-				;replace .nan with 0 (as is done for inactive features), typically from untrained features
-				(if (contains_value local_convictions_map .nan)
-					(assign (assoc
-						local_convictions_map
-							(map
-								(lambda
-									(if (!= .nan (current_value))
-										(current_value)
-
-										0
-									)
-								)
-								local_convictions_map
 							)
 					))
 				)


### PR DESCRIPTION
When calling React with local case feature residual convictions requested and an untrained feature as a context, ".nas" is returned. 

This occurs because the residual for an untrained feature is calculated to be .nan.  This adds a pass that checks the residuals for .nans and if there are any - they are treated as inactive features, receiving a 0 for conviction.