### PR TITLE
20285: Adds support for sparse deviation matrix in hyperparameters, MINOR

### DIFF
--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -915,7 +915,7 @@
 		(assoc
 			deviation_value
 				(if feature_is_nominal
-					;if the deviation is an assoc containing a SDM, pull the expected deviation value from it
+					;if the deviation is an assoc containing a sparse deviation matrix, pull the expected deviation value from it
 					(if (~ (assoc) feature_deviation)
 						(get feature_deviation "expected_deviation")
 

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -890,6 +890,7 @@
 										0
 
 										(call !ConvertDeviationToFeatureWeight (assoc
+											feature_is_nominal (contains_index !nominalsMap (current_index 1) )
 											feature_deviation (current_value 1)
 											p_value (get output_map "p")
 										))
@@ -906,6 +907,7 @@
 
 	;helper method to convert deviation value to feature weight given a deviation and p value
 	;parameters:
+	; feature_is_nominal: flag, set to true if feature is nominal
 	; feature_deviation: value or tuple as passed in from the hyperparameter map
 	; p_value: p value from the hyperarameter map
 	#!ConvertDeviationToFeatureWeight
@@ -913,8 +915,26 @@
 		(assoc
 			deviation_value
 				;deviation may be a tuple if it contains null uncertainties
-				(if (= (list) (get_type feature_deviation))
-					(first feature_deviation)
+				(if (~ (list) feature_deviation)
+					;if nominal, make sure to grab deviation and not sparse deviation matrix
+					(if feature_is_nominal
+
+						;if first value is a tuple that contains the SDM, grab the value instead of the SDM
+						(if (~ (list) (first feature_deviation))
+							(get (first feature_deviation) 1)
+
+							;if first value is the SDM, grab the value instead of the SDM
+							(~ (assoc) (first feature_deviation))
+							(get feature_deviation 1)
+
+							;else just return the value
+							(first feature_deviation)
+						)
+
+						;else continuous, grab first value which is the actual devitaion
+						(first feature_deviation)
+					)
+					;else it's a single value, use it as-is
 					feature_deviation
 				)
 		)
@@ -1071,6 +1091,7 @@
 									0
 
 									(call !ConvertDeviationToFeatureWeight (assoc
+										feature_is_nominal (contains_index !nominalsMap (current_index 1) )
 										feature_deviation (current_value 1)
 										p_value p_value
 									))

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -914,27 +914,15 @@
 	(let
 		(assoc
 			deviation_value
-				;deviation may be a tuple if it contains null uncertainties
-				(if (~ (list) feature_deviation)
-					;if nominal, make sure to grab deviation and not sparse deviation matrix
-					(if feature_is_nominal
+				(if feature_is_nominal
+					;if the deviation is an assoc containing a SDM, pull the expected deviation value from it
+					(if (~ (assoc) feature_deviation)
+						(get feature_deviation "expected_deviation")
 
-						;if first value is a tuple that contains the SDM, grab the value instead of the SDM
-						(if (~ (list) (first feature_deviation))
-							(get (first feature_deviation) 1)
-
-							;if first value is the SDM, grab the value instead of the SDM
-							(~ (assoc) (first feature_deviation))
-							(get feature_deviation 1)
-
-							;else just return the value
-							(first feature_deviation)
-						)
-
-						;else continuous, grab first value which is the actual devitaion
-						(first feature_deviation)
+						feature_deviation
 					)
-					;else it's a single value, use it as-is
+
+					;else continuous
 					feature_deviation
 				)
 		)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -43,6 +43,7 @@
 	; use_case_weights: optional, default is null. when true will scale influence weights by each case's weight_feature weight. if use_case_weights isn't specified, it will
 	;				   be true if auto ablation is enabled and false otherwise
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
+	; use_sdm: optional flag, default is false. if set to true, uses sparse deviation matrix for nominal deviations.
 	;
 	; returns success when completed
 	#analyze
@@ -54,6 +55,7 @@
 			weight_feature ".case_weight"
 			use_case_weights (null)
 			inverse_residuals_as_weights (null)
+			use_sdm (false)
 		)
 
 		(call !ValidateFeatures)
@@ -168,6 +170,7 @@
 				residual_num_samples (if (> num_samples 0) num_samples 200)
 				use_case_weights use_case_weights
 				weight_feature weight_feature
+				use_sdm use_sdm
 			))
 		)
 

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -47,12 +47,14 @@
 										num_samples
 									)
 								custom_hyperparam_map baseline_hyperparameter_map
+								compute_all_statistics (true)
 							))
 					))
 			))
 
 			(call !UpdateHyperparameters (assoc
 				feature_deviations (get residuals_map "residual_map")
+				confusion_matrix_map (get residuals_map (list "prediction_stats" "confusion_matrix"))
 				ordinal_feature_deviations (get residuals_map "ordinal_residual_map")
 				null_deviations (get residuals_map (list "hyperparam_map" "!nullUncertaintyMap"))
 				use_deviations use_deviations
@@ -329,6 +331,7 @@
 											(max residual_num_samples num_samples_converge)
 										)
 									custom_hyperparam_map baseline_hyperparameter_map
+									compute_all_statistics (true)
 								))
 						))
 					)
@@ -336,6 +339,7 @@
 
 			(call !UpdateHyperparameters (assoc
 				feature_deviations (get residuals_map "residual_map")
+				confusion_matrix_map (get residuals_map (list "prediction_stats" "confusion_matrix"))
 				ordinal_feature_deviations (get residuals_map "ordinal_residual_map")
 				null_deviations (get residuals_map (list "hyperparam_map" "!nullUncertaintyMap"))
 				use_deviations use_deviations

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -47,14 +47,15 @@
 										num_samples
 									)
 								custom_hyperparam_map baseline_hyperparameter_map
-								compute_all_statistics (true)
+								;must compute confusion matrix to use sparse deviation matrix
+								compute_all_statistics use_sdm
 							))
 					))
 			))
 
 			(call !UpdateHyperparameters (assoc
 				feature_deviations (get residuals_map "residual_map")
-				confusion_matrix_map (get residuals_map (list "prediction_stats" "confusion_matrix"))
+				confusion_matrix_map (if use_sdm (get residuals_map (list "prediction_stats" "confusion_matrix")) )
 				ordinal_feature_deviations (get residuals_map "ordinal_residual_map")
 				null_deviations (get residuals_map (list "hyperparam_map" "nullUncertaintyMap"))
 				use_deviations use_deviations
@@ -331,7 +332,8 @@
 											(max residual_num_samples num_samples_converge)
 										)
 									custom_hyperparam_map baseline_hyperparameter_map
-									compute_all_statistics (true)
+									;must compute confusion matrix to use sparse deviation matrix
+									compute_all_statistics use_sdm
 								))
 						))
 					)
@@ -339,7 +341,7 @@
 
 			(call !UpdateHyperparameters (assoc
 				feature_deviations (get residuals_map "residual_map")
-				confusion_matrix_map (get residuals_map (list "prediction_stats" "confusion_matrix"))
+				confusion_matrix_map (if use_sdm (get residuals_map (list "prediction_stats" "confusion_matrix")) )
 				ordinal_feature_deviations (get residuals_map "ordinal_residual_map")
 				null_deviations (get residuals_map (list "hyperparam_map" "nullUncertaintyMap"))
 				use_deviations use_deviations

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -56,7 +56,7 @@
 				feature_deviations (get residuals_map "residual_map")
 				confusion_matrix_map (get residuals_map (list "prediction_stats" "confusion_matrix"))
 				ordinal_feature_deviations (get residuals_map "ordinal_residual_map")
-				null_deviations (get residuals_map (list "hyperparam_map" "!nullUncertaintyMap"))
+				null_deviations (get residuals_map (list "hyperparam_map" "nullUncertaintyMap"))
 				use_deviations use_deviations
 			))
 
@@ -341,7 +341,7 @@
 				feature_deviations (get residuals_map "residual_map")
 				confusion_matrix_map (get residuals_map (list "prediction_stats" "confusion_matrix"))
 				ordinal_feature_deviations (get residuals_map "ordinal_residual_map")
-				null_deviations (get residuals_map (list "hyperparam_map" "!nullUncertaintyMap"))
+				null_deviations (get residuals_map (list "hyperparam_map" "nullUncertaintyMap"))
 				use_deviations use_deviations
 				feature_weights
 					(map

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -801,6 +801,9 @@
 				)
 		))
 
+		(if (= (null) param_path)
+			(declare (assoc param_path (get hyperparam_map "paramPath")))
+		)
 
 		(declare (assoc
 			prediction_stats
@@ -835,10 +838,10 @@
 				))
 				(call !UpdateHyperparametersWithResiduals)
 			)
-
-			;else return values
-			prediction_stats
 		)
+
+		;return values
+		prediction_stats
 	)
 
 	;helper method for CalculateFeatureResiduals to average out the list(s) of residual values into individual value(s)
@@ -979,5 +982,8 @@
 				)
 			)
 		)
+
+		;return null prediction_stats
+		(null)
 	)
 )

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -249,7 +249,7 @@
 	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	; num_samples: optional, limit on the number of cases for the action set to use in calculating conditional residuals. Works with or without 'action_condition_filter_query'. If
 	; 		'action_condition_filter_query' is not provided, will be ignored if 'case_ids' is provided.
-	; context_condition_filter_query: optional list of filtering queries for the context set. Ignored if 'action_condition_filter_query' is not specified. 
+	; context_condition_filter_query: optional list of filtering queries for the context set. Ignored if 'action_condition_filter_query' is not specified.
 	;		If both 'action_condition_filter_query' and 'context_condition_filter_query' are specified, then all of the cases selected by the 'action_condition_filter_query'
 	;		will be excluded from the context set, effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	; focal_case: optional case id of case for which to compute residuals for  is to be ignored during computation
@@ -270,7 +270,7 @@
 			focal_case (null)
 			robust_residuals (false)
 
