### PR TITLE
20155: Adds tests to verify case weights are reflected in prediction stats and residuals

### DIFF
--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -139,7 +139,13 @@
 							(get output_map "residual_map")
 							(assoc
 								".robust" (= (true) robust_residuals)
-								".hyperparam_path" param_path
+								".hyperparam_path"
+									(if (and use_case_weights (= param_path (list ".default")))
+										;intentionally storing which case weight feature is used for retrieval
+										(list ".default" (null) (null) weight_feature)
+
+										param_path
+									)
 							)
 						)
 					)
@@ -627,7 +633,7 @@
 			accuracy_map
 				(map
 					(lambda
-						(let 
+						(let
 							;grab the current action feature's confusion matrix
 							(assoc confusion_matrix (get confusion_matrix_map (current_index 1)))
 							(if (size confusion_matrix)
@@ -635,8 +641,8 @@
 									;correct predictions count
 									(apply "+" (values
 										;get correct prediction count for each class
-										(map 
-											(lambda (or (get (current_value) (current_index)))) 
+										(map
+											(lambda (or (get (current_value) (current_index))))
 											confusion_matrix
 										)
 									))
@@ -657,15 +663,15 @@
 		(assign (assoc
 			precision_map
 				(map
-					(lambda 
-						(let 
+					(lambda
+						(let
 							;grab the current action feature's confusion matrix
 							(assoc confusion_matrix (get confusion_matrix_map (current_index 1)))
 							(if (size confusion_matrix)
 								;for each row in confusion matrix, average out: correct / total of row
 								(/
-									(apply "+" 
-										(values (map 
+									(apply "+"
+										(values (map
 											(lambda (let
 												(assoc row_total (apply "+" (values (current_value 1))) )
 												;if there were no  predictions at all for this class, prevent divide by zero
@@ -693,7 +699,7 @@
 			recall_map
 				(map
 					(lambda
-						(let 
+						(let
 							;grab the current action feature's confusion matrix
 							(assoc confusion_matrix (get confusion_matrix_map (current_index 1)))
 							(if (size confusion_matrix)
@@ -740,12 +746,12 @@
 			mcc_map
 				(map
 					(lambda
-						(let 
+						(let
 							;grab the current action feature's confusion matrix
 							(assoc confusion_matrix (get confusion_matrix_map (current_index 1)))
 							(if (size confusion_matrix)
-								(let 
-									(assoc 
+								(let
+									(assoc
 										;get the total correctly predicted counts, variable c in the mcc formula
 										total_predicted_correct
 											(apply "+" (values
@@ -759,7 +765,7 @@
 										;get a list containing the true counts of each class, vector t in the mcc formula
 										true_counts
 											(append (values
-												(map 
+												(map
 													(lambda (apply "+" (filter (values (get confusion_matrix (current_index))))))
 													confusion_matrix
 												)
@@ -767,17 +773,17 @@
 										;get a list containing the predicted counts of each class, vector p in the mcc formula
 										predicted_counts
 											(append (values
-												(map 
-													(lambda 
+												(map
+													(lambda
 														(apply "+" (values (map
-															;current_index 1 is the predicted class that is being aggregated 
+															;current_index 1 is the predicted class that is being aggregated
 															(lambda (or (get (current_value) (current_index 1))) 0)
 															confusion_matrix
 														)))
 													)
 													confusion_matrix
 												)
-											)) 
+											))
 									)
 									;calculates the mcc
 									(/
@@ -800,7 +806,13 @@
 			prediction_stats
 				(assoc
 					".robust" (= (true) robust_residuals)
-					".hyperparam_path" param_path
+					".hyperparam_path"
+						(if (and use_case_weights (= param_path (list ".default")) )
+							;intentionally storing which case weight feature is used for retrieval
+							(list ".default" (null) (null) weight_feature)
+
+							param_path
+						)
 					"accuracy" accuracy_map
 					"precision" precision_map
 					"recall" recall_map

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -521,7 +521,15 @@
 								(range (lambda 1) 1 (size perfect_match_indices) 1)
 							)
 					candidate_case_values (keep candidate_case_values perfect_match_indices)
-					total_weight (size perfect_match_indices)
+				))
+
+				(assign (assoc
+					total_weight
+						(if valid_weight_feature
+							(apply "+" candidate_case_weights)
+
+							(size perfect_match_indices)
+						)
 				))
 			)
 

--- a/unit_tests/ut_h_weighted_residuals_cont.amlg
+++ b/unit_tests/ut_h_weighted_residuals_cont.amlg
@@ -72,6 +72,7 @@
             )
     ))
 
+    (print "MAE's are as expected: ")
     (call assert_approximate (assoc
         exp expected_residuals
         obs (map (lambda (get (current_value) "mae")) residuals)

--- a/unit_tests/ut_h_weighted_residuals_cont.amlg
+++ b/unit_tests/ut_h_weighted_residuals_cont.amlg
@@ -1,0 +1,86 @@
+(seq
+	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_weighted_residuals_cont.amlg"))
+
+	(declare (assoc
+		input_cases
+			(list
+				(list 0 0 1)
+				(list 0 0 1)
+                (list 0 0 1)
+                (list 1 0.01 100)
+
+                (list 10 10 1)
+                (list 10 10 1)
+                (list 10 10 1)
+                (list 10.01 30 100)
+			)
+		features (list "A" "B" "case_weight")
+	))
+
+    ;206 total case weight
+    ;6/206 case weight will have 0 residuals for both features
+    ;100/206 case weight will have residual=1.0 for A, residual=0.01 for B,
+    ;100/206 case weight will have residual=0.01 for A, residual=20 for B,
+
+    (declare (assoc
+        expected_residuals
+            (assoc
+                A
+                    (/ (dot_product
+                        (list 6 100 100)
+                        (list 0 1.0 0.01)
+                    ) 206)
+                B
+                    (/ (dot_product
+                        (list 6 100 100)
+                        (list 0 0.01 20)
+                    ) 206)
+            )
+    ))
+
+	(declare (assoc
+		regular_train_payload
+			(call_entity "howso" "train" (assoc
+				features features
+				input_cases input_cases
+				session "unit_test"
+			))
+	))
+
+    (call_entity "howso" "set_internal_parameters" (assoc
+		default_hyperparameter_map (assoc "k" 2 "p" 1 "dt" -1)
+	))
+
+    (call_entity "howso" "react_into_trainee" (assoc
+        residuals (true)
+        use_case_weights (true)
+        weight_feature "case_weight"
+        context_features (list "A" "B")
+        num_samples 5000
+    ))
+
+    (declare (assoc
+        residuals
+            (get
+                (call_entity "howso" "get_prediction_stats" (assoc
+                    stats (list "mae")
+                    robust (false)
+                ))
+                "payload"
+            )
+    ))
+
+    (call assert_approximate (assoc
+        exp expected_residuals
+        obs (map (lambda (get (current_value) "mae")) residuals)
+        ;these thresholds feel generous at the time of writing, we should investigate if these fail.
+        thresh
+            (assoc
+                A 0.05
+                B 0.5
+            )
+    ))
+
+    (call exit_if_failures (assoc msg unit_test_name ))
+)

--- a/unit_tests/ut_h_weighted_residuals_cont.amlg
+++ b/unit_tests/ut_h_weighted_residuals_cont.amlg
@@ -18,6 +18,10 @@
 		features (list "A" "B" "case_weight")
 	))
 
+    (call_entity "howso" "set_internal_parameters" (assoc
+		default_hyperparameter_map (assoc "k" 2 "p" 1 "dt" -1)
+	))
+
     ;206 total case weight
     ;6/206 case weight will have 0 residuals for both features
     ;100/206 case weight will have residual=1.0 for A, residual=0.01 for B,
@@ -48,9 +52,6 @@
 			))
 	))
 
-    (call_entity "howso" "set_internal_parameters" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 1 "dt" -1)
-	))
 
     (call_entity "howso" "react_into_trainee" (assoc
         residuals (true)

--- a/unit_tests/ut_h_weighted_residuals_nom.amlg
+++ b/unit_tests/ut_h_weighted_residuals_nom.amlg
@@ -25,6 +25,10 @@
 			)
 	))
 
+    (call_entity "howso" "set_internal_parameters" (assoc
+		default_hyperparameter_map (assoc "k" 2 "p" 1 "dt" -1)
+	))
+
     ;210 total case weight
     ;204/210 case weight should get 100% CAP towards incorrect class (cases 1, 4, 5, 8)
     ;3/210 case weight should get ~33% CAP towards incorrect class (case 7)
@@ -61,9 +65,6 @@
 			))
 	))
 
-    (call_entity "howso" "set_internal_parameters" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 1 "dt" -1)
-	))
 
     (call_entity "howso" "react_into_trainee" (assoc
         residuals (true)

--- a/unit_tests/ut_h_weighted_residuals_nom.amlg
+++ b/unit_tests/ut_h_weighted_residuals_nom.amlg
@@ -86,18 +86,21 @@
             )
     ))
 
+    (print "MAE is as expected: ")
     (call assert_approximate (assoc
         exp exp_b_residual
         obs (get residuals (list "B" "mae"))
         thresh 0.005
     ))
 
+    (print "Recall is as expected: ")
     (call assert_approximate (assoc
         exp exp_recall
         obs (get residuals (list "B" "recall"))
         thresh 0.005
     ))
 
+    (print "Accuracy is as expected: ")
     (call assert_approximate (assoc
         exp exp_accuracy
         obs (get residuals (list "B" "accuracy"))

--- a/unit_tests/ut_h_weighted_residuals_nom.amlg
+++ b/unit_tests/ut_h_weighted_residuals_nom.amlg
@@ -1,0 +1,107 @@
+(seq
+	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_weighted_residuals_nom.amlg"))
+
+	(declare (assoc
+		input_cases
+			(list
+				(list 0 "blue" 3) ;should always be classified incorrectly, pred red
+				(list 1 "red" 1) ;should get 75% blue, 25% red, pred blue
+                (list 2 "red" 1) ;should get 60% blue, 40% red, pred blue
+                (list 5 "blue" 100) ;should always be classified incorrectly, pred red
+
+                (list 10 "down" 1) ;should always be classified incorrectly, pred up
+                (list 11 "up" 1) ;should get 75% up, 25% down, pred up
+                (list 12 "up" 3) ;should get 66% up, 33% down, pred up
+                (list 15 "down" 100) ;should always be classified incorrectly, pred up
+			)
+		features (list "A" "B" "case_weight")
+	))
+
+    (call_entity "howso" "set_feature_attributes" (assoc
+		features
+			(assoc
+				"B" (assoc "type" "nominal")
+			)
+	))
+
+    ;210 total case weight
+    ;204/210 case weight should get 100% CAP towards incorrect class (cases 1, 4, 5, 8)
+    ;3/210 case weight should get ~33% CAP towards incorrect class (case 7)
+    ;1/210 case weight should get 60% CAP towards incorrect class (case 3)
+    ;1/210 case weight should get 75% CAP towards incorrect class (case 2)
+    ;1/210 case weight should get 25% CAP towards incorrect class (case 6)
+    ;
+    ;it follows that only cases 6, 7 should be classified correctly, 5/210 case weight
+    (declare (assoc
+        exp_b_residual
+            (/ (dot_product
+                (list 204 3 1 1 1)
+                (list 1.0 0.3333 0.6 0.75 0.25)
+            ) 210)
+        exp_accuracy (/ 4 210)
+        exp_recall
+            (/
+                (+
+                    (/ 0 1) ;blue
+                    (/ 0 104) ;red
+                    0 ;down (no case should be predicted down)
+                    (/ 4 105) ;up
+                )
+                4 ;4 classes
+            )
+    ))
+
+	(declare (assoc
+		regular_train_payload
+			(call_entity "howso" "train" (assoc
+				features features
+				input_cases input_cases
+				session "unit_test"
+			))
+	))
+
+    (call_entity "howso" "set_internal_parameters" (assoc
+		default_hyperparameter_map (assoc "k" 2 "p" 1 "dt" -1)
+	))
+
+    (call_entity "howso" "react_into_trainee" (assoc
+        residuals (true)
+        use_case_weights (true)
+        weight_feature "case_weight"
+        context_features (list "A" "B")
+        num_samples 5000
+    ))
+
+    (declare (assoc
+        residuals
+            (get
+                (call_entity "howso" "get_prediction_stats" (assoc
+                    stats (list "mae" "accuracy" "recall")
+                    robust (false)
+                    weight_feature "case_weight"
+                ))
+                "payload"
+            )
+    ))
+
+    (call assert_approximate (assoc
+        exp exp_b_residual
+        obs (get residuals (list "B" "mae"))
+        thresh 0.005
+    ))
+
+    (call assert_approximate (assoc
+        exp exp_recall
+        obs (get residuals (list "B" "recall"))
+        thresh 0.005
+    ))
+
+    (call assert_approximate (assoc
+        exp exp_accuracy
+        obs (get residuals (list "B" "accuracy"))
+        thresh 0.015
+    ))
+
+    (call exit_if_failures (assoc msg unit_test_name ))
+)

--- a/unit_tests/ut_howso.amlg
+++ b/unit_tests/ut_howso.amlg
@@ -63,6 +63,8 @@
 				"ut_h_constraints.amlg"
 				"ut_h_hierarchy_by_id.amlg"
 				"ut_h_hierarchy_by_name.amlg"
+				"ut_h_weighted_residuals_cont.amlg"
+				"ut_h_weighted_residuals_nom.amlg"
 
 				;should always be last
 				"ut_h_migration.amlg"


### PR DESCRIPTION
Adds two tests with pathological datasets that verifies case weights affect the resulting residuals and other prediction stats. 