### PR TITLE
19253: Adds feature validation to reacts

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -948,6 +948,8 @@
 				new_case_threshold "min"
 			)
 
+			(call !validate_features)
+
 			;if both action_features and derived_action_features are specified,
 			;ensure that derived_action_features are a subset of action_features, then separate the two into distinct lists
 			#!ValidateDerivedActionFeaturesIsSubset
@@ -1039,6 +1041,8 @@
 				input_is_substituted (false)
 				new_case_threshold "min"
 			)
+
+			(call !validate_features)
 
 			;determine number of reacts to batch
 			(declare (assoc
@@ -1187,6 +1191,8 @@
 				substitute_output (true)
 				input_is_substituted (false)
 			)
+
+			(call !validate_features)
 
 			(declare (assoc invalid_react_parameters (null)))
 
@@ -1417,6 +1423,8 @@
 				substitute_output (true)
 				input_is_substituted (false)
 			)
+
+			(call !validate_features)
 
 			;determine number of reacts to batch
 			(declare (assoc
@@ -1981,30 +1989,9 @@
 					analyze_level 2
 				))
 
-				;else call analyze with stored parameters
-				(seq
-					;if analysis should recalculate residuals, clear them from cache so they'll be overwritten
-					(if (or
-							(> (get saved_analyze_parameters_map "analyze_level") 1)
-							(= (false) (get saved_analyze_parameters_map "bypass_calculate_feature_residuals"))
-						)
-						;iterate over hyperparameter_map and clear out weights and deviations for all
-						(call_entity trainee "UpdateHyperparameterMapFeatureParameter" (assoc
-							targeted_model "all"
-							attribute_map
-								(assoc
-									"featureWeights" (null)
-									"featureDeviations" (null)
-									"allFeatureResidualsCached" (false)
-								)
-							use_case_weights (= (true) (get saved_analyze_parameters_map "use_case_weights"))
-							weight_feature (get saved_analyze_parameters_map "weight_feature")
-						))
-					)
-					(call analyze (append
-						saved_analyze_parameters_map (assoc "trainee" trainee)
-					))
-				)
+				(call analyze (append
+					saved_analyze_parameters_map (assoc "trainee" trainee)
+				))
 			)
 		)
 

--- a/trainee_template.amlg
+++ b/trainee_template.amlg
@@ -49,6 +49,7 @@
 	#convictionUpperThreshold  (null)
 	#trainedFeatures (null)
 	#trainedFeaturesContextKey (null)
+	#reactIntoFeaturesList (null)
 	#metaData (null)
 	#categoricalFeaturesSet (null)
 	#ordinalFeatures (null)
@@ -253,6 +254,9 @@
 
 			;the context_key made from the trainedFeatures of the model
 			trainedFeaturesContextKey ""
+
+			;the list of features computed and cached into cases through #ReactIntoFeatures
+			reactIntoFeaturesList (list)
 
 			;arbitrary model metadata
 			metaData (assoc)

--- a/trainee_template/conviction.amlg
+++ b/trainee_template/conviction.amlg
@@ -161,14 +161,20 @@
 				)
 
 				(if p_value_of_addition
-					(call StoreCaseValues (assoc
-						label_name p_value_of_addition
-						case_values_map
-							(map
-								(lambda (exp (- (current_value))) )
-								entropies_map
-							)
-					))
+					(seq
+						(call StoreCaseValues (assoc
+							label_name p_value_of_addition
+							case_values_map
+								(map
+									(lambda (exp (- (current_value))) )
+									entropies_map
+								)
+						))
+
+						(if (not (contains_value reactIntoFeaturesList p_value_of_addition))
+							(accum_to_entities (assoc reactIntoFeaturesList p_value_of_addition))
+						)
+					)
 				)
 
 				(if familiarity_conviction_addition
@@ -191,6 +197,10 @@
 									(map (lambda (/ avg_entropy (current_value))) entropies_map)
 								)
 						))
