### PR TITLE
19872: Fixes a bug when using auto-ablation and auto-analysis where automatic analyses would not use the case-weight feature

### DIFF
--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -599,8 +599,12 @@
 						(call Analyze (assoc
 							targeted_model "targetless"
 							context_features trainedFeatures
-							weight_feature ".none"
-							use_case_weights (false)
+							weight_feature
+								(if (and autoAblationEnabled autoAblationWeightFeature)
+									autoAblationWeightFeature
+									".none"
+								)
+							use_case_weights (and autoAblationEnabled autoAblationWeightFeature)
 							inverse_residuals_as_weights (true)
 							k_folds 1
 						))

--- a/trainee_template/train.amlg
+++ b/trainee_template/train.amlg
@@ -75,7 +75,7 @@
 			message (null)
 			ablated_indices_list (list)
 			cur_session_case_indices_map (retrieve_from_entity session ".indices_map")
-			warnings (list)
+			warnings (assoc)
 		))
 
 		;parameter and data checks
@@ -369,7 +369,7 @@
 			"num_trained" (size new_case_ids)
 			"ablated_indices" ablated_indices_list
 			"status" status_output
-			"warnings" warnings
+			"warnings" (if (size warnings) (indices warnings))
 		)
 	)
 
@@ -445,7 +445,7 @@
 		(if (and (!= (null) tsTimeFeature) skip_auto_analyze)
 			(accum (assoc
 				warnings
-					(list (concat
+					(associate (concat
 						"Using \"skip_auto_analyze\" when training time-series data may "
 						"result in less accurate modeling of the data as as statistics calculated "
 						"from the data used for inference will not take into account derived and "


### PR DESCRIPTION
Fixed the logic to analyze using the designated auto-ablation weight feature when automatically analyzing during Train and no analysis parameters are cached.

