### PR TITLE
19418: Improves error messages for feature parameter validation

### DIFF
--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -13,8 +13,9 @@
 			action_features (list)
 			action_feature (null)
 
-			;not a parameter
+			;not parameters
 			valid_features (append trainedFeatures reactIntoFeaturesList)
+			invalid_feature_set (assoc)
 		)
 
 		(if
@@ -27,25 +28,39 @@
 			;if there is an untrained feature in the any specified features, check each parameter to give the correct
 			(seq
 				(if (size context_features)
-					(if (size (remove (zip context_features) valid_features))
-						(accum (assoc
-							errors "context_features contains features that are not trained."
-						))
+					(seq
+						(assign (assoc invalid_feature_set (remove (zip context_features) valid_features) ))
+						(if (size invalid_feature_set)
+							(accum (assoc
+								errors
+									(concat
+										"context_features contains features that are not trained: "
+										(apply "concat" (trunc (weave (indices invalid_feature_set) ", ")))
+									)
+							))
+						)
 					)
 				)
 
 				(if (size action_features)
-					(if (size (remove (zip action_features) valid_features))
-						(accum (assoc
-							errors "action_features contains features that are not trained."
-						))
+					(seq
+						(assign (assoc invalid_feature_set (remove (zip action_features) valid_features) ))
+						(if (size invalid_feature_set)
+							(accum (assoc
+								errors
+									(concat
+										"action_features contains features that are not trained: "
+										(apply "concat" (trunc (weave (indices invalid_feature_set) ", ")))
+									)
+							))
+						)
 					)
 				)
 
 				(if (and (!= (null) action_feature) (!= action_feature ".targetless"))
 					(if (not (contains_value valid_features action_feature))
 						(accum (assoc
-							errors "action_feature is a feature that is not trained."
+							errors (concat "action_feature is a feature that is not trained: " action_feature)
 						))
 					)
 				)

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -25,7 +25,8 @@
 					valid_features
 				)
 			)
-			;if there is an untrained feature in the any specified features, check each parameter to give the correct
+			;if there is an untrained feature in the any specified features, check each parameter
+			;to give the correct error
 			(seq
 				(if (size context_features)
 					(seq

--- a/trainee_template/validation.amlg
+++ b/trainee_template/validation.amlg
@@ -34,7 +34,8 @@
 							(accum (assoc
 								errors
 									(concat
-										"context_features contains features that are not trained: "
+										"context_features contains features that are neither trained nor "
+										"defined in the feature attributes: "
 										(apply "concat" (trunc (weave (indices invalid_feature_set) ", ")))
 									)
 							))
@@ -49,7 +50,8 @@
 							(accum (assoc
 								errors
 									(concat
-										"action_features contains features that are not trained: "
+										"action_features contains features that are neither trained nor "
+										"defined in the feature attributes: "
 										(apply "concat" (trunc (weave (indices invalid_feature_set) ", ")))
 									)
 							))
@@ -60,7 +62,12 @@
 				(if (and (!= (null) action_feature) (!= action_feature ".targetless"))
 					(if (not (contains_value valid_features action_feature))
 						(accum (assoc
-							errors (concat "action_feature is a feature that is not trained: " action_feature)
+							errors
+								(concat
+									"action_feature is a feature that is neither trained nor "
+									"defined in the feature attributes: "
+									action_feature
+								)
 						))
 					)
 				)


### PR DESCRIPTION
Improves the error messages raised through !validate_features by listing the specific invalid feature names that were specified by the user.