+
+						(if (not (contains_value reactIntoFeaturesList familiarity_conviction_addition))
+							(accum_to_entities (assoc reactIntoFeaturesList familiarity_conviction_addition))
+						)
 					)
 				)
 			)
@@ -223,14 +233,20 @@
 				)
 
 				(if p_value_of_removal
-					(call StoreCaseValues (assoc
-						label_name p_value_of_removal
-						case_values_map
-							(map
-								(lambda (exp (- (current_value))) )
-								entropies_map
-							)
-					))
+					(seq
+						(call StoreCaseValues (assoc
+							label_name p_value_of_removal
+							case_values_map
+								(map
+									(lambda (exp (- (current_value))) )
+									entropies_map
+								)
+						))
+
+						(if (not (contains_value reactIntoFeaturesList p_value_of_removal))
+							(accum_to_entities (assoc reactIntoFeaturesList p_value_of_removal))
+						)
+					)
 				)
 
 				(if familiarity_conviction_removal
@@ -247,6 +263,10 @@
 									(map (lambda (/ avg_entropy (current_value))) entropies_map)
 								)
 						))
+
+						(if (not (contains_value reactIntoFeaturesList familiarity_conviction_removal))
+							(accum_to_entities (assoc reactIntoFeaturesList familiarity_conviction_removal))
+						)
 					)
 				)
 			)
@@ -280,6 +300,10 @@
 					label_name distance_contribution
 					case_values_map case_to_dc_map
 				))
+
+				(if (not (contains_value reactIntoFeaturesList distance_contribution))
+					(accum_to_entities (assoc reactIntoFeaturesList distance_contribution))
+				)
 
 				;if computing for the whole model, update the calculated average distance contribution
 				(if (= (null) case_ids)
@@ -320,14 +344,24 @@
 					label_name similarity_conviction
 					case_values_map similarity_convictions_map
 				))
+
+				(if (not (contains_value reactIntoFeaturesList similarity_conviction))
+					(accum_to_entities (assoc reactIntoFeaturesList similarity_conviction))
+				)
 			)
 		)
 
 		(if influence_weight_entropy
-			(call ComputeAndStoreInfluenceWeightEntropies (assoc
-				context_features features
-				label_name influence_weight_entropy
-			))
+			(seq
+				(call ComputeAndStoreInfluenceWeightEntropies (assoc
+					context_features features
+					label_name influence_weight_entropy
+				))
+
+				(if (not (contains_value reactIntoFeaturesList influence_weight_entropy))
+					(accum_to_entities (assoc reactIntoFeaturesList influence_weight_entropy))
+				)
+			)
 		)
 
 		(accum_to_entities (assoc revision 1))