-			;ordered by priority for the action set, with the 'case_ids' parameters having the top priority. 
+			;ordered by priority for the action set, with the 'case_ids' parameters having the top priority.
 			case_ids (list)
 			action_condition_filter_query (list)
 			context_condition_filter_query (list)
@@ -796,7 +796,7 @@
 												)
 											))
 									)
-									
+
 									;calculates the mcc
 									(declare (assoc
 										mcc_numerator
@@ -977,15 +977,16 @@
 									;update deviation value with null uncertainies
 									(if (contains_index null_uncertainties_map (current_index))
 										(if (~ (list) (current_value))
-											;if the deviation is an assoc, it must be an SDM, wrap it in a list so that the output is a triple
-											;in the format of [sdm, null-value, null-null] instead of appending as keys to assoc
-											(if (~ (assoc) (first (current_value)))
+											;if the deviation is a number, wrap it in a triple
+											(if (or (~ 0 (first (current_value))) (= (null) (first (current_value))) )
+												(append (first (current_value)) (get null_uncertainties_map (current_index)) )
+
+												;else the deviation must be a SDM, wrap it in a list so that the output is a triple
+												;in the format of [sdm, null-value, null-null] instead of appending null uncertaintes to the SDM
 												(append
 													(list (first (current_value 1)))
 													(get null_uncertainties_map (current_index))
 												)
-
-												(append (first (current_value)) (get null_uncertainties_map (current_index)) )
 											)
 											(append (list (current_value 1)) (get null_uncertainties_map (current_index)) )
 										)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -957,8 +957,17 @@
 								(lambda
 									;update deviation value with null uncertainies
 									(if (contains_index null_uncertainties_map (current_index))
-										(if (= (list) (get_type (current_value)))
-											(append (first (current_value)) (get null_uncertainties_map (current_index)) )
+										(if (~ (list) (current_value))
+											;if the deviation is an assoc, it must be an SDM, wrap it in a list so that the output is a triple
+											;in the format of [sdm, null-value, null-null] instead of appending as keys to assoc
+											(if (~ (assoc) (first (current_value)))
+												(append
+													(list (first (current_value 1)))
+													(get null_uncertainties_map (current_index))
+												)
+
+												(append (first (current_value)) (get null_uncertainties_map (current_index)) )
+											)
 											(append (list (current_value 1)) (get null_uncertainties_map (current_index)) )
 										)
 

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -998,6 +998,17 @@
 		(declare (assoc
 			;map of class -> accuracy of random guessing
 			rand_guess_accuracy_map (map (lambda (/ (current_value) total_predictions)) predictions_per_class_map)
+			all_classes_map
+				(compute_on_contained_entities (list
+					(query_value_masses
+						feature
+						(null)
+						(or
+							(not (contains_index !nominalsMap feature))
+							(contains_index !numericNominalFeaturesMap feature)
+						)
+					)
+				))
 		))
 
 		;filter out counts below threshold in confusion matrix and store as probabilities correct instead of counts
@@ -1008,22 +1019,7 @@
 			(conclude (null))
 		)
 
-		(declare (assoc
-			all_classes
-				(indices
-					(compute_on_contained_entities (list
-						(query_value_masses
-							feature
-							(null)
-							(or
-								(not (contains_index !nominalsMap feature))
-								(contains_index !numericNominalFeaturesMap feature)
-							)
-						)
-					))
-				)
-		))
-		(declare (assoc num_classes (size all_classes) ))
+		(declare (assoc num_classes (size all_classes_map) ))
 
 		;average all probabilities for a class that are same as or more than the predicted class probability
 		(declare (assoc
@@ -1036,7 +1032,7 @@
 								(filter
 									(lambda (>= (current_value) predicted_class_prob))
 									(values
-										(append (zip all_classes 0) (current_value 1))
+										(append (zip (indices all_classes_map) 0) (current_value 1))
 									)
 								)
 						))
@@ -1196,19 +1192,6 @@
 				)
 		))
 
-	`	;weighted accuracy for each class is its predicted probability * random guess accuracy
-		(declare (assoc
-			weighted_accuracy_map
-				(map
-					(lambda (let
-						(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
-						(* predicted_class_prob (get rand_guess_accuracy_map (current_index)) )
-					))
-					confusion_matrix
-				)
-		))
-		(declare (assoc avg_accuracy (apply "+" (values weighted_accuracy_map)) ))
-
 		(assign (assoc
 			leftover_unknown_class_deviation
 				(if (>= total_leftover_correct_predictions smallest_count_threshold)
@@ -1216,9 +1199,51 @@
 
 					;else don't have enough enough leftover counts to compute unknown class deviation, use weighted random chance
 					(> total_leftover_all_predictions total_leftover_correct_predictions)
-					(- 1 avg_accuracy)
+					(let
+						(assoc
+							non_sdm_classes (indices (remove all_classes_map (indices confusion_matrix)) )
+						)
+						(if (size non_sdm_classes)
+							(let
+								(assoc total_count (apply "+" (values all_classes_map)) )
 
-					;else value remains as  null if there are no leftover counts
+								;rand guess prob of classes not in sdm : 1 - sum of prob^2
+								(- 1
+									(apply "+"
+										(map
+											(lambda
+												(pow
+													(/ (get all_classes_map (current_value)) total_count)
+													2
+												)
+											)
+											non_sdm_classes
+										)
+									)
+								)
+							)
+
+							;else:
+							(let
+								(assoc
+									weighted_accuracy_map
+										;weighted accuracy for each class is its predicted probability * random guess accuracy
+										(map
+											(lambda (let
+												(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
+												(* predicted_class_prob (get rand_guess_accuracy_map (current_index)) )
+											))
+											confusion_matrix
+										)
+								)
+								;1 - average accuracy
+								(- 1 (apply "+" (values weighted_accuracy_map)))
+							)
+						)
+					)
+
+					;else value remains as null if there are no leftover counts
+					;TODO: what if only leftovers are predicted classes?
 					(null)
 				)
 		))
@@ -1255,7 +1280,7 @@
 								)
 							)
 							;iterate over all_classes since every row needs to have a value for every class even if it's 0
-							(zip all_classes)
+							all_classes_map
 						)
 					))
 					confusion_matrix

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -1059,65 +1059,14 @@
 					))
 					confusion_matrix
 				)
+
 			;map of class -> accuracy of random guessing
 			rand_guess_accuracy_map (map (lambda (/ (current_value) total_predictions)) predictions_per_class_map)
 		))
 
-		;indistinguishable accuracy
-		(declare (assoc
-			guessing_accuracy_matrix
-				(map
-					(lambda (let
-						(assoc
-							predicted_class (current_index 1)
-							row_map (current_value 1)
-						)
-						(map
-							(lambda
-								(if (= predicted_class (current_index))
-									(get prob_match_or_indistinguishable_map (current_index))
-
-									(min
-										(get prob_match_or_indistinguishable_map predicted_class)
-										(+ (or (get row_map (current_index))))
-									)
-								)
-							)
-							;iterate over all_classes since every row needs to have a value for every class even if it's 0
-							(zip all_classes)
-						)
-					))
-					confusion_matrix
-				)
-		))
-
-		;guessing clamped accuracy
-		(assign (assoc
-			guessing_accuracy_matrix
-				(map
-					(lambda (let
-						(assoc
-							predicted_class (current_index 1)
-							row_map (current_value 1)
-						)
-
-						(map
-							(lambda
-								(if (= predicted_class (current_index))
-									(max (get row_map predicted_class) (get rand_guess_accuracy_map predicted_class))
-
-									(min
-										(max smallest_prob (get row_map (current_index)))
-										(- 1 (get rand_guess_accuracy_map predicted_class) )
-									)
-								)
-							)
-							row_map
-						)
-					))
-					guessing_accuracy_matrix
-				)
-		))
+		;indistinguishable accuracy matrix
+		;Clamps predicted probabilities to random guesses
+		(declare (assoc guessing_accuracy_matrix (call !ClampSDMProbabilities) ))
 
 		;compute the full deviation matrix
 		(declare (assoc
@@ -1126,9 +1075,14 @@
 					(lambda (let
 						(assoc
 							predicted_class (current_index 1)
+							;probability of correct predicted class
 							class_probability (get (current_value 1) (current_index 1))
+							;total probability of the row
 							total_probability (apply "+" (values (current_value 1)) )
 						)
+
+						;normalize each prediction probability by iterating over all the predictions
+						;in the row and dividing by total_probability
 						(map
 							(lambda
 								(- 1 (/ (min class_probability (current_value)) total_probability))
@@ -1174,4 +1128,70 @@
 			deviation_matrix
 		)
 	)
+
+
+	;helper method for computing SDM that clamps probabilities for the predicted classes vs random guessing
+	#!ClampSDMProbabilities
+	(declare
+		(assoc
+			guessing_accuracy_matrix
+				;diagonal values are the probability of the match
+				;all other classes are their probability without exceeding the predicted class probability (corresponding diagonal value)
+				(map
+					(lambda (let
+						(assoc
+							predicted_class (current_index 1)
+							row_map (current_value 1)
+						)
+						(map
+							(lambda
+								(if (= predicted_class (current_index))
+									(get prob_match_or_indistinguishable_map (current_index))
+
+									;all other classes can't exceed the predicted class's probability
+									(min
+										(get prob_match_or_indistinguishable_map predicted_class)
+										(+ (or (get row_map (current_index))))
+									)
+								)
+							)
+							;iterate over all_classes since every row needs to have a value for every class even if it's 0
+							(zip all_classes)
+						)
+					))
+					confusion_matrix
+				)
+		)
+
+		;guessing clamped accuracy
+		;limit max accuracy of predicted classes to max of computed probability and random correct guess
+		;limit min accuracy of other classes to min of computed probability and random wrong guess
+		(map
+			(lambda (let
+				(assoc
+					predicted_class (current_index 1)
+					row_map (current_value 1)
+				)
+
+				(map
+					(lambda
+						(if (= predicted_class (current_index))
+							(max (get row_map predicted_class) (get rand_guess_accuracy_map predicted_class))
+
+							;set floor for accuracy using random matching probability
+							(min
+								(max smallest_prob (get row_map (current_index)))
+								;probability of guessing wrong is 1 - random guess
+								(- 1 (get rand_guess_accuracy_map predicted_class) )
+							)
+						)
+					)
+					row_map
+				)
+			))
+			guessing_accuracy_matrix
+		)
+	)
+
+
 )

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -35,16 +35,17 @@
 			(assign (assoc
 				feature_deviations
 					(map
-						;convert deviations for nominals that have a confusion matrix into a tuple with the SDM
+						;convert deviations for nominals that have a confusion matrix into a assoc with the SDM
 						(lambda
 							(if (contains_index confusion_matrix_map (current_index))
-								;output a pair of [sdm, default_deviation]
-								(list
-									(call !ConfusionMatrixToSDM (assoc
-										confusion_matrix (get confusion_matrix_map (current_index 2))
-										feature (current_index 2)
-									))
-									(current_value 1)
+								;output an assoc of sdm and expected deviation
+								(assoc
+									"sdm"
+										(call !ConfusionMatrixToSDM (assoc
+											confusion_matrix (get confusion_matrix_map (current_index 2))
+											feature (current_index 2)
+										))
+									"expected_deviation" (current_value 1)
 								)
 
 								;else leave deviation value as-is
@@ -92,9 +93,9 @@
 										(lambda
 											;create a tuple of [deviation, value<->null uncertainty, null<->null uncertainty]
 											(if (size (last (current_value)))
-												;if the deviation is a list (nominal feature with sdm), ensure the result is a triple
-												(if (~ (list) (first (current_value)))
-													(append (list (first (current_value 1))) (last (current_value)) )
+												;if the deviation is an assoc (nominal feature with SDM), ensure the result is a triple
+												(if (~ (assoc) (first (current_value)))
+													(append (list (get (current_value 1) (list 0 "sdm"))) (last (current_value)) )
 
 													(append (first (current_value)) (last (current_value)) )
 												)
@@ -949,8 +950,8 @@
 	;parameters:
 	; confusion_matrix:  assoc of class -> assoc of class -> predicted count for each class.
 	; feature: name of nominal feature
-	; smallest_count_threshold: number of predictions a class should have for it to count. If the count is less than this value, it'll be ignored.
-	;    default value is 10
+	; smallest_count_threshold: number of predictions a class should have for it to have an explicit deviation value.
+	;	If the count is less than this value, the deviation will be in the combined deviation for the class. default value is 10
 	#!ConfusionMatrixToSDM
 	(declare
 		(assoc

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -995,6 +995,11 @@
 			leftover_unknown_class_deviation (null)
 		))
 
+		(declare (assoc
+			;map of class -> accuracy of random guessing
+			rand_guess_accuracy_map (map (lambda (/ (current_value) total_predictions)) predictions_per_class_map)
+		))
+
 		;filter out counts below threshold in confusion matrix and store as probabilities correct instead of counts
 		;leaving only those predicted classes that had enough predictions
 		(call !ConvertAndReduceConfusionMatrix)
@@ -1039,9 +1044,6 @@
 					))
 					confusion_matrix
 				)
-
-			;map of class -> accuracy of random guessing
-			rand_guess_accuracy_map (map (lambda (/ (current_value) total_predictions)) predictions_per_class_map)
 		))
 
 		;indistinguishable accuracy matrix
@@ -1161,20 +1163,6 @@
 		))
 
 		(assign (assoc
-			leftover_unknown_class_deviation
-				(if (>= total_leftover_correct_predictions smallest_count_threshold)
-					(- 1 (/ total_leftover_correct_predictions total_leftover_all_predictions) )
-
-					;else don't have enough enough leftover counts to copute unknown class deviation, use weighted random chance
-					(> total_leftover_all_predictions total_leftover_correct_predictions)
-					;TODO: implement
-					(rand)
-
-					;else value remains as  null if there are no leftover counts
-				)
-		))
-
-		(assign (assoc
 			confusion_matrix
 				;current_index is the class being predicted
 				;current_value is an assoc of class -> number predictions
@@ -1207,6 +1195,38 @@
 					confusion_matrix
 				)
 		))
+
+	`	;weighted accuracy for each class is its predicted probability * random guess accuracy
+		(declare (assoc
+			weighted_accuracy_map
+				(map
+					(lambda (let
+						(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
+						(* predicted_class_prob (get rand_guess_accuracy_map (current_index)) )
+					))
+					confusion_matrix
+				)
+		))
+		(declare (assoc avg_accuracy (apply "+" (values weighted_accuracy_map)) ))
+
+		(assign (assoc
+			leftover_unknown_class_deviation
+				(if (>= total_leftover_correct_predictions smallest_count_threshold)
+					(- 1 (/ total_leftover_correct_predictions total_leftover_all_predictions) )
+
+					;else don't have enough enough leftover counts to compute unknown class deviation, use weighted random chance
+					(> total_leftover_all_predictions total_leftover_correct_predictions)
+					(- 1 avg_accuracy)
+
+					;else value remains as  null if there are no leftover counts
+					(null)
+				)
+		))
+
+		;average accuracy of 0 means there are no (or not significantly enough) counts for any of the predicted classes
+		(if (= 0 avg_accuracy)
+			(assign (assoc confusion_matrix (assoc) ))
+		)
 	)
 
 	;helper method for computing SDM that clamps probabilities for the predicted classes to be no worse than random guessing

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -41,6 +41,7 @@
 								;output an assoc of sdm and expected deviation
 								(assoc
 									"sdm"
+										##SparseDeviationMatrix
 										(call !ConfusionMatrixToSDM (assoc
 											confusion_matrix (get confusion_matrix_map (current_index 2))
 											feature (current_index 2)
@@ -108,8 +109,16 @@
 										null_deviations
 									)
 
-									;else just store provided deviations
-									feature_deviations
+									;else just store provided deviations, but pull the sdm out to store as-is
+									(map
+										(lambda
+											(if (~ (assoc) (current_value))
+												(get (current_value) "sdm")
+												(current_value)
+											)
+										)
+										feaure_deviations
+									)
 								)
 						)
 
@@ -1088,25 +1097,33 @@
 				))
 		))
 
