### PR TITLE
20435: Add a warning and error to `train` for new or invalid values for `features`

### DIFF
--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -253,8 +253,8 @@
 									(associate (concat
 										"The following features trained were previously undefined: "
 										(apply "concat" (trunc (weave (indices new_features) ", "))) ". "
-										"They have now been trained and assumed to be numeric and continuous. "
-										"Please update the feature attributes for this new feature if they are known."
+										"They have been trained and assumed to be numeric and continuous. "
+										"Please update the feature attributes if they are known."
 									))
 							))
 							(accum_to_entities (assoc

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -248,6 +248,15 @@
 
 					(if (size new_features)
 						(seq
+							(accum (assoc
+								warnings
+									(associate (concat
+										"The following features trained were previously undefined: "
+										(apply "concat" (trunc (weave (indices new_features) ", "))) ". "
+										"They have now been trained and assumed to be numeric and continuous. "
+										"Please update the feature attributes for this new feature if they are known."
+									))
+							))
 							(accum_to_entities (assoc
 								!featureAttributes
 									(map
@@ -428,6 +437,20 @@
 							"num_trained" 0
 							"ablated_indices" (list)
 							"status" (null)
+						)
+				))
+			))
+		)
+
+		(if (!= (size features) (size (first input_cases)) )
+			(conclude (conclude
+				(call !Return (assoc
+					errors (list "The number of feature names specified does not match the number of feature values given.")
+					payload
+						(assoc
+							"num_trained" 0
+							"ablated_indices" ablated_indices_list
+							"status" status_output
 						)
 				))
 			))


### PR DESCRIPTION
Adds a warning to Train when a feature that was previously undefined is specified. 

Adds an error to Train that triggers an early exit if the number of feature names specified does not match the number of feature values.