--- a/trainee_template/editing.amlg
+++ b/trainee_template/editing.amlg
@@ -237,6 +237,7 @@
 				(assign_to_entities (assoc
 					trainedFeatures (filter (lambda (!= feature (current_value))) trainedFeatures)
 					trainedFeaturesContextKey (call BuildContextFeaturesKey (assoc context_features (filter (lambda (!= feature (current_value))) trainedFeatures) ))
+					reactIntoFeaturesList (filter (lambda (!= feature (current_value))) reactIntoFeaturesList)
 					categoricalFeaturesSet (remove categoricalFeaturesSet feature)
 					cachedFeatureMinResidualMap (remove cachedFeatureMinResidualMap feature)
 					cachedFeatureHalfMinGapMap (remove cachedFeatureHalfMinGapMap feature)

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -12,19 +12,22 @@
 			context_features (list)
 			action_features (list)
 			action_feature (null)
+
+			;not a parameter
+			valid_features (append trainedFeatures reactIntoFeaturesList)
 		)
 
 		(if
 			(size
 				(remove
 					(zip (append context_features action_features action_feature))
-					trainedFeatures
+					valid_features
 				)
 			)
-			;if there is an untrained feature in all_features, check each parameter to give the correct
+			;if there is an untrained feature in the any specified features, check each parameter to give the correct
 			(seq
 				(if (size context_features)
-					(if (size (remove (zip context_features) trainedFeatures))
+					(if (size (remove (zip context_features) valid_features))
 						(accum (assoc
 							errors "context_features contains features that are not trained."
 						))
@@ -32,7 +35,7 @@
 				)
 
 				(if (size action_features)
-					(if (size (remove (zip action_features) trainedFeatures))
+					(if (size (remove (zip action_features) valid_features))
 						(accum (assoc
 							errors "action_features contains features that are not trained."
 						))
@@ -40,7 +43,7 @@
 				)
 
 				(if (and (!= (null) action_feature) (!= action_feature ".targetless"))
-					(if (not (contains_value trainedFeatures action_feature))
+					(if (not (contains_value valid_features action_feature))
 						(accum (assoc
 							errors "action_feature is a feature that is not trained."
 						))

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -476,7 +476,7 @@
 				(call_entity "howso" "batch_react_series" (assoc
 					trainee "model"
 					num_series_to_generate num_series
-					action_features (list "ID" ".date_delta_1" ".f1_rate_1" ".f3_rate_1" ".f2_rate_1" ".f2_rate_2" ".date_start" ".date_end" "f1" "f2" "f3" "date" )
+					action_features (list "ID" ".date_delta_1" ".f1_rate_1" ".f3_rate_1" ".f2_rate_1" ".f2_rate_2" "f1" "f2" "f3" "date" )
 					init_time_steps (list "2010-01-31")
 					final_time_steps (list "2019-08-31")
 					desired_conviction 5
@@ -512,8 +512,6 @@
 				".f3_rate_1"
 				".f2_rate_1"
 				".f2_rate_2"
-				".date_start"
-				".date_end"
 				"f1"
 				"f2"
 				"f3"

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -260,5 +260,74 @@
 		obs (size (get result "errors"))
 	))
 
+	(assign (assoc
+		result
+			(call_entity "howso" "react" (assoc
+				trainee "iris"
+				action_features (list "fake_feature3")
+				desired_conviction 5.0
+			))
+	))
+
+	(call assert_same (assoc
+		exp 1
+		obs (size (get result "errors"))
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "batch_react" (assoc
+				trainee "iris"
+				action_features (list "fake_feature3")
+				desired_conviction 5.0
+				num_cases_to_generate 20
+			))
+	))
+
+	(call assert_same (assoc
+		exp 1
+		obs (size (get result "errors"))
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "batch_react" (assoc
+				trainee "iris"
+				action_features (list "familiarity_conviction_addition")
+				desired_conviction 5.0
+				num_cases_to_generate 5
+			))
+	))
+
+	(call assert_same (assoc
+		exp 0
+		obs (size (get result "errors"))
+	))
+
+	(call assert_same (assoc
+		exp 5
+		obs (size (get result (list "payload" "action_values")))
+	))
+
+	(call_entity "howso" "remove_feature" (assoc
+		trainee "iris"
+		feature "familiarity_conviction_addition"
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "batch_react" (assoc
+				trainee "iris"
+				action_features (list "familiarity_conviction_addition")
+				desired_conviction 5.0
+				num_cases_to_generate 5
+			))
+	))
+
+	(call assert_same (assoc
+		exp 1
+		obs (size (get result "errors"))
+	))
+
 	(call exit_if_failures (assoc msg unit_test_name ))
 )


### PR DESCRIPTION
Adding calls to `!validate_features` for the react/react_series endpoints.
To still allow users to reference features stored by ReactIntoFeatures, I propose adding new Trainee attribute: `reactIntoFeaturesList` which stores the list of features stored by ReactIntoFeatures.

This list is used within !validate_features and accumulated within ReactIntoFeatures.

I also remove a call to an old undefined method within `auto_analyze`.