### PR TITLE
20154: Fixes an issue in interpolation when case weights are used

### DIFF
--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -521,7 +521,15 @@
 								(range (lambda 1) 1 (size perfect_match_indices) 1)
 							)
 					candidate_case_values (keep candidate_case_values perfect_match_indices)
-					total_weight (size perfect_match_indices)
+				))
+
+				(assign (assoc
+					total_weight
+						(if valid_weight_feature
+							(apply "+" candidate_case_weights)
+
+							(size perfect_match_indices)
+						)
 				))
 			)
 


### PR DESCRIPTION
In interpolation when using case weights, the divisor was not correctly the sum of each case's weights. Instead, it was dividing by the total number of cases, leading to an incorrect prediction (especially when the any of the case weights were extreme).