### PR TITLE
19213: Streamline performance for train when no ablation is necessary

### DIFF
--- a/trainee_template/ablation.amlg
+++ b/trainee_template/ablation.amlg
@@ -89,7 +89,7 @@
 
 	;initialize parameters and internal features related to auto ablation
 	; weight_feature: optional, default '.case_weight'. name of feature whose values to use as case weights
-	#InitializeautoAblation
+	#InitializeAutoAblation
 	(declare
 		(assoc weight_feature autoAblationWeightFeature)
 

--- a/trainee_template/ablation.amlg
+++ b/trainee_template/ablation.amlg
@@ -22,7 +22,7 @@
         (if (not use_case_weights)
             (assign (assoc weight_feature ".none"))
         )
-        
+
         (assign (assoc
             react_kwargs
                 (assoc
@@ -32,8 +32,8 @@
                     details (assoc influential_cases (true) )
                 )
         ))
-        
-        (if 
+
+        (if
             ;if context_values are not null, we are reacting to a new case
             (!= context_values (null))
 
@@ -48,7 +48,6 @@
 		)
 
 		;compute the entropy of the influence weights as retrieved by react
-		; TODO - 19101: streamline this code to directly use the query engine
 		(entropy (map
 			(lambda (get (current_value) ".influence_weight") )
 			(get (call React react_kwargs) "influential_cases")
@@ -59,7 +58,7 @@
 	; context_features: list of context features to use when determining influential cases.
 	; label_name: optional name of the feature to store influence weight entropies in.
 	#ComputeAndStoreInfluenceWeightEntropies
-	(let 
+	(let
 		(assoc
 			influence_weight_entropy_map
 				||(map
@@ -93,7 +92,7 @@
 	#InitializeautoAblation
 	(declare
 		(assoc weight_feature autoAblationWeightFeature)
-		
+
 		(assign_to_entities (assoc hasPopulatedCaseWeight (true)) )
 		(accum_to_entities (assoc revision 1) )
 		(call CreateCaseWeights (assoc feature_name weight_feature) )
@@ -103,6 +102,7 @@
 	; a return value of 1 indicates that a case should be kept and a return value of 0 indicates that the case should be ablated.
 	; context_values: list of context values to react to
 	; context_features: list of context features to react to
+	; num_cases: number of current cases in the model
 	#ShouldNewCaseBeAblated
 	(declare
 		(assoc
@@ -114,14 +114,15 @@
 		)
 
 		;If we do not have influence weight entropies stored, ablation cannot happen.
-		; So, always return 1 when that is the case.  The same is true for when there
+		; So, always return true when that is the case.  The same is true for when there
 		; are not enough cases in the model.
 		(if
-			(or 
+			(or
 				(not (and hasInfluenceWeightEntropies autoAblationEnabled) )
-				(< (call GetNumTrainingCases) autoAblationMinModelSize )
+				(< num_cases autoAblationMinModelSize )
 			)
-			(conclude 1)
+			;return true, keep case / do not ablate
+			(conclude (true))
 		)
 
 		(assign (assoc
@@ -139,7 +140,7 @@
 						context_values context_values
 						context_features context_features
 					))
-					
+
 				)
 				; This is probably unnecessary but in case we cannot compute the requested influence weight
 				; quantile return 1 as well.
@@ -148,22 +149,43 @@
 		)
 	)
 
-	#CaseOutsideThresholds
-	(let
-		(assoc
-			action_features
-				(filter
-					(lambda (or 
-						(contains_value autoAblationExactPredictionFeatures (current_value))
-						(contains_index autoAblationTolerancePredictionThresholdMap (current_value))
-						(contains_index autoAblationRelativePredictionThresholdMap (current_value))
-						(contains_value autoAblationResidualPredictionFeatures (current_value))
-					))
-					features
-				)
-			feature_value_map (zip features feature_values)
+	;Helper method called by Train to see if ablation can be skipped altogether
+	;outputs true if ablation can be skipped
+	;parameters:
+	; input_cases: list of cases from train method
+	; num_cases: number of currently trained cases in the model
+	#!CanTrainAblationBeSkipped
+	(and
+		(or
+			(not (and hasInfluenceWeightEntropies autoAblationEnabled) )
+			(< num_cases autoAblationMinModelSize )
 		)
+		(= (null)
+			autoAblationExactPredictionFeatures
+			autoAblationTolerancePredictionThresholdMap
+			autoAblationRelativePredictionThresholdMap
+			autoAblationResidualPredictionFeatures
+			autoAblationConvictionLowerThreshold
+			autoAblationConvictionUpperThreshold
+		)
+		;keep any cases that are null or only have null values
+		;if there are zero 'null only' cases, can skip ablation since every case should be trained
+		(= 0
+			(size (filter
+				(lambda (or
+					(= (null) (current_value))
+					(apply "=" (append (current_value) (list (null))))
+				))
+				input_cases
+			))
+		)
+	)
 
+	;Helper method called by Train to check whether case values are within thresholds for training or if it should be ablated
+	;returns true if case should be kept / not ablated
+	;return false if case should be ablated
+	#CaseOutsideThresholds
+	(seq
 		(if
 			(= (null)
 				autoAblationExactPredictionFeatures
@@ -173,8 +195,23 @@
 				autoAblationConvictionLowerThreshold
 				autoAblationConvictionUpperThreshold
 			)
-			(conclude 1)
+			;return true, keep case / do not ablate
+			(conclude (true))
 		)
+
+		(declare (assoc
+			action_features
+				(filter
+					(lambda (or
+						(contains_value autoAblationExactPredictionFeatures (current_value))
+						(contains_index autoAblationTolerancePredictionThresholdMap (current_value))
+						(contains_index autoAblationRelativePredictionThresholdMap (current_value))
+						(contains_value autoAblationResidualPredictionFeatures (current_value))
+					))
+					features
+				)
+			feature_value_map (zip features feature_values)
+		))
 
 		(declare (assoc
 			action_values (unzip feature_value_map action_features)
@@ -346,8 +383,8 @@
 						(= conviction_value 0)
 					)
 				)
-				;else
-				0
+				;else false, ablate case
+				(false)
 			)
 		)
 	)

--- a/trainee_template/ablation.amlg
+++ b/trainee_template/ablation.amlg
@@ -99,7 +99,7 @@
 	)
 
 	;determine whether a new case (one that is not in the Trainee) should be ablated (trained as weights) or kept.
-	; a return value of 1 indicates that a case should be kept and a return value of 0 indicates that the case should be ablated.
+	; a return value of true indicates that a case should be kept and a return value of false indicates that the case should be ablated.
 	; context_values: list of context values to react to
 	; context_features: list of context features to react to
 	; num_cases: number of current cases in the model

--- a/trainee_template/analysis.amlg
+++ b/trainee_template/analysis.amlg
@@ -123,7 +123,7 @@
 		(if
 			autoAblationEnabled
 			(seq
-				(call InitializeautoAblation)
+				(call InitializeAutoAblation)
 				(call ComputeAndStoreInfluenceWeightEntropies (assoc
 					context_features
 						(if

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -313,27 +313,44 @@
 		(declare (assoc
 			new_case_ids
 				(if skip_ablation
-					(map
-						(lambda (let
-							(assoc feature_values (current_value 1))
+					(let
+						(assoc
+							train_features
+								;if auto ablate is enabled, populate the weight feature for this case
+								(if autoAblationEnabled
+									(append features (list autoAblationWeightFeature))
+									features
+								)
+						)
+						(map
+							(lambda (let
+								(assoc
+									feature_values
+										;if auto ablate is enabled, default the weight to 1 for this case
+										(if autoAblationEnabled
+											(append (current_value 1) (list 1))
+											(current_value 1)
+										)
+								)
 
-							;create the case and output case id
-							(call CreateCase (assoc
-								features features
-								feature_values
-									(if encode_features_on_train
-										(call ConvertFromInput (assoc
-											feature_values feature_values
-											features features
-										))
-										;else use feature_values as-is
-										feature_values
-									)
-								session (get_value session)
-								session_training_index (+ trained_instance_count (current_index 1))
+								;create the case and output case id
+								(call CreateCase (assoc
+									features train_features
+									feature_values
+										(if encode_features_on_train
+											(call ConvertFromInput (assoc
+												feature_values feature_values
+												features train_features
+											))
+											;else use feature_values as-is
+											feature_values
+										)
+									session (get_value session)
+									session_training_index (+ trained_instance_count (current_index 1))
+								))
 							))
-						))
-						input_cases
+							input_cases
+						)
 					)
 
 					(weave

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -305,84 +305,116 @@
 			)
 		)
 
+		(declare (assoc num_cases (call GetNumTrainingCases) ))
+
+		(declare (assoc skip_ablation (call !CanTrainAblationBeSkipped) ))
+
 		;iterate over the input cases and create them, only returning case ids for cases that were able to be created
 		(declare (assoc
 			new_case_ids
-				(weave
-					(lambda (let
-						(assoc feature_values (first (current_value 1)))
+				(if skip_ablation
+					(map
+						(lambda (let
+							(assoc feature_values (current_value 1))
 
-						(if encode_features_on_train
-							(assign (assoc
+							;create the case and output case id
+							(call CreateCase (assoc
+								features features
 								feature_values
-									(call ConvertFromInput (assoc
-										feature_values feature_values
-										features features
-									))
+									(if encode_features_on_train
+										(call ConvertFromInput (assoc
+											feature_values feature_values
+											features features
+										))
+										;else use feature_values as-is
+										feature_values
+									)
+								session (get_value session)
+								session_training_index (+ trained_instance_count (current_index 1))
 							))
-						)
+						))
+						input_cases
+					)
 
-						;do not train on this case if it is null or all case values are null or it's within provided thresholds
-						(if (and
-								(!= (null) feature_values)
-								(not (apply "=" (append feature_values (list (null)))))
-								;no thresholds specified or the case is outside of thresholds
+					(weave
+						(lambda (let
+							(assoc feature_values (first (current_value 1)))
 
-								;if one of the ablation methods returns 0, then the case should be ablated.
-								(and
-									(call CaseOutsideThresholds)
-									(call ShouldNewCaseBeAblated (assoc
-										context_features features
-										context_values feature_values
-									))
-								)
-
-							)
-							(seq
-								;create the case and store case id
-								(declare (assoc
-									new_case_id
-										(call CreateCase (assoc
-											features
-												;if auto ablate is enabled, populate the weight feature for this case
-												(if
-													autoAblationEnabled
-													(append features (list autoAblationWeightFeature))
-													features
-												)
-											feature_values
-												;if auto ablate is enabled, populate the weight feature for this case
-												(if
-													autoAblationEnabled
-													(append feature_values (list 1))
-													feature_values
-												)
-											session (get_value session)
-											session_training_index trained_instance_count
+							(if encode_features_on_train
+								(assign (assoc
+									feature_values
+										(call ConvertFromInput (assoc
+											feature_values feature_values
+											features features
 										))
 								))
-								(accum (assoc trained_instance_count 1 ))
-
-								;output the new case id
-								(list new_case_id)
 							)
 
-							;else don't output anything, filtering out any null case ids
-							(seq
-								(accum (assoc ablated_indices_list (current_index 1)))
-								(list)
+							;do not train on this case if it is null or all case values are null or it's within provided thresholds
+							(if (and
+									(!= (null) feature_values)
+									(not (apply "=" (append feature_values (list (null)))))
+									;no thresholds specified or the case is outside of thresholds
+
+									;if one of the ablation methods returns false, then the case should be ablated.
+									(and
+										(call CaseOutsideThresholds)
+										(call ShouldNewCaseBeAblated (assoc
+											context_features features
+											context_values feature_values
+											num_cases num_cases
+										))
+									)
+								)
+								(seq
+									;create the case and store case id
+									(declare (assoc
+										new_case_id
+											(call CreateCase (assoc
+												features
+													;if auto ablate is enabled, populate the weight feature for this case
+													(if
+														autoAblationEnabled
+														(append features (list autoAblationWeightFeature))
+														features
+													)
+												feature_values
+													;if auto ablate is enabled, populate the weight feature for this case
+													(if
+														autoAblationEnabled
+														(append feature_values (list 1))
+														feature_values
+													)
+												session (get_value session)
+												session_training_index trained_instance_count
+											))
+									))
+									(accum (assoc trained_instance_count 1 ))
+
+									;output the new case id
+									(list new_case_id)
+								)
+
+								;else don't output anything, filtering out any null case ids
+								(seq
+									(accum (assoc ablated_indices_list (current_index 1)))
+									(list)
+								)
 							)
-						)
-					))
-					input_cases
-					;use weave as a map-filter by specifying null as the second list
-					(null)
+						))
+						input_cases
+						;use weave as a map-filter by specifying null as the second list
+						(null)
+					)
 				)
 		))
 
 		;set values if there were cases that were trained on
 		(if (> (size new_case_ids ) 0)
 			(seq
+				;if ablation awas skipped, trained_instance_count was never updated, update it here instead
+				(if skip_ablation (accum (assoc trained_instance_count (size new_case_ids))) )
+
 				;add action to the existing replay data
 				(assign_to_entities session (assoc
 					".replay_steps" (append cur_session_data new_case_ids)


### PR DESCRIPTION
Added a check prior to creating all the cases during train to see if the ablation logic can be skipped wholesale. 
If it can, the train loop only has to execute CreateCase's and no longer needs to check for ablation for every single case nor do an (accum) of case indices

also moved the logic to quick-out of the 'CaseOutsideThresholds' method before it has to do any logic when we do check ablation.

Result: I see about 20-40% improvement in train speed for normal (non-ablation) training.