### PR TITLE
19745: Fixes an issue when forecasting with 'max_series_lengths' and time-series features with deltas

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -1499,6 +1499,7 @@
 	;	   specifying ".series_progress" with a value between 0 and 1.0 corresponding to percent completion e.g., { ".series_progress" : .95 } -
 	;			stops series when it progresses at or beyond 95%.
 	; max_series_length: optional, maximum size a series is allowed to be.  Default is 3 * model_size, a 0 or less is no limit.
+	; 		If forecasting with 'continue_series', this defines the maximum length of the forecast.
 	; derived_context_features: list of context features whose values should be computed from the entire series in the specified order.
 	;		Must be different than context_features.
 	; derived_action_features: list of action features whose values should be computed from the resulting last row in series, in the specified

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -1242,6 +1242,12 @@
 			)
 		)
 
+		;increase the max_series_length by the amount of pre-pended data so the series ends
+		;after the correct maximum amount of rows is generated
+		(if (size series_data)
+			(accum (assoc max_series_length (size series_data) ))
+		)
+
 		;if end condition is not specified, generate progress based on where series is continuing from
 		(if (not (contains_index series_stop_map tsTimeFeature))
 			;if there are previous cases to continue from, generate a progress value given the values from the last case


### PR DESCRIPTION
Fixes an issue that arose when users with time-series features using deltas would call `react_series` with the `continue_series` flag and the `max_series_lengths` parameter specified.

In this situation, the returned series data was often of less rows than `max_series_lengths` would specify because the amount of rows pulled into the generation to account for lags in the series being continued counted towards the series length. This caused generation to terminate early and the amount of generated cases to typically be the max_series_length subtracted by the number of lags.

This change fixes the issue by increasing the internal maximum series length by the amount of rows brought in to begin the forecast.