-		;output sparse deviation matrix by filtering out deviations that correspond to counts that aren't in the sparse confusion matrix
-		;and return tuples with the default class deviation for classes that have those computed
-		(map
-			(lambda
-				;if there is a default deviation for the class, output a tuple of [sparse deviation map, default class deviation]
-				(if (contains_index leftover_class_deviation_map (current_index))
-					(list
-						(keep (current_value 1) (indices (get confusion_matrix (current_index 1))) )
-						(get leftover_class_deviation_map (current_index 1))
-					)
+		;if there's a leftover_unknown_class_deviation, output the SDM as a list (pair)
+		(if leftover_unknown_class_deviation
+			(list (call !FormatSDMForOutput) leftover_unknown_class_deviation)
 
-					;just output the sdm assoc
-					(keep (current_value) (indices (get confusion_matrix (current_index))) )
-				)
-			)
-			deviation_matrix
+			;else just output the SDM as an assoc
+			(call !FormatSDMForOutput)
 		)
 	)
 
+	;Edits deviation_matrix for output by filtering out deviations that correspond to counts that aren't in the sparse confusion matrix
+	;and return tuples with the default class deviation for classes that have those computed
+	#!FormatSDMForOutput
+	(map
+		(lambda
+			;if there is a default deviation for the class, output a tuple of [sparse deviation map, default class deviation]
+			(if (contains_index leftover_class_deviation_map (current_index))
+				(list
+					(keep (current_value 1) (indices (get confusion_matrix (current_index 1))) )
+					(get leftover_class_deviation_map (current_index 1))
+				)
+
+				;just output the sdm assoc
+				(keep (current_value) (indices (get confusion_matrix (current_index))) )
+			)
+		)
+		deviation_matrix
+	)
 
 	;Helper method for computing SDM, filters out counts below threshold and stores as probabilities correct instead.
 	;leaves only those predicted classes that had enough predictions.
@@ -1192,6 +1209,19 @@
 				)
 		))
 
+		(declare (assoc
+			weighted_accuracy_map
+				;weighted accuracy for each class is its predicted probability * random guess accuracy
+				(map
+					(lambda (let
+						(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
+						(* predicted_class_prob (get rand_guess_accuracy_map (current_index)) )
+					))
+					confusion_matrix
+				)
+		))
+		(declare (assoc avg_random_accuracy (apply "+" (values weighted_accuracy_map)) ))
+
 		(assign (assoc
 			leftover_unknown_class_deviation
 				;fallback #1, if there are enough leftover predictions, deviation is 1 - correct leftovers / total leftovers
@@ -1226,21 +1256,8 @@
 							)
 
 							;else fallback #3, use the average weighted random guess accuracy from the confusion matrix
-							(let
-								(assoc
-									weighted_accuracy_map
-										;weighted accuracy for each class is its predicted probability * random guess accuracy
-										(map
-											(lambda (let
-												(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
-												(* predicted_class_prob (get rand_guess_accuracy_map (current_index)) )
-											))
-											confusion_matrix
-										)
-								)
-								;1 - average accuracy
-								(- 1 (apply "+" (values weighted_accuracy_map)))
-							)
+							;deviation = 1 - average accuracy
+							(- 1 avg_random_accuracy)
 						)
 					)
 
@@ -1256,8 +1273,8 @@
 			))
 		)
 
-		;average accuracy of 0 means there are no (or not significantly enough) counts for any of the predicted classes
-		(if (= 0 avg_accuracy)
+		;average accuracy of 0 means there are no (or not enough significant) counts for any of the predicted classes
+		(if (= 0 avg_random_accuracy)
 			(assign (assoc confusion_matrix (assoc) ))
 		)
 	)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -992,6 +992,7 @@
 					confusion_matrix
 				)
 			leftover_confusion_matrix (assoc)
