### PR TITLE
20088: Adds disallow_subtrainee_file_operations flag to initialize method, MINOR

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -156,6 +156,7 @@
 	#!influenceWeightThreshold (null)
 	#!regionalModelMinSize (null)
 	#!regionalModelMinPercent (null)
+	#!disallowSubtraineeFileOperations	(null)
 	#!revision 0
 	#!supportedPredictionStats (list "mae" "mda" "contribution" "confusion_matrix" "mda_permutation" "r2" "rmse" "spearman_coeff" "precision" "recall" "accuracy" "missing_value_accuracy" "mcc")
 	#!sandboxedComputeLimit (null)
@@ -253,6 +254,7 @@
 	;
 	; trainee_id: optional, unique id for this trainee
 	; filepath: optional, filepath location to where the howso file is stored
+	; disallow_subtrainee_file_operations: optional, flag. If true copy_subtrainee, load_subtrainee and save_subtrainee will ignore filepath parameter.
 	#initialize
 	(seq
 		;load specified modules' code into the trainee if they have not been loaded yet
@@ -270,6 +272,9 @@
 		#!InitializeValues
 		(assign_to_entities (assoc
 			!revision 0
+
+			;flag prevents user from specifying file-specific operations when calling subtrainee methods
+			!disallowSubtraineeFileOperations (= (true) disallow_subtrainee_file_operations)
 
 			;assoc of id of trainee -> name of trainee
 			!containedTraineeIdToNameMap (assoc)

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -236,6 +236,7 @@
 	; trainee_id: optional, unique id for trainee
 	#create_subtrainee
 	(seq
+		(call !ValidateFilepathParameter)
 		;create contained trainee inside the !traineeContainer
 		(assign (assoc trainee_path (append !traineeContainer trainee) ))
 
@@ -274,6 +275,7 @@
 	; separate_files: flag, default to false. if set to true will load each case from its individual file
 	#load_subtrainee
 	(seq
+		(call !ValidateFilepathParameter)
 		(declare (assoc trainee_path (append !traineeContainer trainee) ))
 
 		(declare (assoc
@@ -325,6 +327,7 @@
 	; separate_files: flag, default to false. if set to true will save each case as an individual file
 	#save_subtrainee
 	(seq
+		(call !ValidateFilepathParameter)
 		(declare (assoc trainee_path (append !traineeContainer trainee) ))
 
 		(if (= (null) trainee_id (call_entity trainee_path "get_trainee_id"))
@@ -937,6 +940,48 @@
 			contained_trainee_id_to_name_map (remove parent_contained_trainee_id_to_name_map child_id)
 			child_trainee_is_contained_map (remove parent_child_trainee_is_contained_map child_name)
 		))
+	)
+
+	;checks if the env variable HOWSO_ENGINE_LIMITED_FS is set to true (not case sensitive), ignore passed in 'filepath' parameter
+	#!ValidateFilepathParameter
+	(seq
+		(declare (assoc
+			env_vars
+				(last (system "system"
+					;pull all environment variables, 'set' in windows, 'env' in posix
+					(if (= "Windows" (system "os")) "set" "env" )
+				))
+			ignore_filepath_parameter (false)
+		))
+
+		;convert the one string that contains all the variables into a list of pairs of [env_var, value]
+		(assign (assoc
+			env_vars
+				(map
+					;split "var=value" by that first =
+					(lambda (split (current_value) "=" 1))
+					;split into individual env variable strings
+					(split env_vars "\n")
+				)
+		))
+
+		(map
+			(lambda
+				;if the env variable HOWSO_ENGINE_LIMITED_FS is set to true (not case sensitive), ignore filepath parameter
+				(if (and
+						(= "HOWSO_ENGINE_LIMITED_FS" (first (current_value)))
+						(contains_value (last (current_value)) "[tT][rR][uU][eE]" )
+					)
+					(conclude
+						(assign (assoc ignore_filepath_parameter (true) ))
+					)
+				)
+			)
+			env_vars
+		)
+
+		;explicitly overwrite filepath with the stored filepath
+		(if ignore_filepath_parameter (assign (assoc filepath (retrieve_from_entity "filepath"))) )
 	)
 
 )

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -942,43 +942,10 @@
 		))
 	)
 
-	;checks if the env variable HOWSO_ENGINE_LIMITED_FS is set to true (not case sensitive), ignore passed in 'filepath' parameter
+	;explicitly overwrite filepath with the stored filepath if subtrainee file operations aren't allowed
 	#!ValidateFilepathParameter
-	(seq
-		(declare (assoc
-			env_vars
-				(last (system "system"
-					;pull all environment variables, 'set' in windows, 'env' in posix
-					(if (= "Windows" (system "os")) "set" "env" )
-				))
-		))
-
-		;convert the one string that contains all the variables into a list of pairs of [env_var, value]
-		(assign (assoc
-			env_vars
-				(map
-					;split "var=value" by that first =
-					(lambda (split (current_value) "=" 1))
-					;split into individual env variable strings
-					(split env_vars "\n")
-				)
-		))
-
-		(map
-			(lambda
-				;if the env variable HOWSO_ENGINE_LIMITED_FS is set to true (not case sensitive), ignore filepath parameter
-				(if (and
-						(= "HOWSO_ENGINE_LIMITED_FS" (first (current_value)))
-						(contains_value (last (current_value)) "[tT][rR][uU][eE]" )
-					)
-					(conclude
-						;explicitly overwrite filepath with the stored filepath
-						(assign (assoc filepath (retrieve_from_entity "filepath") ))
-					)
-				)
-			)
-			env_vars
-		)
+	(if !disallowSubtraineeFileOperations
+		(assign (assoc filepath (retrieve_from_entity "filepath") ))
 	)
 
 )

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -951,7 +951,6 @@
 					;pull all environment variables, 'set' in windows, 'env' in posix
 					(if (= "Windows" (system "os")) "set" "env" )
 				))
