### PR TITLE
20286: Adds `action_condition` and `context_condition` parameters to `get_prediction_stats`, MAJOR

### DIFF
--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -243,9 +243,16 @@
 	;parameters:
 	; features: optional list of all features used during computation. If not specified will use !trainedFeatures.
 	; target_residual_feature: optional feature for which to calculate the (MAE) residual. If not specified, will compute for all features.
-	; case_ids: optional list of case ids to compute residuals.
+	; case_ids: optional list of case ids to compute residuals for the action set, will ignore 'action_condition_filter_query' and 'num_samples' if specified
+	; action_condition_filter_query: optional list of filtering queries for the action set. If both 'action_condition_filter_query' and 'context_condition_filter_query' are specified,
+	;		then all of the action cases selected by the 'action_condition_filter_query' will be excluded from the context set, effectively holding them out.
+	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
+	; num_samples: optional, limit on the number of cases for the action set to use in calculating conditional residuals. Works with or without 'action_condition_filter_query'. If
+	; 		'action_condition_filter_query' is not provided, will be ignored if 'case_ids' is provided.
+	; context_condition_filter_query: optional list of filtering queries for the context set. Ignored if 'action_condition_filter_query' is not specified. 
+	;		If both 'action_condition_filter_query' and 'context_condition_filter_query' are specified, then all of the cases selected by the 'action_condition_filter_query'
+	;		will be excluded from the context set, effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	; focal_case: optional case id of case for which to compute residuals for  is to be ignored during computation
-	; num_samples: optional case sample size to use in calculation, will be ignored if the case_ids parameter is specified
 	; regional_model_only: flag, default to false. when set to true will only explicitly use the specified case_ids for computation.
 	; robust_residuals: flag, default to false. when true calculates residuals robust with respect to the set of contexts used (across the power set of contexts)
 	; hyperparameter_feature: optional  default '.targetless'.  feature whose hyperparameters to use
@@ -254,7 +261,6 @@
 	; custom_hyperparam_map: optional, hyperparameters to use for residuals computation
 	; compute_all_statistics: flag, optional. if set to true will compute other statistics (precision, recall, r^2, rmse, etc.) in addition to MAE
 	; store_values: flag, optional. if set to true will store the statistics in trainee-level caches, if set to false will return the set of values