+			leftover_unknown_class_deviation (null)
 		))
 
 		;filter out counts below threshold in confusion matrix and store as probabilities correct instead of counts
@@ -1124,7 +1125,7 @@
 						;leave entire row out if predicted class doesn't have enough samples
 						(if
 							(or
-								(= (null (get row_map predicted_class)))
+								(= (null) (get row_map predicted_class))
 								(< (get row_map predicted_class) smallest_count_threshold)
 							)
 							row_map
@@ -1143,6 +1144,34 @@
 		;remove classes with empty rows by leaving only those with non-empty rows
 		(assign (assoc
 			leftover_confusion_matrix (filter (lambda (size (current_value))) leftover_confusion_matrix )
+		))
+
+		(declare (assoc
+			total_leftover_correct_predictions
+				(apply "+" (values
+					(map (lambda (+ (or (get (current_value) (current_index))))) leftover_confusion_matrix)
+				))
+			total_leftover_all_predictions
+				(apply "+" (values
+					(map
+						(lambda (apply "+" (values (current_value))))
+						leftover_confusion_matrix
+					)
+				))
+		))
+
+		(assign (assoc
+			leftover_unknown_class_deviation
+				(if (>= total_leftover_correct_predictions smallest_count_threshold)
+					(- 1 (/ total_leftover_correct_predictions total_leftover_all_predictions) )
+
+					;else don't have enough enough leftover counts to copute unknown class deviation, use weighted random chance
+					(> total_leftover_all_predictions total_leftover_correct_predictions)
+					;TODO: implement
+					(rand)
+
+					;else value remains as  null if there are no leftover counts
+				)
 		))
 
 		(assign (assoc

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -959,6 +959,19 @@
 						confusion_matrix
 					)
 				))
+			num_classes
+				(size
+					(compute_on_contained_entities (list
+						(query_value_masses
+							feature
+							(null)
+							(or
+								(not (contains_index !nominalsMap feature))
+								(contains_index !numericNominalFeaturesMap feature)
+							)
+						)
+					))
+				)
 		))
 		(declare (assoc
 			smallest_prob (/ 1 (+ 2 total_predictions))
@@ -1048,7 +1061,11 @@
 							(lambda
 								(if (= predicted_class (current_index))
 									(current_value)
-									(min (get prob_match_or_indistinguishable_map predicted_class) (+ (or (get row_map (current_index)))) )
+
+									(min
+										(get prob_match_or_indistinguishable_map predicted_class)
+										(+ (or (get row_map (current_index))))
+									)
 								)
 							)
 							prob_match_or_indistinguishable_map
@@ -1056,7 +1073,6 @@
 					))
 					confusion_matrix
 				)
-
 		))
 
 		;clamp accuracies
@@ -1087,8 +1103,9 @@
 				)
 		))
 
+		;compute the full deviation matrix
 		(declare (assoc
-			sparse_deviation_matrix
+			deviation_matrix
 				(map
 					(lambda (let
 						(assoc
@@ -1107,7 +1124,38 @@
 				)
 		))
 
-		sparse_deviation_matrix
+		;store default class deviations for any classes that are not in the sparse confusion matrix
+		(declare (assoc
+			default_class_deviation_map
+				(filter (map
+					(lambda
+						;only need default if a class isn't in the sparse confusion matrix
+						(if (< (size (current_value)) num_classes)
+							(first (values
+								(remove (get deviation_matrix (current_index)) (indices (current_value)))
+							))
+						)
+					)
+					confusion_matrix
+				))
+		))
 
+		;output sparse deviation matrix by filtering out deviations that correspond to counts that aren't in the sparse confusion matrix
+		;and return tuples with the default class deviation for classes that have those computed
+		(map
+			(lambda
+				;if there is a default deviation for the class, output a tuple of [sparse deviation map, default class deviation]
+				(if (contains_index default_class_deviation_map (current_index))
+					(list
+						(keep (current_value 1) (indices (get confusion_matrix (current_index 1))) )
+						(get default_class_deviation_map (current_index 1))
+					)
+
+					;just output the sdm assoc
+					(keep (current_value) (indices (get confusion_matrix (current_index))) )
+				)
+			)
+			deviation_matrix
+		)
 	)
 )

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -42,6 +42,7 @@
 								(list
 									(call !ConfusionMatrixToSDM (assoc
 										confusion_matrix (get confusion_matrix_map (current_index 2))
+										feature (current_index 2)
 									))
 									(current_value 1)
 								)
@@ -942,9 +943,10 @@
 	;Convert confusion matrix (assoc of assoc of counts) to sparse deviation matrix (assoc of assoc of deviation)
 	;parameters:
 	; confusion_matrix:  assoc of class -> assoc of class -> predicted count for each class.
+	; feature: name of nominal feature
 	; smallest_count_threshold: number of predictions a class should have for it to count. If the count is less than this value, it'll be ignored.
 	;    default value is 10
-	#ConfusionMatrixToSDM
+	#!ConfusionMatrixToSDM
 	(declare
 		(assoc
 			confusion_matrix (assoc)
@@ -959,8 +961,65 @@
 						confusion_matrix
 					)
 				))
-			num_classes
-				(size
+		))
+
+		(if (< total_predictions smallest_count_threshold)
+			(conclude (null))
+		)
+
+		(declare (assoc
+			smallest_prob (/ 1 (+ 2 total_predictions))
+			max_accuracy (- 1 (/ 1 (+ 2 total_predictions)))
+			predictions_per_class_map
+				(map
+					(lambda (apply "+" (values (current_value))) )
+					confusion_matrix
+				)
+		))
+
+		;filter out counts below threshold and store as sparse probability correct
+		;leaving only those predicted classes that had enough predictions
+		(assign (assoc
+			confusion_matrix
+				;current_index is the class being predicted
+				;current_value is an assoc of class -> number predictions
+				(map
+					(lambda (let
+						(assoc
+							total_class_predictions (apply "+" (values (current_value 1)))
+							predicted_class (current_index 1)
+						)
+						;convert counts to percent accuracy by dividing each count by total_class_predictions
+						;filter out any entries where there weren't enough counts
+						(filter (map
+							(lambda
+								(if (>= (current_value) smallest_count_threshold)
+									(/ (current_value) total_class_predictions)
+
+									;if the predicted class (diagonal) doesn't have enough, represent it with a 0 instead of filtering it out
+									(= (current_index) predicted_class)
+									0
+								)
+							)
+							;ensure the predicted class is represented in the row even if it has no counts
+							;since the values on the diagonal should all be present
+							(if (contains_index (current_value) predicted_class)
+								(current_value)
+								(append (current_value) (associate predicted_class 0))
+							)
+						))
+					))
+					confusion_matrix
+				)
+		))
+
+		(if (= 0 (size confusion_matrix))
+			(conclude (null))
+		)
+
+		(declare (assoc
+			all_classes
+				(indices
 					(compute_on_contained_entities (list
 						(query_value_masses
 							feature
@@ -973,82 +1032,32 @@
 					))
 				)
 		))
-		(declare (assoc
-			smallest_prob (/ 1 (+ 2 total_predictions))
-			max_accuracy (- 1 (/ 1 (+ 2 total_predictions)))
-			predictions_per_class_map
-				(map
-					(lambda (apply "+" (values (current_value))) )
-					confusion_matrix
-				)
-		))
-
-		;filter out counts below threshold and store as sparse probability correct
-		(assign (assoc
-			confusion_matrix
-				;current_index is the class being predicted
-				;current_value is an assoc of class -> number predictions
-				(map
-					(lambda (let
-						(assoc total_class_predictions (apply "+" (values (current_value 1))) )
-						;convert counts to percent accuracy by dividing each count by total_class_predictions
-						;filter out any entries where there weren't enough counts
-						(filter (map
-							(lambda
-								(if (>= (current_value) smallest_count_threshold)
-									(/ (current_value) total_class_predictions)
-								)
-							)
-							(current_value)
-						))
-					))
-					confusion_matrix
-				)
-		))
+		(declare (assoc num_classes (size all_classes) ))
 
 		;average all probabilities for a class that are same as or more than the predicted class probability
 		(declare (assoc
 			prob_match_or_indistinguishable_map
 				(map
 					(lambda (let
-						(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
+						(assoc predicted_class_prob (+ (or (get (current_value 1) (current_index 1)))) )
 						(declare (assoc
 							avg_probs_same_or_larger_than_predicted
 								(filter
 									(lambda (>= (current_value) predicted_class_prob))
-									(values (current_value 1))
+									(values
+										(append (zip all_classes 0) (current_value 1))
+									)
 								)
 						))
 						(/ (apply "+" avg_probs_same_or_larger_than_predicted) (size avg_probs_same_or_larger_than_predicted))
 					))
 					confusion_matrix
 				)
+			;map of class -> accuracy of random guessing
 			rand_guess_accuracy_map (map (lambda (/ (current_value) total_predictions)) predictions_per_class_map)
 		))
 
-		(declare (assoc
-			weighted_accuracy_map
-				(map
-					(lambda (let
-						(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
-						(* predicted_class_prob (get rand_guess_accuracy_map (current_index)) )
-					))
-					confusion_matrix
-				)
-
-		))
-
-		(declare (assoc
-			avg_accuracy (apply "+" (values weighted_accuracy_map))
-			min_accuracy
-				(apply "+"
-					(map
-						(lambda (pow (/ (current_value) total_predictions) 2) )
-						(values predictions_per_class_map)
-					)
-				)
-		))
-
+		;indistinguishable accuracy
 		(declare (assoc
 			guessing_accuracy_matrix
 				(map
@@ -1060,7 +1069,7 @@
 						(map
 							(lambda
 								(if (= predicted_class (current_index))
-									(current_value)
+									(get prob_match_or_indistinguishable_map (current_index))
 
 									(min
 										(get prob_match_or_indistinguishable_map predicted_class)
@@ -1068,14 +1077,15 @@
 									)
 								)
 							)
-							prob_match_or_indistinguishable_map
+							;iterate over all_classes since every row needs to have a value for every class even if it's 0
+							(zip all_classes)
 						)
 					))
 					confusion_matrix
 				)
 		))
 
-		;clamp accuracies
+		;guessing clamped accuracy
 		(assign (assoc
 			guessing_accuracy_matrix
 				(map

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -946,7 +946,16 @@
 		(call !Return)
 	)
 
-	;Convert confusion matrix (assoc of assoc of counts) to sparse deviation matrix (assoc of assoc of deviation)
+	;Convert confusion matrix (assoc class -> (assoc of class -> counts)) to sparse deviation matrix (SDM):
+	;with the possible formats:
+	;  (assoc of class -> (assoc of class -> deviation))
+	;  (assoc of class -> (list of: (assoc of class -> deviation), default_class_deviation))
+	;where default_class_deviation is the deviation value to be used for any classes that didn't have any counts.
+	;Can also be output as a pair in the format of: (list SDM, unspecified_class_deviation)
+	;where unspecified_class_deviation is the deviation value to be used for a class that isn't defined in the SDM
+
+	;returns null if the the passed in confusion matrix does not have enough counts to be statistically significant.
+	;
 	;parameters:
 	; confusion_matrix:  assoc of class -> assoc of class -> predicted count for each class.
 	; feature: name of nominal feature
@@ -969,6 +978,7 @@
 				))
 		))
 