-			ignore_filepath_parameter (false)
 		))
 
 		;convert the one string that contains all the variables into a list of pairs of [env_var, value]
@@ -973,15 +972,13 @@
 						(contains_value (last (current_value)) "[tT][rR][uU][eE]" )
 					)
 					(conclude
-						(assign (assoc ignore_filepath_parameter (true) ))
+						;explicitly overwrite filepath with the stored filepath
+						(assign (assoc filepath (retrieve_from_entity "filepath") ))
 					)
 				)
 			)
 			env_vars
 		)
-
-		;explicitly overwrite filepath with the stored filepath
-		(if ignore_filepath_parameter (assign (assoc filepath (retrieve_from_entity "filepath"))) )
 	)
 
 )

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -942,7 +942,7 @@
 		))
 	)
 
-	;explicitly overwrite filepath with the stored filepath if subtrainee file operations aren't allowed
+	;explicitly overwrite filepath parameter with the stored filepath if subtrainee file operations aren't allowed
 	#!ValidateFilepathParameter
 	(if !disallowSubtraineeFileOperations
 		(assign (assoc filepath (retrieve_from_entity "filepath") ))

--- a/unit_tests/unit_test_howso.amlg
+++ b/unit_tests/unit_test_howso.amlg
@@ -30,8 +30,7 @@
 	;TODO: pull path of test from argv, and auto-set howso path to be one directory up relative to the test
 
 	(load_entity "../howso.amlg" "howso" (false) (false))
-	(assign_to_entities "howso" (assoc filepath "../"))
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	;set root permission on howso engine so it has access to load and write files
 	(set_entity_root_permission "howso" 1)

--- a/unit_tests/ut_h_hierarchy_by_id.amlg
+++ b/unit_tests/ut_h_hierarchy_by_id.amlg
@@ -436,6 +436,33 @@
 			)
 	))
 
+
+	;create a trainee that disallows subtrainee file operations
+	(load_entity "../howso.amlg" "howso2" (false) (false))
+	(call_entity "howso2" "initialize" (assoc trainee_id "model2" filepath "./" disallow_subtrainee_file_operations (true)))
+	(set_entity_root_permission "howso2" 1)
+	(assign (assoc
+		result
+			(call_entity "howso2" "load_subtrainee" (assoc
+				trainee "load_test_trainee"
+				filename "deleteme"
+				filepath "/specified_filepath_should_be_ignored"
+			))
+	))
+	(print "Invalid filepath to subtrainee method is ignored because subtrainee file operations are disallowed: ")
+	(call assert_same (assoc
+		obs result
+		exp
+			(assoc
+				errors (null)
+				payload (assoc name (list ".trainee_container" "load_test_trainee") )
+				status "ok"
+				warnings (null)
+			)
+	))
+	(destroy_entities "howso2")
+
+
 	;cleanup saved test model
 	(if (= (system "os") "Windows")
 		(system "system" "del deleteme.*")
@@ -519,7 +546,6 @@
 	))
 
 	(call exit_if_failures (assoc msg "delete trainees." ))
-
 
 	(call exit_if_failures (assoc msg unit_test_name ))
 )


### PR DESCRIPTION
adds flag to initialize method, if set to true,  create_subtrainee, load_subtrainee and save_subtrainee filepath parameter will be ignored and the stored value will be used instead.