-	; holdout: flag, optional. if set to true will hold out all of the cases from 'case_ids'
 	#!CalculateFeatureResiduals
 	(declare
 		(assoc
@@ -264,23 +270,17 @@
 			focal_case (null)
 			robust_residuals (false)
 
-			;ordered by priority for the action set, with the action condition parameters having the top priority. 
-			action_condition_filter_query (list)
-			action_condition_num_cases (null)
-			action_condition_precision "exact"
+			;ordered by priority for the action set, with the 'case_ids' parameters having the top priority. 
 			case_ids (list)
-			num_samples (null)
-
+			action_condition_filter_query (list)
 			context_condition_filter_query (list)
-			context_condition_num_cases (null)
-			context_condition_precision "exact"
+ 			num_samples (null)
 
 			hyperparameter_feature ".targetless"
 			use_case_weights (false)
 			weight_feature ".case_weight"
 			custom_hyperparam_map (null)
 			compute_all_statistics (false)
-			holdout (false)
 			store_values (true)
 		)
 

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -254,6 +254,7 @@
 	; custom_hyperparam_map: optional, hyperparameters to use for residuals computation
 	; compute_all_statistics: flag, optional. if set to true will compute other statistics (precision, recall, r^2, rmse, etc.) in addition to MAE
 	; store_values: flag, optional. if set to true will store the statistics in trainee-level caches, if set to false will return the set of values
+	; holdout: flag, optional. if set to true will hold out all of the cases from 'case_ids'
 	#!CalculateFeatureResiduals
 	(declare
 		(assoc
@@ -270,6 +271,7 @@
 			weight_feature ".case_weight"
 			custom_hyperparam_map (null)
 			compute_all_statistics (false)
+			holdout (false)
 			store_values (true)
 		)
 

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -261,15 +261,19 @@
 			features (null)
 			target_residual_feature (null)
 			regional_model_only (false)
-			case_ids (list)
 			focal_case (null)
-			num_samples (null)
 			robust_residuals (false)
 
+			;ordered by priority for the action set, with the action condition parameters having the top priority. 
 			action_condition_filter_query (list)
+			action_condition_num_cases (null)
+			action_condition_precision "exact"
+			case_ids (list)
+			num_samples (null)
+
 			context_condition_filter_query (list)
-			num_cases (null)
-			precision "exact"
+			context_condition_num_cases (null)
+			context_condition_precision "exact"
 
 			hyperparameter_feature ".targetless"
 			use_case_weights (false)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -266,6 +266,11 @@
 			num_samples (null)
 			robust_residuals (false)
 
+			action_condition_filter_query (list)
+			context_condition_filter_query (list)
+			num_cases (null)
+			precision "exact"
+
 			hyperparameter_feature ".targetless"
 			use_case_weights (false)
 			weight_feature ".case_weight"

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -306,17 +306,19 @@
 	;	If 'condition_filter_query' is not specified:
 	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact".
 	#!GetCasesByCondition
-	(declare (assoc
-		condition (assoc)
-		condition_filter_query (list)
-		condition_session (null)
-		precision "exact"
-		num_cases (null)
+	(declare 
+		(assoc
+			condition (assoc)
+			condition_filter_query (list)
+			condition_session (null)
+			precision "exact"
+			num_cases (null)
 		)
 	
 		(if (!= (null) condition_session)
 			;get all the case ids in the order they were stored for the specified session
 			(retrieve_from_entity condition_session ".replay_steps")
+
 			(seq
 				;if 'condition_filter_query' is not provided, get the 'condition_filter_query'
 				(if (= (size condition_filter_query) 0)
@@ -354,12 +356,13 @@
 	; precision: flag, default is "exact". Whether to query for 'exact' matches; if set to 'similar' will query for similar values intead of 'exact'
 	; num_cases: optional, default is null. The number of "similar" cases to get if 'precision' is "similar" or no limit if precision is "exact".
 	#!GetQueryByCondition
-	(declare (assoc
-		condition (assoc)
-		condition_session (null)
-		precision "exact"
-		num_cases (null)
-	)
+	(declare 
+		(assoc
+			condition (assoc)
+			condition_session (null)
+			precision "exact"
+			num_cases (null)
+		)
 
 		;set num_cases appropriately if null
 		(if (= (null) num_cases)
@@ -527,7 +530,6 @@
 			)
 		)
 	)
-
 
 
 	;retrieve the top or bottom number of cases for a specified feature, sorted top to bottom for top, and bottom to top for bottom

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -289,9 +289,9 @@
 	;return all cases that match the specified condition
 	;parameters:
 	; precision: flag, whether to query for 'exact' matches; if set to 'similar' will query for similar values intead of 'exact'
-	; condition_session: optional, if specified ignores condition and returns cases for the specified session id
-	; condition_filter_query: optional, list of query conditions
-	; condition: optional assoc of feature->value(s). If 'condition_filter_query' is also provided, then 'condition_filter_query' overrides this parameter
+	; condition_session: optional, if specified ignores condition and condition_filter_query and returns cases for the specified session id
+	; condition_filter_query: optional, list of query conditions. If specified ignores condition and returns cases for the specified fitery query
+	; condition: optional assoc of feature->value(s). Condition for the returned cases. If 'condition_filter_query' is also provided, then this parameter is ignored.
 	;	no value = must have feature
 	;	- for continuous or numeric ordinal features:
 	;	one value = must equal exactly the value or be close to it for fuzzy match

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -290,7 +290,8 @@
 	;parameters:
 	; precision: flag, whether to query for 'exact' matches; if set to 'similar' will query for similar values intead of 'exact'
 	; condition_session: optional, if specified ignores condition and returns cases for the specified session id
-	; condition: optional assoc of feature->value(s). If 'condition' is not provided, then 'query_condition' must be provided
+	; condition_filter_query: optional, list of query conditions
+	; condition: optional assoc of feature->value(s). If 'condition_filter_query' is also provided, then 'condition_filter_query' overrides this parameter
 	;	no value = must have feature
 	;	- for continuous or numeric ordinal features:
 	;	one value = must equal exactly the value or be close to it for fuzzy match
@@ -308,6 +309,7 @@
 		num_cases (null)
 		)
 
+	
 		(if (!= (null) condition_session)
 			;get all the case ids in the order they were stored for the specified session
 			(retrieve_from_entity condition_session ".replay_steps")

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -290,7 +290,7 @@
 	;parameters:
 	; precision: flag, whether to query for 'exact' matches; if set to 'similar' will query for similar values intead of 'exact'
 	; condition_session: optional, if specified ignores condition and returns cases for the specified session id
-	; condition: assoc of feature->value(s)
+	; condition: optional assoc of feature->value(s). If 'condition' is not provided, then 'query_condition' must be provided
 	;	no value = must have feature
 	;	- for continuous or numeric ordinal features:
 	;	one value = must equal exactly the value or be close to it for fuzzy match
@@ -301,11 +301,57 @@
 	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
 	#!GetCasesByCondition
 	(declare (assoc
-			condition (assoc)
-			condition_session (null)
-			precision "exact"
-			num_cases (null)
+		condition (assoc)
+		condition_filter_query (list)
+		condition_session (null)
+		precision "exact"
+		num_cases (null)
 		)
+
+		(if (!= (null) condition_session)
+			;get all the case ids in the order they were stored for the specified session
+			(retrieve_from_entity condition_session ".replay_steps")
+			(seq
+				(if (= (size condition_filter_query) 0)
+					(assign (assoc
+						condition_filter_query
+							(call !GetQueryByCondition (assoc 
+								condition condition
+								condition_session condition_session
+								precision precision
+								num_cases num_cases
+							))
+					))
+				)
+
+				(if num_cases
+					(trunc (contained_entities condition_filter_query) num_cases)
+					(contained_entities condition_filter_query)
+				)
+			)
+		)
+	)
+
+
+	;return the query conditions for cases that match the specified condition
+	;parameters:
+	; precision: flag, whether to query for 'exact' matches; if set to 'similar' will query for similar values intead of 'exact'
+	; condition_session: optional, if specified ignores condition and returns cases for the specified session id
+	; condition: assoc of feature->value(s)
+	;	no value = must have feature
+	;	- for continuous or numeric ordinal features:
+	;	one value = must equal exactly the value or be close to it for fuzzy match
+	;	two values = inclusive between
+	;	- for nominal or string ordinal features:
+	;	n values = must match any of these values exactly
+	; num_cases: optional, the number of "similar" cases to get is "similar" or no limit if precision is "exact". default is null #TODO:
+	#!GetQueryByCondition
+	(declare (assoc
+		condition (assoc)
+		condition_session (null)
+		precision "exact"
+		num_cases (null)
+	)
 
 		;set num_cases appropriately if null
 		(if (= (null) num_cases)
@@ -327,173 +373,154 @@
 			)
 		)
 
-		(if (!= (null) condition_session)
-			;get all the case ids in the order they were stored for the specified session
-			(retrieve_from_entity condition_session ".replay_steps")
 
-			;else return cases that match the condition
-			(seq
-				(if !hasStringOrdinals
-					(assign (assoc
-						condition
-							(map
-								(lambda
-									;if the features in the condition are string ordinals, look up the encoded value and overwrite it in the condition statement
-									;since querying is done on numeric (encoded) values
-									(if (and (contains_index !ordinalStringToOrdinalMap (current_index)) (!= (null) (current_value)))
-										(let
-											(assoc
-												feature (current_index 1)
-												cond_value (current_value 1)
-											)
-											;get the enum value for the value(s) for this feature
-											(if (~ (list) cond_value)
-												(map
-													(lambda (get !ordinalStringToOrdinalMap (list feature (current_value 1))) )
-													cond_value
-												)
-												;else get the one single value
-												(get !ordinalStringToOrdinalMap (list feature cond_value))
-											)
+		(if !hasStringOrdinals
+			(assign (assoc
+				condition
+					(map
+						(lambda
+							;if the features in the condition are string ordinals, look up the encoded value and overwrite it in the condition statement
+							;since querying is done on numeric (encoded) values
+							(if (and (contains_index !ordinalStringToOrdinalMap (current_index)) (!= (null) (current_value)))
+								(let
+									(assoc
+										feature (current_index 1)
+										cond_value (current_value 1)
+									)
+									;get the enum value for the value(s) for this feature
+									(if (~ (list) cond_value)
+										(map
+											(lambda (get !ordinalStringToOrdinalMap (list feature (current_value 1))) )
+											cond_value
 										)
-
-										;else return the value without encoding
-										(current_value)
+										;else get the one single value
+										(get !ordinalStringToOrdinalMap (list feature cond_value))
 									)
 								)
-								condition
+
+								;else return the value without encoding
+								(current_value)
 							)
+						)
+						condition
+					)
+			))
+		)
+
+		(if (= "exact" precision)
+			;limit the list to the number of specified cases
+				;iterate over each condition and create a conjunctive filter to return only the matching cases
+			(append
+				(query_exists !internalLabelSession)
+				(map
+					(lambda (let
+						(assoc
+							feature (current_value 1)
+							cond_value (get condition (current_value 1))
+						)
+						(if
+							;feature must exist
+							(= cond_value (null))
+							(query_exists feature)
+
+							;else then feature value must equal
+							(contains_value (list "number" "string") (get_type_string cond_value))
+							(query_equals feature cond_value)
+
+							;else this is a list of values, for nominals use query_among, for continuous use query_between
+							(if (or (contains_index !nominalsMap feature) (contains_index !ordinalStringToOrdinalMap feature))
+								(query_among feature cond_value)
+								;else continuous, inclusive query between the two provided values
+								(query_between feature (first cond_value) (last cond_value))
+							)
+						)
 					))
+					(indices condition)
+				)
+			)
+
+			;else do a fuzzy query
+			(let
+				(assoc
+					;list of features where the condition is an 'equals'
+					equals_features (list)
+					;list of features where the condition is a range or null
+					other_features (list)
+					hyperparam_map
+						(call !GetHyperparameters (assoc
+							feature ".targetless"
+							mode "robust"
+							weight_feature ".none"
+						))
+				)
+				;iterate over condition and populate the equals and other lists
+				(map
+					(lambda (if
+						;if the condition for this feature is an equals, add it to the equals_features list
+						(contains_value (list "string" "number") (get_type_string (get condition (current_value))))
+						(accum (assoc equals_features (current_value 1)))
+						;else add it to the other list
+						(accum (assoc other_features (current_value 1)))
+					))
+					(indices condition)
 				)
 
-				(if (= "exact" precision)
-					;limit the list to the number of specified cases
-					(trunc
-						;iterate over each condition and create a conjunctive filter to return only the matching cases
-						(contained_entities (append
-							(query_exists !internalLabelSession)
-							(map
-								(lambda (let
-									(assoc
-										feature (current_value 1)
-										cond_value (get condition (current_value 1))
-									)
-									(if
-										;feature must exist
-										(= cond_value (null))
-										(query_exists feature)
+				;pull corresponding feature values and flags for the equals features to be used in the generalized_distance query below
+				(declare (assoc equals_features_values (unzip condition equals_features) ))
 
-										;else then feature value must equal
-										(contains_value (list "number" "string") (get_type_string cond_value))
-										(query_equals feature cond_value)
+				;build the fuzzy query condition, appending the generalized norm query to the other conditions
+				(append
+					(query_exists !internalLabelSession)
+					(map
+						(lambda (let
+							(assoc
+								feature (current_value 1)
+								cond_value (get condition (current_value 1))
+							)
+							(if
+								;feature must exist
+								(= cond_value (null))
+								(query_exists feature)
 
-										;else this is a list of values, for nominals use query_among, for continuous use query_between
-										(if (or (contains_index !nominalsMap feature) (contains_index !ordinalStringToOrdinalMap feature))
-											(query_among feature cond_value)
-											;else continuous, inclusive query between the two provided values
-											(query_between feature (first cond_value) (last cond_value))
-										)
-									)
-								))
-								(indices condition)
+								;else this is a list of values, for nominals use query_among, for continuous use query_between
+								(if (or (contains_index !nominalsMap feature) (contains_index !ordinalStringToOrdinalMap feature))
+									(query_among feature cond_value)
+									;else continuous, inclusive query between the two provided values
+									(query_between feature (first cond_value) (last cond_value))
+								)
 							)
 						))
-						num_cases
+						other_features
 					)
-
-					;else do a fuzzy query
-					(let
-						(assoc
-							;list of features where the condition is an 'equals'
-							equals_features (list)
-							;list of features where the condition is a range or null
-							other_features (list)
-							hyperparam_map
-								(call !GetHyperparameters (assoc
-									feature ".targetless"
-									mode "robust"
-									weight_feature ".none"
-								))
-						)
-						;iterate over condition and populate the equals and other lists
-						(map
-							(lambda (if
-								;if the condition for this feature is an equals, add it to the equals_features list
-								(contains_value (list "string" "number") (get_type_string (get condition (current_value))))
-								(accum (assoc equals_features (current_value 1)))
-								;else add it to the other list
-								(accum (assoc other_features (current_value 1)))
-							))
-							(indices condition)
+					(if (> num_cases 0)
+						(query_nearest_generalized_distance
+							num_cases
+							equals_features
+							equals_features_values
+							(get hyperparam_map "featureWeights")
+							!queryDistanceTypeMap
+							(get hyperparam_map "featureDomainAttributes")
+							(get hyperparam_map "featureDeviations")
+							(get hyperparam_map "p")
+							(get hyperparam_map "dt")
+							(null) ;weight
+							;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
+							"fixed rand seed"
+							(null) ;radius
+							;the distance values are not needed, so this could in theory be
+							; (if (= "precise" !numericalPrecision) "precise" "fast")), however, that incurs overhead as well
+							;left as is to be simple, but could be modified for performance if large numbers of cases are being retrieved this way
+							!numericalPrecision
 						)
 
-						;pull corresponding feature values and flags for the equals features to be used in the generalized_distance query below
-						(declare (assoc equals_features_values (unzip condition equals_features) ))
-
-						;build the fuzzy query condition, appending the generalized norm query to the other conditions
-						(declare (assoc
-							query_conditions
-								(append
-									(query_exists !internalLabelSession)
-									(map
-										(lambda (let
-											(assoc
-												feature (current_value 1)
-												cond_value (get condition (current_value 1))
-											)
-											(if
-												;feature must exist
-												(= cond_value (null))
-												(query_exists feature)
-
-												;else this is a list of values, for nominals use query_among, for continuous use query_between
-												(if (or (contains_index !nominalsMap feature) (contains_index !ordinalStringToOrdinalMap feature))
-													(query_among feature cond_value)
-													;else continuous, inclusive query between the two provided values
-													(query_between feature (first cond_value) (last cond_value))
-												)
-											)
-										))
-										other_features
-									)
-									(if (> num_cases 0)
-										(query_nearest_generalized_distance
-											num_cases
-											equals_features
-											equals_features_values
-											(get hyperparam_map "featureWeights")
-											!queryDistanceTypeMap
-											(get hyperparam_map "featureDomainAttributes")
-											(get hyperparam_map "featureDeviations")
-											(get hyperparam_map "p")
-											(get hyperparam_map "dt")
-											(null) ;weight
-											;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
-											"fixed rand seed"
-											(null) ;radius
-											;the distance values are not needed, so this could in theory be
-											; (if (= "precise" !numericalPrecision) "precise" "fast")), however, that incurs overhead as well
-											;left as is to be simple, but could be modified for performance if large numbers of cases are being retrieved this way
-											!numericalPrecision
-										)
-
-										(list)
-									)
-								)
-						))
-
-						;run query conditions only if they exist, otherwise return all cases
-						(if (> (size query_conditions) 0)
-							(contained_entities query_conditions)
-
-							;else return all
-							(contained_entities (list (query_exists !internalLabelSession)))
-						)
+						(list)
 					)
 				)
 			)
 		)
 	)
+
+
 
 	;retrieve the top or bottom number of cases for a specified feature, sorted top to bottom for top, and bottom to top for bottom
 	;parmeters:

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -286,20 +286,25 @@
 		)
 	)
 
+
 	;return all cases that match the specified condition
 	;parameters:
-	; precision: flag, whether to query for 'exact' matches; if set to 'similar' will query for similar values intead of 'exact'
-	; condition_session: optional, if specified ignores condition and condition_filter_query and returns cases for the specified session id
-	; condition_filter_query: optional, list of query conditions. If specified ignores condition and returns cases for the specified fitery query
-	; condition: optional assoc of feature->value(s). Condition for the returned cases. If 'condition_filter_query' is also provided, then this parameter is ignored.
+	; condition_session: optional, if specified ignores 'condition' and 'condition_filter_query' and returns cases for the specified session id
+	; condition_filter_query: optional, list of query conditions. If specified ignores 'condition' and returns cases for the specified fitery query
+	; condition: optional assoc of feature->value(s). Condition for the returned cases. If 'condition_filter_query' is provided, then this parameter is ignored.
 	;	no value = must have feature
 	;	- for continuous or numeric ordinal features:
 	;	one value = must equal exactly the value or be close to it for fuzzy match
 	;	two values = inclusive between
 	;	- for nominal or string ordinal features:
 	;	n values = must match any of these values exactly
-	; num_cases: optional, limit on the number of cases to get; If set to zero there will be no limit.
-	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
+	; precision: flag, default is "exact". Whether to query for 'exact' matches when using the 'condition' parameter; if set to 'similar' will query for similar values intead of 'exact'
+	;	If 'condition_filter_query' is provided, then this parameter is ignored.
+	; num_cases: optional, limit on the number of cases to get when using the 'condition' parameter. Works with or without 'condition_filter_query'. default is null.
+	;	If 'condition_filter_query' is specified:
+	;		If null there will be no limit.
+	;	If 'condition_filter_query' is not specified:
+	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact".
 	#!GetCasesByCondition
 	(declare (assoc
 		condition (assoc)
@@ -308,12 +313,12 @@
 		precision "exact"
 		num_cases (null)
 		)
-
 	
 		(if (!= (null) condition_session)
 			;get all the case ids in the order they were stored for the specified session
 			(retrieve_from_entity condition_session ".replay_steps")
 			(seq
+				;if 'condition_filter_query' is not provided, get the 'condition_filter_query'
 				(if (= (size condition_filter_query) 0)
 					(assign (assoc
 						condition_filter_query
@@ -326,6 +331,7 @@
 					))
 				)
 
+				;retrieve cases with the 'condition_filter_query'
 				(if num_cases
 					(trunc (contained_entities condition_filter_query) num_cases)
 					(contained_entities condition_filter_query)
@@ -337,7 +343,6 @@
 
 	;return the query conditions for cases that match the specified condition
 	;parameters:
-	; precision: flag, whether to query for 'exact' matches; if set to 'similar' will query for similar values intead of 'exact'
 	; condition_session: optional, if specified ignores condition and returns cases for the specified session id
 	; condition: assoc of feature->value(s)
 	;	no value = must have feature
@@ -346,7 +351,8 @@
 	;	two values = inclusive between
 	;	- for nominal or string ordinal features:
 	;	n values = must match any of these values exactly
-	; num_cases: optional, the number of "similar" cases to get is "similar" or no limit if precision is "exact". default is null #TODO:
+	; precision: flag, default is "exact". Whether to query for 'exact' matches; if set to 'similar' will query for similar values intead of 'exact'
+	; num_cases: optional, default is null. The number of "similar" cases to get if 'precision' is "similar" or no limit if precision is "exact".
 	#!GetQueryByCondition
 	(declare (assoc
 		condition (assoc)

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -583,7 +583,7 @@
 	(declare
 		(assoc
 			weight_feature (null)
-			action_condition (null)
+			condition (null)
 			precision "exact"
 			num_cases (null)
 		)
@@ -594,7 +594,7 @@
 
 		(call !Return (assoc
 			payload
-				(if (= (null) action_condition)
+				(if (= (null) condition)
 					(seq
 						;if marginal stats haven't been computed yet, compute them here
 						(if (not (contains_index !featureMarginalStatsMap weight_feature))
@@ -612,7 +612,7 @@
 						(assoc
 							case_ids
 								(call !GetCasesByCondition (assoc
-									condition action_condition
+									condition condition
 									num_cases num_cases
 									prevision precision
 								))

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -583,7 +583,7 @@
 	(declare
 		(assoc
 			weight_feature (null)
-			condition (null)
+			action_condition (null)
 			precision "exact"
 			num_cases (null)
 		)
@@ -594,7 +594,7 @@
 
 		(call !Return (assoc
 			payload
-				(if (= (null) condition)
+				(if (= (null) action_condition)
 					(seq
 						;if marginal stats haven't been computed yet, compute them here
 						(if (not (contains_index !featureMarginalStatsMap weight_feature))
@@ -612,7 +612,7 @@
 						(assoc
 							case_ids
 								(call !GetCasesByCondition (assoc
-									condition condition
+									condition action_condition
 									num_cases num_cases
 									prevision precision
 								))

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -32,7 +32,7 @@
 	; weight_feature: string, optional. if specified, will attempt to return stats that were computed using this weight_feature.
 	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
-	;       will be excluded from the context set, which is the set being queried to make to make predictions for the action set, effectively holding them out.
+	;       will be excluded from the context set, which is the set being queried to make to make predictions on the action set, effectively holding them out.
 	;		If only 'action_condition' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
@@ -46,7 +46,7 @@
 	;			If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
 	;		If 'action_condition' is not set:
 	;			If null, will be set to the Howso default limit of 2000. default is null
-	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions for the action set.
+	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions on the action set.
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
 	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition' is specified, then only the single predicted case will be left out.	
 	;		no value = must have feature
@@ -406,7 +406,7 @@
 	; weight_feature: string, optional. if specified, will attempt to return residuals that were computed using this weight_feature.
 	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
-	;       will be excluded from the context set, which is the set being queried to make to make predictions for the action set, effectively holding them out.
+	;       will be excluded from the context set, which is the set being queried to make to make predictions on the action set, effectively holding them out.
 	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
@@ -420,7 +420,7 @@
 	;			If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
 	;		If 'action_condition_filter_query' is not set:
 	;			If null, will be set to the Howso default limit of 2000. default is null
-	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions for the action set.
+	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions on the action set.
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
 	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.	
 	;		no value = must have feature

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -33,7 +33,7 @@
 	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
 	;       will be excluded from the context set, which is the set being queried to make to make predictions for the action set, effectively holding them out.
-	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
+	;		If only 'action_condition' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
 	;			one value = must equal exactly the value or be close to it for fuzzy match
@@ -42,13 +42,13 @@
 	;			n values = must match any of these values exactly
 	; action_condition_precision: optional string,  default is 'exact', used only with 'action_condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
 	; action_num_cases: optional, limit on the number of action cases used in calculating conditional prediction stats. Works with or without 'action_condition_filter_query'.
-	;		If 'action_condition_filter_query' is set:
+	;		If 'action_condition' is set:
 	;			If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
-	;		If 'action_condition_filter_query' is not set:
+	;		If 'action_condition' is not set:
 	;			If null, will be set to the Howso default limit of 2000. default is null
 	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions for the action set.
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
-	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.	
+	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition' is specified, then only the single predicted case will be left out.	
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
 	;			one value = must equal exactly the value or be close to it for fuzzy match

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -41,10 +41,12 @@
 	;   	- for nominal or string ordinal features:
 	;			n values = must match any of these values exactly
 	; action_condition_precision: optional string,  default is 'exact', used only with 'action_condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
-	; 
-	action_condition_num_cases: optional, used only with 'action_condition' parameter, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
-	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
-	; action_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions for the action set.
+	; action_num_cases: optional, limit on the number of action cases used in calculating conditional prediction stats. Works with or without 'action_condition_filter_query'.
+	;		If 'action_condition_filter_query' is set:
+	;			If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
+	;		If 'action_condition_filter_query' is not set:
+	;			If null, will be set to the Howso default limit of 2000. default is null
+	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions for the action set.
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
 	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.	
 	;		no value = must have feature
@@ -53,9 +55,9 @@
 	;			two values = inclusive between
 	;   	- for nominal or string ordinal features:
 	;			n values = must match any of these values exactly
-	; precision: optional string,  default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
-	; num_cases: optional, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
-	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
+	; context_condition_precision: optional string, default is 'exact'. Used only with 'context_condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
+	; context_precision_num_cases: optional, limit on the number of context cases when 'context_condition_precision' is set to 'similar'.
+	;		If null, will be set to k. default is null
 	; num_robust_influence_samples_per_case: optional, Specifies the number of robust samples to use for each case for robust contribution computations.
 	;				  Defaults to 300 + 2 * (number of features).
 	#get_prediction_stats
@@ -67,11 +69,11 @@
 			robust_hyperparameters (null)
 			weight_feature (null)
 			action_condition (null)
-			action_condition_num_cases (null)
+			action_num_cases (null)
 			action_condition_precision "exact"
 			context_condition (null)
 			context_condition_precision "exact"
-			context_condition_num_cases (null)
+			context_precision_num_cases (null)
 		)
 
 		;if there are specified stats remaining after all the supported stats have been removed, that means unsupported ones were provided
@@ -96,10 +98,10 @@
 					robust_hyperparameters robust_hyperparameters
 					weight_feature weight_feature
 					context_condition context_condition
-					context_condition_num_cases context_condition_num_cases
-					context_condition_precision context_condition_num_cases
+					context_precision_num_cases context_precision_num_cases
+					context_condition_precision context_precision_num_cases
 					action_condition action_condition
-					action_condition_num_cases action_condition_num_cases
+					action_num_cases action_num_cases
 					action_condition_precision action_condition_precision
 					num_robust_influence_samples_per_case num_robust_influence_samples_per_case
 				))
@@ -402,16 +404,34 @@
 	; robust_hyperparameters: flag, optional. if true, will attempt to return residuals that were computed using hyperparameters with the
 	;						  specified robust or non-robust type.
 	; weight_feature: string, optional. if specified, will attempt to return residuals that were computed using this weight_feature.
-	; condition: assoc of feature->value(s)
+	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
+	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
+	;       will be excluded from the context set, which is the set being queried to make to make predictions for the action set, effectively holding them out.
+	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
 	;			one value = must equal exactly the value or be close to it for fuzzy match
 	;			two values = inclusive between
 	;   	- for nominal or string ordinal features:
 	;			n values = must match any of these values exactly
-	; precision: optional string,  default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
-	; num_cases: optional, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
-	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
+	; action_condition_precision: optional string,  default is 'exact', used only with 'action_condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
+	; action_num_cases: optional, limit on the number of action cases used in calculating conditional prediction stats. Works with or without 'action_condition_filter_query'.
+	;		If 'action_condition_filter_query' is set:
+	;			If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
+	;		If 'action_condition_filter_query' is not set:
+	;			If null, will be set to the Howso default limit of 2000. default is null
+	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions for the action set.
+	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
+	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.	
+	;		no value = must have feature
+	;   	- for continuous or numeric ordinal features:
+	;			one value = must equal exactly the value or be close to it for fuzzy match
+	;			two values = inclusive between
+	;   	- for nominal or string ordinal features:
+	;			n values = must match any of these values exactly
+	; context_condition_precision: optional string, default is 'exact'. Used only with 'context_condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
+	; context_precision_num_cases: optional, limit on the number of context cases when 'context_condition_precision' is set to 'similar'.
+	;		If null, will be set to k. default is nulls
 	; num_robust_influence_samples_per_case: optional integer. Specifies the number of robust samples to use for each case.
 	;				  Applicable only for computing feature contributions. When unspecified, defaults to 200 + 2 * number of features.
 	;				  Higher values will take longer but provide more stable results.
@@ -423,10 +443,10 @@
 			robust_hyperparameters (null)
 			weight_feature (null)
 			action_condition (null)
-			action_condition_num_cases (null)
+			action_num_cases (null)
 			action_condition_precision "exact"
 			context_condition (null)
-			context_condition_num_cases (null)
+			context_precision_num_cases (null)
 			context_condition_precision "exact"
 			num_robust_influence_samples_per_case (null)
 		)
@@ -439,7 +459,7 @@
 					(call !GetQueryByCondition (assoc
 						condition action_condition
 						precision action_condition_precision
-						num_cases action_condition_num_cases
+						num_cases action_num_cases
 					))
 					(list)
 				)
@@ -448,7 +468,7 @@
 					(call !GetQueryByCondition (assoc
 						condition context_condition
 						precision context_condition_precision
-						num_cases context_condition_num_cases
+						num_cases context_precision_num_cases
 					))
 					(list)
 				)
@@ -501,11 +521,11 @@
 							compute_all_statistics (!= basic_stats (list))
 							store_values (false)
 							context_condition_filter_query context_condition_filter_query
-							context_condition_num_cases context_condition_num_cases
-							context_condition_num_cases context_condition_precision
+							context_precision_num_cases context_precision_num_cases
+							context_precision_num_cases context_condition_precision
 							action_condition_filter_query action_condition_filter_query
-							action_condition_num_cases action_condition_num_cases
-							action_condition_num_cases action_condition_num_precision
+							action_condition_num_precision action_condition_num_precision
+							num_samples action_num_cases
 						))
 				)
 				(if (contains_value stats "mae")

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -30,15 +30,29 @@
 	; robust_hyperparameters: flag, optional. if specified, will attempt to return stats that were computed using hyperpparameters with the
 	;						  specified robust or non-robust type.
 	; weight_feature: string, optional. if specified, will attempt to return stats that were computed using this weight_feature.
-	; condition: assoc of feature->value(s)
+	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
+	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
+	;       will be excluded from the context set, which is the set being queried to make to make predictions for the action set, effectively holding them out.
+	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
 	;			one value = must equal exactly the value or be close to it for fuzzy match
 	;			two values = inclusive between
 	;   	- for nominal or string ordinal features:
 	;			n values = must match any of these values exactly
-	; holdout: flag, optional. If set to true, the cases specified in 'condition' will be held out entirely when making predictions for calculating stats.
-	;		   Only used when 'condition' is specified.
+	; action_condition_precision: optional string,  default is 'exact', used only with 'action_condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
+	; 
+	action_condition_num_cases: optional, used only with 'action_condition' parameter, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
+	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
+	; action_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions for the action set.
+	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
+	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.	
+	;		no value = must have feature
+	;   	- for continuous or numeric ordinal features:
+	;			one value = must equal exactly the value or be close to it for fuzzy match
+	;			two values = inclusive between
+	;   	- for nominal or string ordinal features:
+	;			n values = must match any of these values exactly
 	; precision: optional string,  default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
 	; num_cases: optional, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
 	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
@@ -52,14 +66,12 @@
 			action_feature (null)
 			robust_hyperparameters (null)
 			weight_feature (null)
-			context_condition (null)
 			action_condition (null)
 			action_condition_num_cases (null)
-			feature_condition_num_cases (null)
 			action_condition_precision "exact"
-			feature_condition_precision "exact"
-			precision "exact"
-			num_cases (null)
+			context_condition (null)
+			context_condition_precision "exact"
+			context_condition_num_cases (null)
 		)
 
 		;if there are specified stats remaining after all the supported stats have been removed, that means unsupported ones were provided
@@ -84,13 +96,11 @@
 					robust_hyperparameters robust_hyperparameters
 					weight_feature weight_feature
 					context_condition context_condition
+					context_condition_num_cases context_condition_num_cases
+					context_condition_precision context_condition_num_cases
 					action_condition action_condition
 					action_condition_num_cases action_condition_num_cases
-					feature_condition_num_cases feature_condition_num_cases
 					action_condition_precision action_condition_precision
-					feature_condition_precision feature_condition_precision
-					precision precision
-					num_cases num_cases
 					num_robust_influence_samples_per_case num_robust_influence_samples_per_case
 				))
 				;else no condition is present
@@ -412,12 +422,12 @@
 			action_feature (null)
 			robust_hyperparameters (null)
 			weight_feature (null)
-			context_condition (null)
 			action_condition (null)
 			action_condition_num_cases (null)
-			feature_condition_num_cases (null)
 			action_condition_precision "exact"
-			feature_condition_precision "exact"
+			context_condition (null)
+			context_condition_num_cases (null)
+			context_condition_precision "exact"
 			num_robust_influence_samples_per_case (null)
 		)
 
@@ -491,9 +501,11 @@
 							compute_all_statistics (!= basic_stats (list))
 							store_values (false)
 							context_condition_filter_query context_condition_filter_query
-							action_condition_filter_query action_condition_filter_query
 							context_condition_num_cases context_condition_num_cases
+							context_condition_num_cases context_condition_precision
+							action_condition_filter_query action_condition_filter_query
 							action_condition_num_cases action_condition_num_cases
+							action_condition_num_cases action_condition_num_precision
 						))
 				)
 				(if (contains_value stats "mae")

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -38,6 +38,7 @@
 	;   	- for nominal or string ordinal features:
 	;			n values = must match any of these values exactly
 	; holdout: flag, optional. If set to true, the cases specified in 'condition' will be held out entirely when making predictions for calculating stats.
+	;		   Only used when 'condition' is specified.
 	; precision: optional string,  default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
 	; num_cases: optional, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
 	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -99,7 +99,7 @@
 					weight_feature weight_feature
 					context_condition context_condition
 					context_precision_num_cases context_precision_num_cases
-					context_condition_precision context_precision_num_cases
+					context_condition_precision context_condition_precision
 					action_condition action_condition
 					action_num_cases action_num_cases
 					action_condition_precision action_condition_precision

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -52,8 +52,8 @@
 			action_feature (null)
 			robust_hyperparameters (null)
 			weight_feature (null)
-			condition (null)
-			holdout (false)
+			context_condition (null)
+			action_condition (null)
 			precision "exact"
 			num_cases (null)
 		)
@@ -72,27 +72,26 @@
 		)
 
 		(call !Return
-			(if (= condition (null))
-				(call !GetFeaturePredictionStats (assoc
-					stats stats
-					robust robust
-					action_feature action_feature
-					robust_hyperparameters robust_hyperparameters
-					weight_feature weight_feature
-				))
-
-				;else condition is present
+			(if (or context_condition action_condition)
 				(call !CalculateConditionalPredictionStats (assoc
 					stats stats
 					robust robust
 					action_feature action_feature
 					robust_hyperparameters robust_hyperparameters
 					weight_feature weight_feature
-					condition condition
+					context_condition context_condition
+					action_condition action_condition
 					precision precision
 					num_cases num_cases
 					num_robust_influence_samples_per_case num_robust_influence_samples_per_case
-					holdout holdout
+				))
+				;else no condition is present
+				(call !GetFeaturePredictionStats (assoc
+					stats stats
+					robust robust
+					action_feature action_feature
+					robust_hyperparameters robust_hyperparameters
+					weight_feature weight_feature
 				))
 			)
 		)
@@ -405,11 +404,11 @@
 			action_feature (null)
 			robust_hyperparameters (null)
 			weight_feature (null)
-			condition (null)
+			context_condition (null)
+			action_condition (null)
 			precision "exact"
 			num_cases (null)
 			num_robust_influence_samples_per_case (null)
-			holdout (false)
 		)
 
 		(if (= num_cases (null))
@@ -428,13 +427,24 @@
 		(declare (assoc
 			output_map (assoc)
 			warnings (assoc)
-			case_ids
-				(call !GetCasesByCondition (assoc
-					condition condition
-					condition_session (null)
-					precision precision
-					num_cases num_cases
-				))
+			action_condition_filter_query 
+				(if action_condition
+					(call !GetQueryByCondition (assoc
+						condition action_condition
+						precision precision
+						num_cases num_cases
+					))
+					(list)
+				)
+			context_condition_filter_query
+				(if context_condition
+					(call !GetQueryByCondition (assoc
+						condition context_condition
+						precision precision
+						num_cases num_cases
+					))
+					(list)
+				)
 			context_features (filter (lambda (!= action_feature (current_value))) !trainedFeatures)
 			use_case_weights (!= (null) weight_feature)
 		))
@@ -477,14 +487,16 @@
 					temp_output
 						(call !CalculateFeatureResiduals (assoc
 							features features
-							case_ids case_ids
 							robust_residuals robust_hyperparameters
 							use_case_weights use_case_weights
 							weight_feature weight_feature
 							custom_hyperparam_map hyperparam_map
 							compute_all_statistics (!= basic_stats (list))
 							store_values (false)
-							holdout holdout
+							context_condition_filter_query context_condition_filter_query
+							action_condition_filter_query action_condition_filter_query
+							num_cases num_cases
+							precision precision
 						))
 				)
 				(if (contains_value stats "mae")

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -37,6 +37,7 @@
 	;			two values = inclusive between
 	;   	- for nominal or string ordinal features:
 	;			n values = must match any of these values exactly
+	; holdout: flag, optional. If set to true, the cases specified in 'condition' will be held out entirely when making predictions for calculating stats.
 	; precision: optional string,  default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
 	; num_cases: optional, limit on the number of cases to use in calculating conditional prediction stats; If set to zero there will be no limit.
 	;		If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
@@ -51,6 +52,7 @@
 			robust_hyperparameters (null)
 			weight_feature (null)
 			condition (null)
+			holdout (false)
 			precision "exact"
 			num_cases (null)
 		)
@@ -89,6 +91,7 @@
 					precision precision
 					num_cases num_cases
 					num_robust_influence_samples_per_case num_robust_influence_samples_per_case
+					holdout holdout
 				))
 			)
 		)
@@ -405,6 +408,7 @@
 			precision "exact"
 			num_cases (null)
 			num_robust_influence_samples_per_case (null)
+			holdout (false)
 		)
 
 		(if (= num_cases (null))
@@ -479,6 +483,7 @@
 							custom_hyperparam_map hyperparam_map
 							compute_all_statistics (!= basic_stats (list))
 							store_values (false)
+							holdout holdout
 						))
 				)
 				(if (contains_value stats "mae")

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -54,6 +54,10 @@
 			weight_feature (null)
 			context_condition (null)
 			action_condition (null)
+			action_condition_num_cases (null)
+			feature_condition_num_cases (null)
+			action_condition_precision "exact"
+			feature_condition_precision "exact"
 			precision "exact"
 			num_cases (null)
 		)
@@ -81,6 +85,10 @@
 					weight_feature weight_feature
 					context_condition context_condition
 					action_condition action_condition
+					action_condition_num_cases action_condition_num_cases
+					feature_condition_num_cases feature_condition_num_cases
+					action_condition_precision action_condition_precision
+					feature_condition_precision feature_condition_precision
 					precision precision
 					num_cases num_cases
 					num_robust_influence_samples_per_case num_robust_influence_samples_per_case
@@ -406,22 +414,11 @@
 			weight_feature (null)
 			context_condition (null)
 			action_condition (null)
-			precision "exact"
-			num_cases (null)
+			action_condition_num_cases (null)
+			feature_condition_num_cases (null)
+			action_condition_precision "exact"
+			feature_condition_precision "exact"
 			num_robust_influence_samples_per_case (null)
-		)
-
-		(if (= num_cases (null))
-			(if (= precision "similar")
-				(assign (assoc
-					num_cases (get hyperparam_map "k")
-				))
-
-				;else precision is exact
-				(assign (assoc
-					num_cases 1000
-				))
-			)
 		)
 
 		(declare (assoc
@@ -431,8 +428,8 @@
 				(if action_condition
 					(call !GetQueryByCondition (assoc
 						condition action_condition
-						precision precision
-						num_cases num_cases
+						precision action_condition_precision
+						num_cases action_condition_num_cases
 					))
 					(list)
 				)
@@ -440,8 +437,8 @@
 				(if context_condition
 					(call !GetQueryByCondition (assoc
 						condition context_condition
-						precision precision
-						num_cases num_cases
+						precision context_condition_precision
+						num_cases context_condition_num_cases
 					))
 					(list)
 				)
@@ -495,8 +492,8 @@
 							store_values (false)
 							context_condition_filter_query context_condition_filter_query
 							action_condition_filter_query action_condition_filter_query
-							num_cases num_cases
-							precision precision
+							context_condition_num_cases context_condition_num_cases
+							action_condition_num_cases action_condition_num_cases
 						))
 				)
 				(if (contains_value stats "mae")

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -340,7 +340,7 @@
 		)
 
 		;ensure features with nulls have cases that have values for computation but only if the selected cases were not conditioned
-		(if (and (not robust_residuals) (= (null) condition))
+		(if (and (not robust_residuals) (= (null) action_condition))
 			(let
 				(assoc not_null_feature_output_map (call !SelectNonNullCases) )
 
@@ -431,6 +431,17 @@
 		;keep a copy of all originally specified features
 		(assign (assoc case_features features))
 
+		(if (!= (size action_condition_filter_query) 0)
+			(assign (assoc
+				case_ids
+					(call !GetCasesByCondition (assoc
+						condition_filter_query action_condition_filter_query
+						precision precision
+						num_cases num_cases
+					))
+			))
+		)
+	
 		;if computing for one target_residual_feature, remove it from features so it's never in the context
 		(if target_residual_feature
 			(assign (assoc
@@ -502,21 +513,6 @@
 							)
 						)
 
-						;if holding out, filter out all case ids provided
-						(declare (assoc
-							filtering_list
-								(if holdout 
-									case_ids
-									(list case_id) 
-								)
-						))	
-
-						(if focal_case
-							(assign (assoc
-								filtering_list (append filtering_list (list focal_case))
-							))
-						)
-
 						(assign (assoc
 							local_cases_map
 								;if empty context set, use global expected values for all features, set local_cases_map to null
@@ -525,8 +521,19 @@
 
 									;else compute the local model around the case using the robust set of react_context_features
 									(compute_on_contained_entities (append
-										(query_not_in_entity_list filtering_list)
-
+										(if focal_case
+											(query_not_in_entity_list (list case_id focal_case))
+											(query_not_in_entity_list (list case_id))
+										)
+										(if (!= (size context_condition_filter_query) 0)
+											context_condition_filter_query
+											(list)
+										)									
+										;If we only have 'action_condition_filter_query', then do not filter on any action condition.
+										(if (!= (size context_condition_filter_query) 0)
+											action_condition_filter_query
+											(list)
+										)			
 										time_series_filter_query
 										(query_nearest_generalized_distance
 											k_parameter
@@ -706,6 +713,17 @@
 
 		(declare (assoc features_map (zip features) ))
 
+		(if (!= (size action_condition_filter_query) 0)
+			(assign (assoc
+				case_ids
+					(call !GetCasesByCondition (assoc
+						condition_filter_query action_condition_filter_query
+						precision precision
+						num_cases num_cases
+					))
+			))
+		)
+
 		(assign (assoc
 			feature_residuals_lists
 				||(map
@@ -757,27 +775,21 @@
 										))
 									)
 
-									;if holding out, filter out all case ids provided
-									(declare (assoc
-										filtering_list
-											(if holdout 
-												case_ids
-												(list case_id) 
-											)
-									))	
-
-									(if focal_case
-										(assign (assoc
-											filtering_list (append filtering_list (list focal_case))
-										))
-									)
-									
 									(declare (assoc
 										candidate_cases_lists
 											(compute_on_contained_entities (append
-												(query_not_in_entity_list filtering_list)
+												(if focal_case
+													(query_not_in_entity_list (list case_id focal_case))
+													(query_not_in_entity_list (list case_id))
+												)									
 												(if ignore_null_action_feature
 													(query_not_equals feature (null))
+													(list)
+												)
+												context_condition_filter_query								
+												;If we only have 'action_condition_filter_query', then do not filter on any action condition.
+												(if (not context_condition_filter_query)
+													action_condition_filter_query
 													(list)
 												)
 												time_series_filter_query

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -759,8 +759,11 @@
 
 									;if holding out, filter out all case ids provided
 									(declare (assoc
-										filtering_list 
-										(if holdout case_ids (list case_id) )
+										filtering_list
+											(if holdout 
+												case_ids
+												(list case_id) 
+											)
 									))	
 
 									(if focal_case

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -447,9 +447,9 @@
 		)
 
 		;Ensure enough cases
-		(if (< (size case_ids) 30) 
+		(if (< (size case_ids) 2000) 
 			(assign (assoc 
-				case_ids (rand case_ids 30)
+				case_ids (rand case_ids 2000)
 			))
 		)
 

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -432,7 +432,7 @@
 		(assign (assoc case_features features))
 
 		;if 'case_ids' are not set, then use 'action_condition_filter_query' to get the case ids of the action set, otherwise
-		;flag that 'case_ids' were provided so 'action_condition_filter_query' is ignored.
+		;flag that 'case_ids' were provided so 'action_condition_filter_query' is ignored. 'case_ids' supercedes 'action_condition_filter_query'.
 		(if (= (size case_ids) 0)
 			(assign (assoc
 				case_ids
@@ -445,7 +445,14 @@
 				provided_case_id_flag (true)
 			))
 		)
-	
+
+		;Ensure enough cases
+		(if (< (size case_ids) 30) 
+			(assign (assoc 
+				case_ids (rand case_ids 30)
+			))
+		)
+
 		;if computing for one target_residual_feature, remove it from features so it's never in the context
 		(if target_residual_feature
 			(assign (assoc
@@ -529,12 +536,21 @@
 											(query_not_in_entity_list (list case_id focal_case))
 											(query_not_in_entity_list (list case_id))
 										)
-										;if both action and context filter queries are provided while 'case_ids' were not provided at the beginning of the function, 
-										;only query the cases specifed by the context filter query, effectively holding out the action set. Otherwise query everything.
-										(if (and 
-												(not provided_case_id_flag)
-												(!= (size action_condition_filter_query) 0)
-												(!= (size context_condition_filter_query) 0)
+										;Only query the cases filtered by the 'context_condition_filter_query' if both action and context filter queries are provided and 'case_ids' 
+										;were not provided at the beginning of the function, or if only the 'context_condition_filter_query' is provided. Otherwise query everything.
+										;This is due to the performance issues when using 'query_not_in_entity_list' from a large list of 'case_ids'.
+										(if 
+											(or
+												(and 
+													(not provided_case_id_flag)
+													(!= (size action_condition_filter_query) 0)
+													(!= (size context_condition_filter_query) 0)
+												)
+												(and
+													(not provided_case_id_flag)
+													(!= (size context_condition_filter_query) 0)
+													(= (size action_condition_filter_query) 0)
+												)
 											)
 											context_condition_filter_query
 											(list)
@@ -795,12 +811,21 @@
 													(query_not_equals feature (null))
 													(list)
 												)
-												;if both action and context filter queries are provided while 'case_ids' were not provided at the beginning of the function, 
-												;only query the cases specifed by the context filter query, effectively holding out the action set. Otherwise query everything.
-												(if (and 
-														(not provided_case_id_flag)
-														(!= (size action_condition_filter_query) 0)
-														(!= (size context_condition_filter_query) 0)
+												;Only query the cases filtered by the 'context_condition_filter_query' if both action and context filter queries are provided and 'case_ids' 
+												;were not provided at the beginning of the function, or if only the 'context_condition_filter_query' is provided. Otherwise query everything.
+												;This is due to the performance issues when using 'query_not_in_entity_list' from a large list of 'case_ids'.
+												(if 
+													(or
+														(and 
+															(not provided_case_id_flag)
+															(!= (size action_condition_filter_query) 0)
+															(!= (size context_condition_filter_query) 0)
+														)
+														(and
+															(not provided_case_id_flag)
+															(!= (size context_condition_filter_query) 0)
+															(= (size action_condition_filter_query) 0)
+														)
 													)
 													context_condition_filter_query
 													(list)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -311,7 +311,7 @@
 		))
 
 		;if case_ids weren't specified either, use a random num_samples sampling of cases from the whole model
-		(if (= 0 (size case_ids))
+		(if (and (= 0 (size case_ids)) (= 0 (size action_condition_filter_query)))
 			(assign (assoc
 				case_ids
 					;if there are more cases than the sample size, randomly select that many cases, by default cases are in random order
@@ -340,7 +340,7 @@
 		)
 
 		;ensure features with nulls have cases that have values for computation but only if the selected cases were not conditioned
-		(if (and (not robust_residuals) (= (null) action_condition))
+		(if (and (not robust_residuals) (= 0 (size action_condition_filter_query)))
 			(let
 				(assoc not_null_feature_output_map (call !SelectNonNullCases) )
 
@@ -431,13 +431,14 @@
 		;keep a copy of all originally specified features
 		(assign (assoc case_features features))
 
+		;if 'action_condition_filter_query' contains queries, then ensure 'case_ids' match
 		(if (!= (size action_condition_filter_query) 0)
 			(assign (assoc
 				case_ids
 					(call !GetCasesByCondition (assoc
 						condition_filter_query action_condition_filter_query
-						precision precision
-						num_cases num_cases
+						precision action_condition_precision
+						num_cases action_condition_num_cases
 					))
 			))
 		)
@@ -525,15 +526,15 @@
 											(query_not_in_entity_list (list case_id focal_case))
 											(query_not_in_entity_list (list case_id))
 										)
-										(if (!= (size context_condition_filter_query) 0)
+										;if both action and context filter queries are provided, only query
+										;the cases specifed by the context filter query, otherwise query everything.
+										(if (and 
+												(!= (size action_condition_filter_query) 0)
+												(!= (size context_condition_filter_query) 0)
+											)
 											context_condition_filter_query
 											(list)
-										)									
-										;If we only have 'action_condition_filter_query', then do not filter on any action condition.
-										(if (!= (size context_condition_filter_query) 0)
-											action_condition_filter_query
-											(list)
-										)			
+										)		
 										time_series_filter_query
 										(query_nearest_generalized_distance
 											k_parameter
@@ -713,13 +714,14 @@
 
 		(declare (assoc features_map (zip features) ))
 
+		;if 'action_condition_filter_query' contains queries, then ensure 'case_ids' match
 		(if (!= (size action_condition_filter_query) 0)
 			(assign (assoc
 				case_ids
 					(call !GetCasesByCondition (assoc
 						condition_filter_query action_condition_filter_query
-						precision precision
-						num_cases num_cases
+						precision action_condition_precision
+						num_cases action_condition_num_cases
 					))
 			))
 		)
@@ -786,12 +788,15 @@
 													(query_not_equals feature (null))
 													(list)
 												)
-												context_condition_filter_query								
-												;If we only have 'action_condition_filter_query', then do not filter on any action condition.
-												(if (not context_condition_filter_query)
-													action_condition_filter_query
+												;if both action and context filter queries are provided, only query
+												;the cases specifed by the context filter query, otherwise query everything.
+												(if (and 
+														(!= (size action_condition_filter_query) 0)
+														(!= (size context_condition_filter_query) 0)
+													)
+													context_condition_filter_query
 													(list)
-												)
+												)	
 												time_series_filter_query
 												(query_nearest_generalized_distance
 													k_parameter

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -502,6 +502,18 @@
 							)
 						)
 
+						;if holding out, filter out all case ids provided
+						(declare (assoc
+							filter 
+							(if holdout case_ids (list case_id) )
+						))	
+
+						(if focal_case
+							(assign (assoc
+								filter (append filter (list focal_case))
+							))
+						)
+
 						(assign (assoc
 							local_cases_map
 								;if empty context set, use global expected values for all features, set local_cases_map to null
@@ -510,10 +522,8 @@
 
 									;else compute the local model around the case using the robust set of react_context_features
 									(compute_on_contained_entities (append
-										(if focal_case
-											(query_not_in_entity_list (list case_id focal_case))
-											(query_not_in_entity_list (list case_id))
-										)
+										(query_not_in_entity_list filter)
+
 										time_series_filter_query
 										(query_nearest_generalized_distance
 											k_parameter
@@ -744,13 +754,22 @@
 										))
 									)
 
+									;if holding out, filter out all case ids provided
+									(declare (assoc
+										filter 
+										(if holdout case_ids (list case_id) )
+									))	
+
+									(if focal_case
+										(assign (assoc
+											filter (append filter (list focal_case))
+										))
+									)
+									
 									(declare (assoc
 										candidate_cases_lists
 											(compute_on_contained_entities (append
-												(if focal_case
-													(query_not_in_entity_list (list case_id focal_case))
-													(query_not_in_entity_list (list case_id))
-												)
+												(query_not_in_entity_list filter)
 												(if ignore_null_action_feature
 													(query_not_equals feature (null))
 													(list)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -505,7 +505,10 @@
 						;if holding out, filter out all case ids provided
 						(declare (assoc
 							filtering_list
-							(if holdout case_ids (list case_id) )
+								(if holdout 
+									case_ids
+									(list case_id) 
+								)
 						))	
 
 						(if focal_case

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -310,7 +310,7 @@
 			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
 		))
 
-		;if case_ids weren't specified either, use a random num_samples sampling of cases from the whole model
+		;if 'case_id' and 'action_condition_filter_query' are not specified either, use a random 'num_samples' sampling of cases from the whole model
 		(if (and (= 0 (size case_ids)) (= 0 (size action_condition_filter_query)))
 			(assign (assoc
 				case_ids
@@ -431,15 +431,18 @@
 		;keep a copy of all originally specified features
 		(assign (assoc case_features features))
 
-		;if 'action_condition_filter_query' contains queries, then ensure 'case_ids' match
-		(if (!= (size action_condition_filter_query) 0)
+		;if 'case_ids' are not set, then use 'action_condition_filter_query' to get the case ids of the action set, otherwise
+		;flag that 'case_ids' were provided so 'action_condition_filter_query' is ignored.
+		(if (= (size case_ids) 0)
 			(assign (assoc
 				case_ids
 					(call !GetCasesByCondition (assoc
 						condition_filter_query action_condition_filter_query
-						precision action_condition_precision
-						num_cases action_condition_num_cases
+						num_cases num_samples
 					))
+			))
+			(declare (assoc
+				provided_case_id_flag (true)
 			))
 		)
 	
@@ -526,9 +529,10 @@
 											(query_not_in_entity_list (list case_id focal_case))
 											(query_not_in_entity_list (list case_id))
 										)
-										;if both action and context filter queries are provided, only query
-										;the cases specifed by the context filter query, otherwise query everything.
+										;if both action and context filter queries are provided while 'case_ids' were not provided at the beginning of the function, 
+										;only query the cases specifed by the context filter query, effectively holding out the action set. Otherwise query everything.
 										(if (and 
+												(not provided_case_id_flag)
 												(!= (size action_condition_filter_query) 0)
 												(!= (size context_condition_filter_query) 0)
 											)
@@ -714,15 +718,18 @@
 
 		(declare (assoc features_map (zip features) ))
 
-		;if 'action_condition_filter_query' contains queries, then ensure 'case_ids' match
-		(if (!= (size action_condition_filter_query) 0)
+		;if 'case_ids' are not set, then use 'action_condition_filter_query' to get the case ids of the action set, otherwise
+		;flag that 'case_ids' were provided so 'action_condition_filter_query' is ignored.
+		(if (= (size case_ids) 0)
 			(assign (assoc
 				case_ids
 					(call !GetCasesByCondition (assoc
 						condition_filter_query action_condition_filter_query
-						precision action_condition_precision
-						num_cases action_condition_num_cases
+						num_cases num_samples
 					))
+			))
+			(declare (assoc
+				provided_case_id_flag (true)
 			))
 		)
 
@@ -788,9 +795,10 @@
 													(query_not_equals feature (null))
 													(list)
 												)
-												;if both action and context filter queries are provided, only query
-												;the cases specifed by the context filter query, otherwise query everything.
+												;if both action and context filter queries are provided while 'case_ids' were not provided at the beginning of the function, 
+												;only query the cases specifed by the context filter query, effectively holding out the action set. Otherwise query everything.
 												(if (and 
+														(not provided_case_id_flag)
 														(!= (size action_condition_filter_query) 0)
 														(!= (size context_condition_filter_query) 0)
 													)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -504,13 +504,13 @@
 
 						;if holding out, filter out all case ids provided
 						(declare (assoc
-							filter 
+							filtering_list
 							(if holdout case_ids (list case_id) )
 						))	
 
 						(if focal_case
 							(assign (assoc
-								filter (append filter (list focal_case))
+								filtering_list (append filtering_list (list focal_case))
 							))
 						)
 
@@ -522,7 +522,7 @@
 
 									;else compute the local model around the case using the robust set of react_context_features
 									(compute_on_contained_entities (append
-										(query_not_in_entity_list filter)
+										(query_not_in_entity_list filtering_list)
 
 										time_series_filter_query
 										(query_nearest_generalized_distance
@@ -756,20 +756,20 @@
 
 									;if holding out, filter out all case ids provided
 									(declare (assoc
-										filter 
+										filtering_list 
 										(if holdout case_ids (list case_id) )
 									))	
 
 									(if focal_case
 										(assign (assoc
-											filter (append filter (list focal_case))
+											filtering_list (append filtering_list (list focal_case))
 										))
 									)
 									
 									(declare (assoc
 										candidate_cases_lists
 											(compute_on_contained_entities (append
-												(query_not_in_entity_list filter)
+												(query_not_in_entity_list filtering_list)
 												(if ignore_null_action_feature
 													(query_not_equals feature (null))
 													(list)

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -324,5 +324,24 @@
 		percent 0.5
 	))
 
+	(assign (assoc
+		result
+			(call_entity "howso" "get_prediction_stats" (assoc
+				"robust" (false)
+				"stats" (list "accuracy")
+				"holdout" (true)
+				"precision" "exact"
+				"condition" (assoc "fruit" (list "apple"))
+			))
+	))
+	(call keep_result_payload)
+
+	; holding out all of one fruit type should result in not being able to predict that fruit correctly
+	(print "Output conditioned prediction stats for fruits using holdout correctly: ")
+	(call assert_same (assoc
+		obs (get result "fruit")
+		exp (assoc accuracy 0)
+	))
+
 	(call exit_if_failures (assoc msg unit_test_name ))
 )

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -328,10 +328,10 @@
 		result
 			(call_entity "howso" "get_prediction_stats" (assoc
 				"robust" (false)
-				"stats" (list "accuracy")
+				"stats" (list "accuracy" "precision")
 				"holdout" (true)
 				"precision" "exact"
-				"context_condition" (assoc "fruit" (list "strawberry" "melon" "pineapple" "banana"))
+				"context_condition" (assoc "fruit" (list "strawberry" "banana"))
 				"action_condition" (assoc "fruit" (list "apple"))
 			))
 	))
@@ -341,7 +341,7 @@
 	(print "Output conditioned prediction stats for fruits using holdout correctly: ")
 	(call assert_same (assoc
 		obs (get result "fruit")
-		exp (assoc accuracy 0)
+		exp (assoc accuracy 0 precision 0)
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -338,10 +338,31 @@
 	(call keep_result_payload)
 
 	; holding out all of one fruit type should result in not being able to predict that fruit correctly
-	(print "Output conditioned prediction stats for fruits using holdout correctly: ")
+	(print "Output conditioned prediction stats for fruits with disjoint datasets correctly: ")
 	(call assert_same (assoc
 		obs (get result "fruit")
 		exp (assoc accuracy 0 precision 0)
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "get_prediction_stats" (assoc
+				"robust" (false)
+				"stats" (list "accuracy" "precision")
+				"holdout" (true)
+				"precision" "exact"
+				"context_condition" (assoc "size" (list "medium"))
+				"action_condition" (assoc "size" (list "small"))
+			))
+	))
+	(call keep_result_payload)
+
+	; Using only medium fruits to predict small fruits should result in 3/7 correct, which is every fruit with both small and medium sizes.
+	(print "Output conditioned prediction stats for fruits with overlap correctly: ")
+	(call assert_approximate (assoc
+		obs (get result "fruit")
+		exp (assoc accuracy 0.42 precision 0.75)
+		percent 0.05
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -79,10 +79,10 @@
 	))
 
 	(assign (assoc
-		result (call_entity "howso" "get_marginal_stats" (assoc action_condition (assoc fruit "pineapple")))
+		result (call_entity "howso" "get_marginal_stats" (assoc condition (assoc fruit "pineapple")))
 	))
 	(call keep_result_payload)
-	(print "Correct Action Conditioned Marginal Stats: ")
+	(print "Correct Conditioned Marginal Stats: ")
 	(call assert_equal (assoc
 		obs (unzip (get result  "fruit") (list "count" "mode" "uniques" "entropy"))
 		exp (list 4 "pinenapple" 1 0)

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -79,10 +79,10 @@
 	))
 
 	(assign (assoc
-		result (call_entity "howso" "get_marginal_stats" (assoc condition (assoc fruit "pineapple")))
+		result (call_entity "howso" "get_marginal_stats" (assoc action_condition (assoc fruit "pineapple")))
 	))
 	(call keep_result_payload)
-	(print "Correct Conditioned Marginal Stats: ")
+	(print "Correct Action Conditioned Marginal Stats: ")
 	(call assert_equal (assoc
 		obs (unzip (get result  "fruit") (list "count" "mode" "uniques" "entropy"))
 		exp (list 4 "pinenapple" 1 0)
@@ -265,13 +265,13 @@
 				"stats" (list "accuracy" "precision" "recall" "mae" "r2")
 				"robust" (false)
 				"robust_hyperparameters" (false)
-				"condition" (assoc "fruit" (list "peach" "melon") )
+				"action_condition" (assoc "fruit" (list "peach" "melon") )
 				"precision" "exact"
 			))
 	))
 	(call keep_result_payload)
 
-	(print "Output all conditioned prediction stats correctly: ")
+	(print "Output all action conditioned prediction stats correctly: ")
 	(call assert_approximate (assoc
 		obs result
 		exp
@@ -331,7 +331,8 @@
 				"stats" (list "accuracy")
 				"holdout" (true)
 				"precision" "exact"
-				"condition" (assoc "fruit" (list "apple"))
+				"context_condition" (assoc "fruit" (list "strawberry" "melon" "pineapple" "banana"))
+				"action_condition" (assoc "fruit" (list "apple"))
 			))
 	))
 	(call keep_result_payload)


### PR DESCRIPTION
Adds action_condition and context_condition parameter, along with several other parameters that accompanies those parameters. This allows the user to specify the action set and the context set. 

Also internally modifies CalculateFeatureResiduals to accept similar parameters.