### PR TITLE
19335: Fixes an issue where residuals are computed and stored before enough cases are trained.

### DIFF
--- a/trainee_template/synthesis.amlg
+++ b/trainee_template/synthesis.amlg
@@ -84,8 +84,12 @@
 			constrained_features (null)
 		))
 
-		;if global residuals have have not been calculated yet, recalculate them. they are needed regardless of which residual mode is being used
-		(if (not (get hyperparam_map "allFeatureResidualsCached"))
+		;if global residuals have have not been calculated yet, recalculate them only if there are enough training cases
+		;they are needed regardless of which residual mode is being used
+		(if (and
+				(not (get hyperparam_map "allFeatureResidualsCached"))
+				(>= (call GetNumTrainingCases) 2)
+			)
 			(call CalculateAndStoreFeatureResiduals (assoc
 				features trainedFeatures
 				num_samples 1000


### PR DESCRIPTION
Our RL testing performance declined after recent changes because the list of known features was defined earlier. Knowing these features earlier opened up the gate to residuals being computed for these features before any cases were trained into the model.

The change here simply adds a check to ensure there are cases in the model before any residuals are calculated and stored into hyperparameters. This fixes the RL testing in my environment.