### PR TITLE
20129: Removes the "time_delta_format" feature attribute, MAJOR

### DIFF
--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -26,7 +26,6 @@
 						(assoc
 							date_time_format (get (last (current_value 1)) "date_time_format")
 							locale (get (last (current_value 1)) "locale")
-							time_delta_format (get (last (current_value 1)) "time_delta_format" )
 						)
 
 						(list
@@ -35,8 +34,6 @@
 								"date_time_format" (concat "date:" date_time_format)
 								;set default of en_US if locale is not specified
 								"locale" locale
-								;set default of secondns if time_delta_format is not specified
-								"time_delta_format" time_delta_format
 							)
 						)
 					)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -24,9 +24,6 @@
 	;
 	;	'locale': string, the date time format locale. If unspecified, uses platform default locale. Example: "en_US"
 	;
-	;	'time_delta_format: string, format of the delta for times, default is "seconds".
-	;						valid values are: milliseconds, seconds, minutes, hours, days, weeks, years
-	;
 	;	'significant_digits': number, round to the specified significant digits, default is no rounding
 	;
 	;	'decimal_places': number, decimal places to round to, default is no rounding. If "significant_digits"
@@ -655,7 +652,6 @@
 								cycle_length (get !cyclicFeaturesMap (current_index 1))
 								date_time_format (get !featureDateTimeMap (list (current_index 2) "date_time_format"))
 								locale (get !featureDateTimeMap (list (current_index 2) "locale"))
-								time_delta_format (get !featureDateTimeMap (list (current_index 2) "time_delta_format"))
 								observational_error (get !userSpecifiedFeatureErrorsMap (current_index 1))
 							)
 
@@ -690,11 +686,6 @@
 
 								(if (!= (null) locale)
 									(assoc "locale" locale )
-									(assoc)
-								)
-
-								(if (!= (null) time_delta_format)
-									(assoc "time_delta_format" time_delta_format )
 									(assoc)
 								)
 							)

--- a/unit_tests/ut_h_datetimeformat.amlg
+++ b/unit_tests/ut_h_datetimeformat.amlg
@@ -50,7 +50,6 @@
 						"type" "continuous"
 						"date_time_format" "%Y-%m-%d %A %H.%M.%S"
 						"locale" "es_ES"
-						"time_delta_format" "milliseconds"
 						"decimal_places" 0
 					)
 			)


### PR DESCRIPTION
This feature attribute is non-functional, so removing it from the documentation/API.