+		;output null if the total count is too small
 		(if (< total_predictions smallest_count_threshold)
 			(conclude (null))
 		)
@@ -1064,7 +1074,7 @@
 
 		;store default class deviations for any classes that are not in the sparse confusion matrix
 		(declare (assoc
-			default_class_deviation_map
+			leftover_class_deviation_map
 				(filter (map
 					(lambda
 						;only need default if a class isn't in the sparse confusion matrix
@@ -1083,10 +1093,10 @@
 		(map
 			(lambda
 				;if there is a default deviation for the class, output a tuple of [sparse deviation map, default class deviation]
-				(if (contains_index default_class_deviation_map (current_index))
+				(if (contains_index leftover_class_deviation_map (current_index))
 					(list
 						(keep (current_value 1) (indices (get confusion_matrix (current_index 1))) )
-						(get default_class_deviation_map (current_index 1))
+						(get leftover_class_deviation_map (current_index 1))
 					)
 
 					;just output the sdm assoc
@@ -1135,7 +1145,7 @@
 			)
 	))
 
-	;helper method for computing SDM that clamps probabilities for the predicted classes vs random guessing
+	;helper method for computing SDM that clamps probabilities for the predicted classes to be no worse than random guessing
 	#!ClampSDMProbabilities
 	(declare
 		(assoc

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -969,10 +969,11 @@
 
 	;Convert confusion matrix (assoc class -> (assoc of class -> counts)) to sparse deviation matrix (SDM):
 	;with the possible formats:
-	;  (assoc of class -> (assoc of class -> deviation))
+	; an assoc of assocs: (assoc of class -> (assoc of class -> deviation))
 	;if there's a default_class_deviation, the deviation value to be used for any classes that didn't have any counts:
+	; each row will be an assoc of list (pair) of: assoc and value:
 	;  (assoc of class -> (list of: (assoc of class -> deviation), default_class_deviation))
-	;The SDM can also be output as a pair in the format of: (list SDM, unspecified_class_deviation)
+	;The SDM can also be output as a list (pair) in the format of: (list SDM, unspecified_class_deviation)
 	;where unspecified_class_deviation is the deviation value to be used for a class that isn't defined in the SDM
 	;
 	;returns null if the the passed in confusion matrix does not have enough counts to be statistically significant.

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -35,7 +35,8 @@
 			(assign (assoc
 				feature_deviations
 					(map
-						;convert deviations for nominals that have a confusion matrix into a assoc with the SDM
+						;convert deviations for nominals that had a confusion matrix computed from a single value into an assoc
+						;containing the nominal deviation as 'expected_deviation' and a sparse deviation matrix as 'sdm'
 						(lambda
 							(if (contains_index confusion_matrix_map (current_index))
 								(let

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -970,11 +970,11 @@
 	;Convert confusion matrix (assoc class -> (assoc of class -> counts)) to sparse deviation matrix (SDM):
 	;with the possible formats:
 	;  (assoc of class -> (assoc of class -> deviation))
+	;if there's a default_class_deviation, the deviation value to be used for any classes that didn't have any counts:
 	;  (assoc of class -> (list of: (assoc of class -> deviation), default_class_deviation))
-	;where default_class_deviation is the deviation value to be used for any classes that didn't have any counts.
-	;Can also be output as a pair in the format of: (list SDM, unspecified_class_deviation)
+	;The SDM can also be output as a pair in the format of: (list SDM, unspecified_class_deviation)
 	;where unspecified_class_deviation is the deviation value to be used for a class that isn't defined in the SDM
-
+	;
 	;returns null if the the passed in confusion matrix does not have enough counts to be statistically significant.
 	;
 	;parameters:

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -92,7 +92,12 @@
 										(lambda
 											;create a tuple of [deviation, value<->null uncertainty, null<->null uncertainty]
 											(if (size (last (current_value)))
-												(append (first (current_value)) (last (current_value)))
+												;if the deviation is a list (nominal feature with sdm), ensure the result is a triple
+												(if (~ (list) (first (current_value)))
+													(append (list (first (current_value 1))) (last (current_value)) )
+
+													(append (first (current_value)) (last (current_value)) )
+												)
 
 												;else just return the deviation value
 												(first (current_value))

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -117,7 +117,7 @@
 												(current_value)
 											)
 										)
-										feaure_deviations
+										feature_deviations
 									)
 								)
 						)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -1194,15 +1194,17 @@
 
 		(assign (assoc
 			leftover_unknown_class_deviation
+				;fallback #1, if there are enough leftover predictions, deviation is 1 - correct leftovers / total leftovers
 				(if (>= total_leftover_correct_predictions smallest_count_threshold)
 					(- 1 (/ total_leftover_correct_predictions total_leftover_all_predictions) )
 
-					;else don't have enough enough leftover counts to compute unknown class deviation, use weighted random chance
+					;else if there aren't enough leftover counts to compute unknown class deviation, use weighted random chance
 					(> total_leftover_all_predictions total_leftover_correct_predictions)
 					(let
 						(assoc
 							non_sdm_classes (indices (remove all_classes_map (indices confusion_matrix)) )
 						)
+						;fallback #2, if there are classes in the dataset that weren't in the sdm, use random guess probability of those classes
 						(if (size non_sdm_classes)
 							(let
 								(assoc total_count (apply "+" (values all_classes_map)) )
@@ -1223,7 +1225,7 @@
 								)
 							)
 
-							;else:
+							;else fallback #3, use the average weighted random guess accuracy from the confusion matrix
 							(let
 								(assoc
 									weighted_accuracy_map
@@ -1243,10 +1245,16 @@
 					)
 
 					;else value remains as null if there are no leftover counts
-					;TODO: what if only leftovers are predicted classes?
 					(null)
 				)
 		))
+
+		;ensure unknown class deviation isn't 0 by setting the floor to be the smallest possible probability
+		(if (!= (null) leftover_unknown_class_deviation)
+			(assign (assoc
+				leftover_unknown_class_deviation (max smallest_prob leftover_unknown_class_deviation)
+			))
+		)
 
 		;average accuracy of 0 means there are no (or not significantly enough) counts for any of the predicted classes
 		(if (= 0 avg_accuracy)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -42,7 +42,6 @@
 								(list
 									(call !ConfusionMatrixToSDM (assoc
 										confusion_matrix (get confusion_matrix_map (current_index 2))
-										smallest_count_threshold (if (>= num_samples 1000) 10 1)
 									))
 									(current_value 1)
 								)
@@ -952,24 +951,79 @@
 			smallest_count_threshold 10
 		)
 
-		(map
-			;current_index is the class being predicted
-			;current_value is an assoc of class -> number predictions
-			(lambda (let
-				(assoc total_class_predictions (apply "+" (values (current_value 1))) )
-
-				;convert counts to percent accuracy by dividing each count by total_class_predictions and to deviation by doing a 1-accuracy
-				;filter out any entries where there weren't enough counts
-				(filter (map
-					(lambda
-						(if (>= (current_value) smallest_count_threshold)
-							(- 1.0 (/ (current_value) total_class_predictions))
-						)
+		(declare (assoc
+			total_predictions
+				(apply "+" (values
+					(map
+						(lambda (apply "+" (values (current_value))))
+						confusion_matrix
 					)
-					(current_value)
 				))
-			))
+		))
+		(declare (assoc
+			smallest_prob (/ 1 (+ 2 total_predictions))
+			max_accuracy (- 1 (/ 1 (+ 2 total_predictions)))
+			predictions_per_class
+				(map
+					(lambda (apply "+" (values (current_value))) )
+					confusion_matrix
+				)
+		))
+
+		;filter out counts below threshold and store as sparse probability correct
+		(assign (assoc
 			confusion_matrix
-		)
+				;current_index is the class being predicted
+				;current_value is an assoc of class -> number predictions
+				(map
+					(lambda (let
+						(assoc total_class_predictions (apply "+" (values (current_value 1))) )
+						;convert counts to percent accuracy by dividing each count by total_class_predictions
+						;filter out any entries where there weren't enough counts
+						(filter (map
+							(lambda
+								(if (>= (current_value) smallest_count_threshold)
+									(/ (current_value) total_class_predictions)
+								)
+							)
+							(current_value)
+						))
+					))
+					confusion_matrix
+				)
+		))
+
+		;average all probabilities for a class that are same as or more than the predicted class probability
+		(declare (assoc
+			prob_match_or_indistinguishable_map
+				(map
+					(lambda (let
+						(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
+						(declare (assoc
+							avg_probs_same_or_larger_than_predicted
+								(filter
+									(lambda (>= (current_value) predicted_class_prob))
+									(values (current_value))
+								)
+						))
+						(/ (apply "+" avg_probs_same_or_larger_than_predicted) (size avg_probs_same_or_larger_than_predicted))
+					))
+					confusion_matrix
+				)
+		))
+
+		(declare (assoc
+			weighted_accuracy_map
+				(map
+					(lambda (let
+						(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
+						(* predicted_class_prob (get predictions_per_class (current_index)))
+					))
+					confusion_matrix
+				)
+		))
+
+
+
 	)
 )

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -38,15 +38,26 @@
 						;convert deviations for nominals that have a confusion matrix into a assoc with the SDM
 						(lambda
 							(if (contains_index confusion_matrix_map (current_index))
-								;output an assoc of sdm and expected deviation
-								(assoc
-									"sdm"
-										##SparseDeviationMatrix
-										(call !ConfusionMatrixToSDM (assoc
-											confusion_matrix (get confusion_matrix_map (current_index 2))
-											feature (current_index 2)
-										))
-									"expected_deviation" (current_value 1)
+								(let
+									(assoc
+										sdm
+											##SparseDeviationMatrix
+											(call !ConfusionMatrixToSDM (assoc
+												confusion_matrix (get confusion_matrix_map (current_index 2))
+												feature (current_index 2)
+											))
+									)
+
+									;output an assoc of sdm and expected deviation
+									(if sdm
+										(assoc
+											"sdm" sdm
+											"expected_deviation" (current_value 1)
+										)
+
+										;else there is no sdm, return just the value
+										(current_value)
+									)
 								)
 
 								;else leave deviation value as-is

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -1004,7 +1004,10 @@
 		)
 
 		(declare (assoc
-			smallest_prob (/ 1 (+ 2 total_predictions))
+			;Using n+1, n+2, or n+.5 are all possible considerations of Laplacian smoothing to apply a Bayesian approach for
+			;estimating the probability of having no incorrect predictions.  We chose .5 assuming the Jeffreys prior approach.
+			smallest_prob (/ 1 (+ 0.5 total_predictions))
+			;max accuracy is 1 - smallest_probability
 			max_accuracy (- 1 (/ 1 (+ 2 total_predictions)))
 			predictions_per_class_map
 				(map
@@ -1013,6 +1016,7 @@
 				)
 			leftover_confusion_matrix (assoc)
 			leftover_unknown_class_deviation (null)
+			valid_weight_feature (and use_case_weights (or !hasPopulatedCaseWeight (!= weight_feature ".case_weight")) )
 		))
 
 		(declare (assoc
@@ -1022,7 +1026,7 @@
 				(compute_on_contained_entities (list
 					(query_value_masses
 						feature
-						(null)
+						(if valid_weight_feature weight_feature)
 						(or
 							(not (contains_index !nominalsMap feature))
 							(contains_index !numericNominalFeaturesMap feature)
@@ -1138,8 +1142,10 @@
 
 	;Helper method for computing SDM, filters out counts below threshold and stores as probabilities correct instead.
 	;leaves only those predicted classes that had enough predictions.
+	;Also computes the fallback residuals if there are any counts that didn't have enough statistical significance.
 	#!ConvertAndReduceConfusionMatrix
 	(seq
+		;compute the "leftover" confusion matrix of class counts that did not have statistical significance
 		(assign (assoc
 			leftover_confusion_matrix
 				(map
@@ -1148,7 +1154,7 @@
 							predicted_class (current_index 1)
 							row_map (current_value 1)
 						)
-						;leave entire row out if predicted class doesn't have enough samples
+						;leave entire row if predicted class doesn't have enough samples
 						(if
 							(or
 								(= (null) (get row_map predicted_class))

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -983,41 +983,9 @@
 				)
 		))
 
-		;filter out counts below threshold and store as sparse probability correct
+		;filter out counts below threshold in confusion matrix and store as probabilities correct instead of counts
 		;leaving only those predicted classes that had enough predictions
-		(assign (assoc
-			confusion_matrix
-				;current_index is the class being predicted
-				;current_value is an assoc of class -> number predictions
-				(map
-					(lambda (let
-						(assoc
-							total_class_predictions (apply "+" (values (current_value 1)))
-							predicted_class (current_index 1)
-						)
-						;convert counts to percent accuracy by dividing each count by total_class_predictions
-						;filter out any entries where there weren't enough counts
-						(filter (map
-							(lambda
-								(if (>= (current_value) smallest_count_threshold)
-									(/ (current_value) total_class_predictions)
-
-									;if the predicted class (diagonal) doesn't have enough, represent it with a 0 instead of filtering it out
-									(= (current_index) predicted_class)
-									0
-								)
-							)
-							;ensure the predicted class is represented in the row even if it has no counts
-							;since the values on the diagonal should all be present
-							(if (contains_index (current_value) predicted_class)
-								(current_value)
-								(append (current_value) (associate predicted_class 0))
-							)
-						))
-					))
-					confusion_matrix
-				)
-		))
+		(call !ConvertAndReduceConfusionMatrix)
 
 		(if (= 0 (size confusion_matrix))
 			(conclude (null))
@@ -1129,6 +1097,43 @@
 		)
 	)
 
+
+	;Helper method for computing SDM, filters out counts below threshold and stores as probabilities correct instead.
+	;leaves only those predicted classes that had enough predictions.
+	#!ConvertAndReduceConfusionMatrix
+	(assign (assoc
+		confusion_matrix
+			;current_index is the class being predicted
+			;current_value is an assoc of class -> number predictions
+			(map
+				(lambda (let
+					(assoc
+						total_class_predictions (apply "+" (values (current_value 1)))
+						predicted_class (current_index 1)
+					)
+					;convert counts to percent accuracy by dividing each count by total_class_predictions
+					;filter out any entries where there weren't enough counts
+					(filter (map
+						(lambda
+							(if (>= (current_value) smallest_count_threshold)
+								(/ (current_value) total_class_predictions)
+
+								;if the predicted class (diagonal) doesn't have enough, represent it with a 0 instead of filtering it out
+								(= (current_index) predicted_class)
+								0
+							)
+						)
+						;ensure the predicted class is represented in the row even if it has no counts
+						;since the values on the diagonal should all be present
+						(if (contains_index (current_value) predicted_class)
+							(current_value)
+							(append (current_value) (associate predicted_class 0))
+						)
+					))
+				))
+				confusion_matrix
+			)
+	))
 
 	;helper method for computing SDM that clamps probabilities for the predicted classes vs random guessing
 	#!ClampSDMProbabilities

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -28,6 +28,27 @@
 			null_deviations (null)
 			ordinal_feature_deviations (null)
 			attribute_map (assoc)
+			confusion_matrix_map (null)
+		)
+
+		(if (size confusion_matrix_map)
+			(assign (assoc
+				feature_deviations
+					(map
+						;convert deviations for nominals that have a confusion matrix into a tuple with the SDM
+						(if (contains_index confusion_matrix_map (current_index))
+							;output a pair of [sdm, default_deviation]
+							(list
+								(call !ConfusionMatrixToSDM (assoc confusion_matrix (get confusion_matrix_map (current_index 2)) ))
+								(current_value 1)
+							)
+
+							;else leave deviation value as-is
+							(current_value)
+						)
+						feature_deviations
+					)
+			))
 		)
 
 		(accum (assoc
@@ -912,5 +933,38 @@
 		))
 
 		(call !Return)
+	)
+
+	;Convert confusion matrix (assoc of assoc of counts) to sparse deviation matrix (assoc of assoc of deviation)
+	;parameters:
+	; confusion_matrix:  assoc of class -> assoc of class -> predicted count for each class.
+	; smallest_count_threshold: number of predictions a class should have for it to count. If the count is less than this value, it'll be ignored.
+	;    default value is 10
+	#!ConfusionMatrixToSDM
+	(declare
+		(assoc
+			confusion_matrix (assoc)
+			smallest_count_threshold 10
+		)
+
+		(map
+			;current_index is the class being predicted
+			;current_value is an assoc of class -> number predictions
+			(lambda (let
+				(assoc total_class_predictions (apply "+" (values (current_value 1))) )
+
+				;convert counts to percent accuracy by dividing each count by total_class_predictions and to deviation by doing a 1-accuracy
+				;filter out any entries where there weren't enough counts
+				(filter (map
+					(lambda
+						(if (>= (current_value) smallest_count_threshold)
+							(- 1.0 (/ (current_value) total_class_predictions))
+						)
+					)
+					(current_value)
+				))
+			))
+			confusion_matrix
+		)
 	)
 )

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -944,7 +944,7 @@
 	; confusion_matrix:  assoc of class -> assoc of class -> predicted count for each class.
 	; smallest_count_threshold: number of predictions a class should have for it to count. If the count is less than this value, it'll be ignored.
 	;    default value is 10
-	#!ConfusionMatrixToSDM
+	#ConfusionMatrixToSDM
 	(declare
 		(assoc
 			confusion_matrix (assoc)
@@ -963,7 +963,7 @@
 		(declare (assoc
 			smallest_prob (/ 1 (+ 2 total_predictions))
 			max_accuracy (- 1 (/ 1 (+ 2 total_predictions)))
-			predictions_per_class
+			predictions_per_class_map
 				(map
 					(lambda (apply "+" (values (current_value))) )
 					confusion_matrix
@@ -1003,13 +1003,14 @@
 							avg_probs_same_or_larger_than_predicted
 								(filter
 									(lambda (>= (current_value) predicted_class_prob))
-									(values (current_value))
+									(values (current_value 1))
 								)
 						))
 						(/ (apply "+" avg_probs_same_or_larger_than_predicted) (size avg_probs_same_or_larger_than_predicted))
 					))
 					confusion_matrix
 				)
+			rand_guess_accuracy_map (map (lambda (/ (current_value) total_predictions)) predictions_per_class_map)
 		))
 
 		(declare (assoc
@@ -1017,13 +1018,96 @@
 				(map
 					(lambda (let
 						(assoc predicted_class_prob (get (current_value 1) (current_index 1)))
-						(* predicted_class_prob (get predictions_per_class (current_index)))
+						(* predicted_class_prob (get rand_guess_accuracy_map (current_index)) )
 					))
 					confusion_matrix
 				)
+
 		))
 
+		(declare (assoc
+			avg_accuracy (apply "+" (values weighted_accuracy_map))
+			min_accuracy
+				(apply "+"
+					(map
+						(lambda (pow (/ (current_value) total_predictions) 2) )
+						(values predictions_per_class_map)
+					)
+				)
+		))
 
+		(declare (assoc
+			guessing_accuracy_matrix
+				(map
+					(lambda (let
+						(assoc
+							predicted_class (current_index 1)
+							row_map (current_value 1)
+						)
+						(map
+							(lambda
+								(if (= predicted_class (current_index))
+									(current_value)
+									(min (get prob_match_or_indistinguishable_map predicted_class) (+ (or (get row_map (current_index)))) )
+								)
+							)
+							prob_match_or_indistinguishable_map
+						)
+					))
+					confusion_matrix
+				)
+
+		))
+
+		;clamp accuracies
+		(assign (assoc
+			guessing_accuracy_matrix
+				(map
+					(lambda (let
+						(assoc
+							predicted_class (current_index 1)
+							row_map (current_value 1)
+						)
+
+						(map
+							(lambda
+								(if (= predicted_class (current_index))
+									(max (get row_map predicted_class) (get rand_guess_accuracy_map predicted_class))
+
+									(min
+										(max smallest_prob (get row_map (current_index)))
+										(- 1 (get rand_guess_accuracy_map predicted_class) )
+									)
+								)
+							)
+							row_map
+						)
+					))
+					guessing_accuracy_matrix
+				)
+		))
+
+		(declare (assoc
+			sparse_deviation_matrix
+				(map
+					(lambda (let
+						(assoc
+							predicted_class (current_index 1)
+							class_probability (get (current_value 1) (current_index 1))
+							total_probability (apply "+" (values (current_value 1)) )
+						)
+						(map
+							(lambda
+								(- 1 (/ (min class_probability (current_value)) total_probability))
+							)
+							(current_value)
+						)
+					))
+					guessing_accuracy_matrix
+				)
+		))
+
+		sparse_deviation_matrix
 
 	)
 )

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -36,15 +36,20 @@
 				feature_deviations
 					(map
 						;convert deviations for nominals that have a confusion matrix into a tuple with the SDM
-						(if (contains_index confusion_matrix_map (current_index))
-							;output a pair of [sdm, default_deviation]
-							(list
-								(call !ConfusionMatrixToSDM (assoc confusion_matrix (get confusion_matrix_map (current_index 2)) ))
-								(current_value 1)
-							)
+						(lambda
+							(if (contains_index confusion_matrix_map (current_index))
+								;output a pair of [sdm, default_deviation]
+								(list
+									(call !ConfusionMatrixToSDM (assoc
+										confusion_matrix (get confusion_matrix_map (current_index 2))
+										smallest_count_threshold (if (>= num_samples 1000) 10 1)
+									))
+									(current_value 1)
+								)
 
-							;else leave deviation value as-is
-							(current_value)
+								;else leave deviation value as-is
+								(current_value)
+							)
 						)
 						feature_deviations
 					)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -991,6 +991,7 @@
 					(lambda (apply "+" (values (current_value))) )
 					confusion_matrix
 				)
+			leftover_confusion_matrix (assoc)
 		))
 
 		;filter out counts below threshold in confusion matrix and store as probabilities correct instead of counts
@@ -1111,39 +1112,73 @@
 	;Helper method for computing SDM, filters out counts below threshold and stores as probabilities correct instead.
 	;leaves only those predicted classes that had enough predictions.
 	#!ConvertAndReduceConfusionMatrix
-	(assign (assoc
-		confusion_matrix
-			;current_index is the class being predicted
-			;current_value is an assoc of class -> number predictions
-			(map
-				(lambda (let
-					(assoc
-						total_class_predictions (apply "+" (values (current_value 1)))
-						predicted_class (current_index 1)
-					)
-					;convert counts to percent accuracy by dividing each count by total_class_predictions
-					;filter out any entries where there weren't enough counts
-					(filter (map
-						(lambda
-							(if (>= (current_value) smallest_count_threshold)
-								(/ (current_value) total_class_predictions)
+	(seq
+		(assign (assoc
+			leftover_confusion_matrix
+				(map
+					(lambda (let
+						(assoc
+							predicted_class (current_index 1)
+							row_map (current_value 1)
+						)
+						;leave entire row out if predicted class doesn't have enough samples
+						(if
+							(or
+								(= (null (get row_map predicted_class)))
+								(< (get row_map predicted_class) smallest_count_threshold)
+							)
+							row_map
 
-								;if the predicted class (diagonal) doesn't have enough, represent it with a 0 instead of filtering it out
-								(= (current_index) predicted_class)
-								0
+							;else only leave those classes that didn't have enough samples
+							(filter
+								(lambda (< (current_value) smallest_count_threshold) )
+								row_map
 							)
 						)
-						;ensure the predicted class is represented in the row even if it has no counts
-						;since the values on the diagonal should all be present
-						(if (contains_index (current_value) predicted_class)
-							(current_value)
-							(append (current_value) (associate predicted_class 0))
-						)
 					))
-				))
-				confusion_matrix
-			)
-	))
+					confusion_matrix
+				)
+		))
+
+		;remove classes with empty rows by leaving only those with non-empty rows
+		(assign (assoc
+			leftover_confusion_matrix (filter (lambda (size (current_value))) leftover_confusion_matrix )
+		))
+
+		(assign (assoc
+			confusion_matrix
+				;current_index is the class being predicted
+				;current_value is an assoc of class -> number predictions
+				(map
+					(lambda (let
+						(assoc
+							total_class_predictions (apply "+" (values (current_value 1)))
+							predicted_class (current_index 1)
+						)
+						;convert counts to percent accuracy by dividing each count by total_class_predictions
+						;filter out any entries where there weren't enough counts
+						(filter (map
+							(lambda
+								(if (>= (current_value) smallest_count_threshold)
+									(/ (current_value) total_class_predictions)
+
+									;if the predicted class (diagonal) doesn't have enough, represent it with a 0 instead of filtering it out
+									(= (current_index) predicted_class)
+									0
+								)
+							)
+							;ensure the predicted class is represented in the row even if it has no counts
+							;since the values on the diagonal should all be present
+							(if (contains_index (current_value) predicted_class)
+								(current_value)
+								(append (current_value) (associate predicted_class 0))
+							)
+						))
+					))
+					confusion_matrix
+				)
+		))
+	)
 
 	;helper method for computing SDM that clamps probabilities for the predicted classes to be no worse than random guessing
 	#!ClampSDMProbabilities

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -30,8 +30,8 @@
 	; robust_hyperparameters: flag, optional. if specified, will attempt to return stats that were computed using hyperpparameters with the
 	;						  specified robust or non-robust type.
 	; weight_feature: string, optional. if specified, will attempt to return stats that were computed using this weight_feature.
-	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
-	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
+	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for.
+	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition'
 	;       will be excluded from the context set, which is the set being queried to make to make predictions on the action set, effectively holding them out.
 	;		If only 'action_condition' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
@@ -48,7 +48,7 @@
 	;			If null, will be set to the Howso default limit of 2000. default is null
 	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions on the action set.
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
-	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition' is specified, then only the single predicted case will be left out.	
+	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
 	;			one value = must equal exactly the value or be close to it for fuzzy match
@@ -220,10 +220,14 @@
 									;GetFeatureResiduals returns the values in !residualsMap, which contains a list of values for features containing nulls.
 									;In the case where !residualsMap holds a list of values for a feature, the first value is the MAE.
 									(lambda
-										(if (= (get_type_string (current_value)) "list")
+										(if (~ (list) (current_value))
 											(first (current_value))
 
-											(current_value)
+											;if the residual is an assoc containing a Sparse Deviation Matrix, return just the deviation value
+											(if (~ (assoc) (current_value))
+												(get (current_value) "expected_deviation")
+												(current_value)
+											)
 										)
 									)
 									(call !GetFeatureResiduals (assoc
@@ -404,8 +408,8 @@
 	; robust_hyperparameters: flag, optional. if true, will attempt to return residuals that were computed using hyperparameters with the
 	;						  specified robust or non-robust type.
 	; weight_feature: string, optional. if specified, will attempt to return residuals that were computed using this weight_feature.
-	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
-	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
+	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for.
+	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition'
 	;       will be excluded from the context set, which is the set being queried to make to make predictions on the action set, effectively holding them out.
 	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
@@ -422,7 +426,7 @@
 	;			If null, will be set to the Howso default limit of 2000. default is null
 	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions on the action set.
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
-	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.	
+	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
 	;			one value = must equal exactly the value or be close to it for fuzzy match
@@ -454,7 +458,7 @@
 		(declare (assoc
 			output_map (assoc)
 			warnings (assoc)
-			action_condition_filter_query 
+			action_condition_filter_query
 				(if action_condition
 					(call !GetQueryByCondition (assoc
 						condition action_condition

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1167,7 +1167,7 @@
 
 		(assign
 			"hyperparam_map"
-			(list "!nullUncertaintyMap")
+			(list "nullUncertaintyMap")
 			null_prediction_map
 		)
 

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -547,6 +547,12 @@
 											diff 0
 											output_categorical_action_probabilities (true)
 											categorical_action_probabilities_map (assoc)
+											feature_is_edit_distance (contains_index !editDistanceFeatureTypesMap (current_index 1))
+											feature_is_non_string_edit_distance (false)
+										)
+
+										(if (and feature_is_edit_distance (!= "string_mixable" (get !editDistanceFeatureTypesMap feature)) )
+											(assign (assoc feature_is_non_string_edit_distance (true)))
 										)
 
 										;create the feature-specific candidate_cases_lists tuple for intepolation
@@ -892,7 +898,7 @@
 							)
 
 							;else continuous
-							(if (contains_index !editDistanceFeatureTypesMap  feature)
+							(if feature_is_edit_distance
 								;use string edit distance only if it's a string
 								(edit_distance case_feature_value interpolated_value
 									(or

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -850,7 +850,14 @@
 			))
 
 			;nominal features just use global residual
-			(assign (assoc feature_residual (get cached_residuals_map feature) ))
+			(seq
+				(assign (assoc feature_residual (get cached_residuals_map feature) ))
+
+				;if residual is a tuple containing the SDM, use the residual value instead of the SDM
+				(if (~ (list) feature_residual)
+					(assign (assoc feature_residual (get feature_residual 1) ))
+				)
+			)
 		)
 
 		;if feature_residual is null but there is an action value, this may generate a 'nan' value for this feature

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -854,8 +854,8 @@
 				(assign (assoc feature_residual (get cached_residuals_map feature) ))
 
 				;if residual is a tuple containing the SDM, use the residual value instead of the SDM
-				(if (~ (list) feature_residual)
-					(assign (assoc feature_residual (get feature_residual 1) ))
+				(if (~ (assoc) feature_residual)
+					(assign (assoc feature_residual (get feature_residual "expected_deviation") ))
 				)
 			)
 		)

--- a/unit_tests/ut_h_id_features.amlg
+++ b/unit_tests/ut_h_id_features.amlg
@@ -157,6 +157,7 @@
 		targeted_model "targetless"
 		inverse_residuals_as_weights (true)
 		use_case_weights (true)
+		use_sdm (true)
 	))
 	(assign (assoc
 		context_key (apply "concat" (weave (sort features) "."))
@@ -252,32 +253,32 @@
 	(call assert_approximate (assoc
 		obs large
 		exp 167
-		thresh 80
+		percent .33
 	))
 
 	(print "red " red " ")
 	(call assert_approximate (assoc
 		obs red
-		exp 440
+		exp 500
 		percent .33
 	))
 	(print "green " green " ")
 	(call assert_approximate (assoc
 		obs green
-		exp 187
+		exp 167
 		percent .33
 	))
 
 	(print "blue " blue " " )
 	(call assert_approximate (assoc
 		obs blue
-		exp 187
+		exp 167
 		percent .33
 	))
 	(print "yellow " yellow " ")
 	(call assert_approximate (assoc
 		obs yellow
-		exp 187
+		exp 167
 		percent .33
 	))
 

--- a/unit_tests/ut_h_id_features.amlg
+++ b/unit_tests/ut_h_id_features.amlg
@@ -252,32 +252,32 @@
 	(call assert_approximate (assoc
 		obs large
 		exp 167
-		percent .33
+		thresh 80
 	))
 
 	(print "red " red " ")
 	(call assert_approximate (assoc
 		obs red
-		exp 500
+		exp 440
 		percent .33
 	))
 	(print "green " green " ")
 	(call assert_approximate (assoc
 		obs green
-		exp 167
+		exp 187
 		percent .33
 	))
 
 	(print "blue " blue " " )
 	(call assert_approximate (assoc
 		obs blue
-		exp 167
+		exp 187
 		percent .33
 	))
 	(print "yellow " yellow " ")
 	(call assert_approximate (assoc
 		obs yellow
-		exp 167
+		exp 187
 		percent .33
 	))
 

--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -196,14 +196,10 @@
 		exp 3
 		obs (size result)
 	))
-	(print "deviations, i.e., first value is a pair of [SDM, default deviation]: ")
-	(call assert_same (assoc
-		exp 2
-		obs (size (first result))
-	))
-	(print "first value in that pair is an assoc (SDM): ")
+
+	(print "first value in that tuple is an assoc (SDM): ")
 	(call assert_true (assoc
-		obs (~ (assoc) (get result (list 0 0)))
+		obs (~ (assoc) (first result))
 	))
 
 

--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -175,5 +175,37 @@
 		exp (append old_null_dev (assoc "A" 120))
 	))
 
+
+	(call exit_if_failures (assoc msg "Set feature attributes updates null deviations."))
+
+
+	(call_entity "howso" "analyze" (assoc
+		use_sdm (true)
+		use_deviations (true)
+	))
+	(assign (assoc
+		result
+			(get
+				(call_entity "howso" "get_internal_parameters")
+				(list 1 "payload" "hyperparameter_map" ".targetless" "A.B.C.D." "robust" ".none" "featureDeviations" "C")
+			)
+	))
+	(print "SDM and null deviations are stored correctly in hyperparameters: ")
+	(print "tuple size of 3 [deviations, value-null, null-null]: ")
+	(call assert_same (assoc
+		exp 3
+		obs (size result)
+	))
+	(print "deviations, i.e., first value is a pair of [SDM, default deviation]: ")
+	(call assert_same (assoc
+		exp 2
+		obs (size (first result))
+	))
+	(print "first value in that pair is an assoc (SDM): ")
+	(call assert_true (assoc
+		obs (~ (assoc) (get result (list 0 0)))
+	))
+
+
 	(call exit_if_failures (assoc msg unit_test_name ))
 )

--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -128,7 +128,7 @@
 	(print "Similar cases are not equal in influence:\n")
 	(call assert_approximate (assoc
 		obs (get result (list 1 "payload" "influential_cases" 0 ".influence_weight"))
-		exp 0.41
+		exp 0.40
 		percent 0.2
 	))
 	(call assert_approximate (assoc
@@ -138,7 +138,7 @@
 	))
 	(call assert_approximate (assoc
 		obs (get result (list 1 "payload" "influential_cases" 2 ".influence_weight"))
-		exp 0.27
+		exp 0.23
 		percent 0.25
 	))
 

--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -197,9 +197,14 @@
 		obs (size result)
 	))
 
-	(print "first value in that tuple is an assoc (SDM): ")
+	(print "first value in that tuple is a list (pair): ")
 	(call assert_true (assoc
-		obs (~ (assoc) (first result))
+		obs (~ (list) (first result))
+	))
+
+	(print "first value n that pair is an assoc (SDM): ")
+	(call assert_true (assoc
+		obs (~ (assoc) (first (first result)))
 	))
 
 

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -88,22 +88,25 @@
 	(call assert_approximate (assoc
 		obs result
 		exp
-			(assoc
-				large
-					(list
-						(assoc large 0.030195)
-						0.98490
-					)
-				medium
-					(list
-						(assoc large 0.50877 medium 0.50877)
-						0.98246
-					)
-				small
-					(list
-						(assoc small 0.12239)
-						0.93881
-					)
+			(list
+				(assoc
+					large
+						(list
+							(assoc large 0.030195)
+							0.98490
+						)
+					medium
+						(list
+							(assoc large 0.50877 medium 0.50877)
+							0.98246
+						)
+					small
+						(list
+							(assoc small 0.12239)
+							0.93881
+						)
+				)
+				0.52439
 			)
 	))
 
@@ -124,22 +127,25 @@
 	(call assert_approximate (assoc
 		obs result
 		exp
-			(assoc
-				large
-					(list
-						(assoc large 0.00692)
-						0.99654
-					)
-				medium
-					(list
-						(assoc small 0.501736 medium 0.501736)
-						0.996528
-					)
-				small
-					(list
-						(assoc small 0.007449)
-						0.996276
-					)
+			(list
+				(assoc
+					large
+						(list
+							(assoc large 0.00692)
+							0.99654
+						)
+					medium
+						(list
+							(assoc small 0.501736 medium 0.501736)
+							0.996528
+						)
+					small
+						(list
+							(assoc small 0.007449)
+							0.996276
+						)
+				)
+				0.368421
 			)
 	))
 

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -57,6 +57,95 @@
 		session "unit_test"
 	))
 
+	;explicitly allow access to internal method for this test
+	(accum_entity_roots "howso" (list
+		(set_labels
+			(lambda
+				(call !ConfusionMatrixToSDM (assoc
+					confusion_matrix confusion_matrix
+					feature feature
+					smallest_count_threshold smallest_count_threshold
+				))
+			)
+			(list "ConfusionMatrixToSDM")
+		)
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "ConfusionMatrixToSDM" (assoc
+				feature "size"
+				confusion_matrix
+					(assoc
+						small (assoc small 4 medium 1 large 9)
+						medium (assoc large 17)
+						large (assoc small 6 medium 6 large 39)
+					)
+				smallest_count_threshold 10
+			))
+	))
+	(print "SDM with values less than threshold: ")
+	(call assert_approximate (assoc
+		obs result
+		exp
+			(assoc
+				large
+					(list
+						(assoc large 0.030195)
+						0.98490
+					)
+				medium
+					(list
+						(assoc large 0.50877 medium 0.50877)
+						0.98246
+					)
+				small
+					(list
+						(assoc small 0.12239)
+						0.93881
+					)
+			)
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "ConfusionMatrixToSDM" (assoc
+				feature "size"
+				confusion_matrix
+					(assoc
+						small (assoc small 65 medium 5 )
+						medium (assoc small 100 medium 15 )
+						large (assoc large 100)
+					)
+				smallest_count_threshold 10
+			))
+	))
+	(print "SDM with values from design spreadsheet: ")
+	(call assert_approximate (assoc
+		obs result
+		exp
+			(assoc
+				large
+					(list
+						(assoc large 0.00692)
+						0.99654
+					)
+				medium
+					(list
+						(assoc small 0.501736 medium 0.501736)
+						0.996528
+					)
+				small
+					(list
+						(assoc small 0.007449)
+						0.996276
+					)
+			)
+	))
+
+	(call exit_if_failures (assoc msg "Sparse deviation matrix computed correctly."))
+
+
 	(assign (assoc
 		result (call_entity "howso" "get_marginal_stats")
 	))


### PR DESCRIPTION
Adds 'use_sdm' parameter to analyze(); when true, if model optimizes to use deviations, all nominal features will attempt to use a sparse deviation matrix (SDM) instead of a single deviation value for their hyperparameter deviations.  The SDM is computed from each nominal feature's confusion matrix.