### PR TITLE
19404: Improves reliability of release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,13 @@ jobs:
       version: ${{ inputs.version }}
       build-type: "release"
 
-  create-release:
+  generate-changelog:
+    secrets: inherit
     needs: ['build-test-package']
+    uses: "howsoai/.github/.github/workflows/release-notes.yml@main"
+
+  create-release:
+    needs: ['build-test-package', 'generate-changelog']
     runs-on: ubuntu-latest
     steps:
 
@@ -35,7 +40,7 @@ jobs:
         commit: ${{ github.sha }}
         name: "Howso Engine ${{ inputs.version }}"
         artifactErrorsFailBuild: true
-        generateReleaseNotes: true
+        body: ${{ needs.generate-changelog.outputs.changelog }}
         makeLatest: legacy
         artifacts: howso-engine-*/howso-engine-*.tar.gz
         artifactContentType: application/gzip


### PR DESCRIPTION
Fixes an intermittent issue where the release notes that appear in the body of GitHub releases include PR titles from older commits. We have ditched the 3rd party release notes generator we were using in favor of a new one + some proprietary code in our centralized workflow repository.