### PR TITLE
19868: Fixes bug where react series final time step may not work for certain date time features

### DIFF
--- a/trainee_template/derive_utilities.amlg
+++ b/trainee_template/derive_utilities.amlg
@@ -479,6 +479,53 @@
 			))
 		)
 
+		;convert dates to epoch in series_stop_maps if necessary
+		(if (size series_stop_maps)
+			(assign (assoc
+				series_stop_maps
+					(map
+						(lambda
+							;for each feature in the stop map
+							(map
+								(lambda
+									(if (contains_index featureDateTimeMap (current_index))
+										(let
+											(assoc
+												stop_map (current_value 1)
+												stop_feature (current_index 1)
+											)
+											;iterate over the 'min' and 'max' keys in the stop_map
+											(map
+												(lambda
+													(if (contains_value (list "max" "min") (current_index))
+														;convert to epoch
+														(format
+															(current_value)
+															(get featureDateTimeMap (list stop_feature "date_time_format"))
+															"number"
+															(assoc "locale" (get featureDateTimeMap (list stop_feature "locale")))
+															(null)
+														)
+
+														(current_value)
+													)
+												)
+												stop_map
+											)
+										)
+
+										;else leave value as-is
+										(current_value)
+									)
+								)
+								(current_value)
+							)
+						)
+						series_stop_maps
+					)
+			))
+		)
+
 		(declare (assoc
 			series_id_features_set (zip (get tsModelFeaturesMap "series_id_features"))
 			all_contexts_set (zip all_contexts)

--- a/trainee_template/react_series.amlg
+++ b/trainee_template/react_series.amlg
@@ -737,14 +737,48 @@
 						)
 
 						(if (contains_index (current_value) "min")
-							(if (>= (get (current_value) "min") (get current_case_map (current_index)))
-								(assign (assoc done (true)))
+							(let
+								(assoc stop_value (get current_case_map (current_index 1)))
+
+								(if (contains_index featureDateTimeMap (current_index))
+									;convert stop_value to epoch
+									(assign (assoc
+										stop_value
+											(format
+												stop_value
+												(get featureDateTimeMap (list (current_index 2) "date_time_format"))
+												"number"
+												(assoc "locale" (get featureDateTimeMap (list (current_index 3) "locale")))
+												(null)
+											)
+									))
+								)
+								(if (>= (get (current_value) "min") stop_value)
+									(assign (assoc done (true)))
+								)
 							)
 						)
 
 						(if (contains_index (current_value) "max")
-							(if (<= (get (current_value) "max") (get current_case_map (current_index)))
-								(assign (assoc done (true)))
+							(let
+								(assoc stop_value (get current_case_map (current_index 1)))
+
+								(if (contains_index featureDateTimeMap (current_index))
+									;convert stop_value to epoch
+									(assign (assoc
+										stop_value
+											(format
+												stop_value
+												(get featureDateTimeMap (list (current_index 2) "date_time_format"))
+												"number"
+												(assoc "locale" (get featureDateTimeMap (list (current_index 3) "locale")))
+												(null)
+											)
+									))
+								)
+								(if (<= (get (current_value) "max") stop_value)
+									(assign (assoc done (true)))
+								)
 							)
 						)
 					))


### PR DESCRIPTION
if final time step was a datetime feature that has a non-numerically comparable datetime format, it would not be respected.
e.g., YYYY-MM-DD would be respected, but MM-DD-YYYY would not. 