### PR TITLE
20472: Fixes recall and precision metric calculations

### DIFF
--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -694,7 +694,7 @@
 											confusion_matrix
 										))
 									)
-									;The 'confusion_matrix' is not a square matrix. Divides by the length of the rows or columns
+									;The 'confusion_matrix' may not be a square matrix. Divides by the length of the rows or columns
 									; as if the matrix was square by taking the max of the number of non-empty rows or the number
 									; of uniquely predicted column indices.
 									(max
@@ -757,7 +757,7 @@
 											confusion_matrix
 										))
 									)
-									;The 'confusion_matrix' is not a square matrix. Divides by the length of the rows or columns
+									;The 'confusion_matrix' may not be a square matrix. Divides by the length of the rows or columns
 									; as if the matrix was square by taking the max of the number of non-empty rows or the number
 									; of uniquely predicted column indices.
 									(max

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -249,7 +249,7 @@
 	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	; num_samples: optional, limit on the number of cases for the action set to use in calculating conditional residuals. Works with or without 'action_condition_filter_query'. If
 	; 		'action_condition_filter_query' is not provided, will be ignored if 'case_ids' is provided.
-	; context_condition_filter_query: optional list of filtering queries for the context set. Ignored if 'action_condition_filter_query' is not specified. 
+	; context_condition_filter_query: optional list of filtering queries for the context set. Ignored if 'action_condition_filter_query' is not specified.
 	;		If both 'action_condition_filter_query' and 'context_condition_filter_query' are specified, then all of the cases selected by the 'action_condition_filter_query'
 	;		will be excluded from the context set, effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	; focal_case: optional case id of case for which to compute residuals for  is to be ignored during computation
@@ -270,7 +270,7 @@
 			focal_case (null)
 			robust_residuals (false)
 
-			;ordered by priority for the action set, with the 'case_ids' parameters having the top priority. 
+			;ordered by priority for the action set, with the 'case_ids' parameters having the top priority.
 			case_ids (list)
 			action_condition_filter_query (list)
 			context_condition_filter_query (list)
@@ -670,9 +670,9 @@
 				)
 		))
 
-		;precision for a single class is = TruePositives / (TruePositives + FalsePositives)
+		;recall !for a single class is = TruePositives / (TruePositives + FalseNegatives)
 		(assign (assoc
-			precision_map
+			recall_map
 				(map
 					(lambda
 						(let
@@ -694,9 +694,24 @@
 											confusion_matrix
 										))
 									)
-										;filter out any empty rows
-									(size
-										(filter (lambda (size (current_value))) confusion_matrix)
+									;The 'confusion_matrix' is not a square matrix. Divides by the length of the rows or columns
+									; as if the matrix was square by taking the max of the number of non-empty rows or the number
+									; of uniquely predicted column indices.
+									(max
+										;Number of rows, filter out empty rows
+										(size
+											(filter (lambda (size (current_value))) confusion_matrix)
+										)
+										;Number of unique columns
+										(size (values
+											(apply "append"
+												(map
+													(lambda (indices (current_value)))
+													(values confusion_matrix)
+												)
+											)
+											(true)
+										))
 									)
 								)
 							)
@@ -705,9 +720,9 @@
 				)
 		))
 
-		;recall !for a single class is = TruePositives / (TruePositives + FalseNegatives)
+		;precision for a single class is = TruePositives / (TruePositives + FalsePositives)
 		(assign (assoc
-			recall_map
+			precision_map
 				(map
 					(lambda
 						(let
@@ -742,8 +757,25 @@
 											confusion_matrix
 										))
 									)
-									;total predictions count
-									(size confusion_matrix)
+									;The 'confusion_matrix' is not a square matrix. Divides by the length of the rows or columns
+									; as if the matrix was square by taking the max of the number of non-empty rows or the number
+									; of uniquely predicted column indices.
+									(max
+										;Number of rows, filter out empty rows
+										(size
+											(filter (lambda (size (current_value))) confusion_matrix)
+										)
+										;Number of unique columns
+										(size (values
+											(apply "append"
+												(map
+													(lambda (indices (current_value)))
+													(values confusion_matrix)
+												)
+											)
+											(true)
+										))
+									)
 								)
 							)
 						)
@@ -796,7 +828,7 @@
 												)
 											))
 									)
-									
+
 									;calculates the mcc
 									(declare (assoc
 										mcc_numerator

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -670,7 +670,7 @@
 				)
 		))
 
-		;recall !for a single class is = TruePositives / (TruePositives + FalseNegatives)
+		;recall for a single class is = TruePositives / (TruePositives + FalseNegatives)
 		(assign (assoc
 			recall_map
 				(map

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -16,8 +16,8 @@
 	;	"r2": r-squared coefficient of determination, for continuous features only.
 	;	"rmse": root mean squared error, for continuous features only.
 	;	"spearman_coeff": Spearman's rank correlation coefficient, for continuous features only.
-	;	"precision": precision (positive predictive) value for nominal features only. Aggregated by taking unweighted mean of the class precisions.
-	;	"recall": recall (sensitivity) value for nominal features only. Aggregated by taking unweighted mean of the class recalls.
+	;	"precision": precision (positive predictive) value for nominal features only. Aggregated by taking the unweighted means of each classes' precisions.
+	;	"recall": recall (sensitivity) value for nominal features only. Aggregated by taking the unweighted means of each classes' recalls.
 	;	"accuracy": The number of correct predictions divided by the total number of predictions.
 	;	"missing_value_accuracy": The number of correct predictions on cases with missing values values divided by the total number of cases with missing
 	;							  values for a specified feature.

--- a/howso/prediction_stats.amlg
+++ b/howso/prediction_stats.amlg
@@ -16,8 +16,8 @@
 	;	"r2": r-squared coefficient of determination, for continuous features only.
 	;	"rmse": root mean squared error, for continuous features only.
 	;	"spearman_coeff": Spearman's rank correlation coefficient, for continuous features only.
-	;	"precision": precision (positive predictive) value for nominal features only.
-	;	"recall": recall (sensitivity) value for nominal features only.
+	;	"precision": precision (positive predictive) value for nominal features only. Aggregated by taking unweighted mean of the class precisions.
+	;	"recall": recall (sensitivity) value for nominal features only. Aggregated by taking unweighted mean of the class recalls.
 	;	"accuracy": The number of correct predictions divided by the total number of predictions.
 	;	"missing_value_accuracy": The number of correct predictions on cases with missing values values divided by the total number of cases with missing
 	;							  values for a specified feature.
@@ -30,8 +30,8 @@
 	; robust_hyperparameters: flag, optional. if specified, will attempt to return stats that were computed using hyperpparameters with the
 	;						  specified robust or non-robust type.
 	; weight_feature: string, optional. if specified, will attempt to return stats that were computed using this weight_feature.
-	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
-	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
+	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for.
+	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition'
 	;       will be excluded from the context set, which is the set being queried to make to make predictions on the action set, effectively holding them out.
 	;		If only 'action_condition' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
@@ -48,7 +48,7 @@
 	;			If null, will be set to the Howso default limit of 2000. default is null
 	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions on the action set.
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
-	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition' is specified, then only the single predicted case will be left out.	
+	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
 	;			one value = must equal exactly the value or be close to it for fuzzy match
@@ -404,8 +404,8 @@
 	; robust_hyperparameters: flag, optional. if true, will attempt to return residuals that were computed using hyperparameters with the
 	;						  specified robust or non-robust type.
 	; weight_feature: string, optional. if specified, will attempt to return residuals that were computed using this weight_feature.
-	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for. 
-	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition' 
+	; action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for.
+	;		If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition'
 	;       will be excluded from the context set, which is the set being queried to make to make predictions on the action set, effectively holding them out.
 	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
@@ -422,7 +422,7 @@
 	;			If null, will be set to the Howso default limit of 2000. default is null
 	; context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions on the action set.
 	;		If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
-	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.	
+	;       will be excluded from the context set,  effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
 	;		no value = must have feature
 	;   	- for continuous or numeric ordinal features:
 	;			one value = must equal exactly the value or be close to it for fuzzy match
@@ -454,7 +454,7 @@
 		(declare (assoc
 			output_map (assoc)
 			warnings (assoc)
-			action_condition_filter_query 
+			action_condition_filter_query
 				(if action_condition
 					(call !GetQueryByCondition (assoc
 						condition action_condition
@@ -493,7 +493,7 @@
 				stats
 					;if no action_feature was specified, don't bother returning stats that need action_feature
 					(if (= (null) action_feature)
-						(filter (lambda (not (contains_value (list "contribution" "mda" "mda_permutation") (current_value)))) !supportedPredictionStats)
+						(filter (lambda (not (contains_value (list "contribution" "mda" "confusion_matrix" "mda_permutation") (current_value)))) !supportedPredictionStats)
 						!supportedPredictionStats
 					)
 
@@ -503,7 +503,7 @@
 		(declare (assoc
 			basic_stats
 				(filter
-					(lambda (contains_value (list "r2" "rmse" "spearman_coeff" "precision" "recall" "mcc" "accuracy") (current_value)))
+					(lambda (contains_value (list "r2" "rmse" "spearman_coeff" "precision" "recall" "confusion_matrix" "mcc" "accuracy") (current_value)))
 					stats
 				)
 		))

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -279,8 +279,8 @@
 				fruit
 					(assoc
 						accuracy 0.7
-						precision 0.6
-						recall 0.7
+						precision 0.7
+						recall 0.3
 						mae 0.59
 					)
 				height
@@ -348,7 +348,7 @@
 		result
 			(call_entity "howso" "get_prediction_stats" (assoc
 				"robust" (false)
-				"stats" (list "accuracy" "precision")
+				"stats" (list "accuracy" "precision" "recall" "confusion_matrix")
 				"holdout" (true)
 				"precision" "exact"
 				"context_condition" (assoc "size" (list "medium"))
@@ -361,7 +361,18 @@
 	(print "Output conditioned prediction stats for fruits with overlap correctly: ")
 	(call assert_approximate (assoc
 		obs (get result "fruit")
-		exp (assoc accuracy 0.42 precision 0.75)
+		exp (assoc
+			accuracy 0.42
+			recall 0.75
+			precision 0.55
+			confusion_matrix
+				(assoc
+					apple (assoc apple 1)
+					banana (assoc banana 1)
+					peach (assoc peach 1)
+					strawberry (assoc apple 4)
+				)
+			)
 		percent 0.05
 	))
 

--- a/unit_tests/ut_h_weighted_residuals_nom.amlg
+++ b/unit_tests/ut_h_weighted_residuals_nom.amlg
@@ -44,7 +44,7 @@
                 (list 1.0 0.3333 0.6 0.75 0.25)
             ) 210)
         exp_accuracy (/ 4 210)
-        exp_recall
+        exp_precision
             (/
                 (+
                     (/ 0 1) ;blue
@@ -78,7 +78,7 @@
         residuals
             (get
                 (call_entity "howso" "get_prediction_stats" (assoc
-                    stats (list "mae" "accuracy" "recall")
+                    stats (list "mae" "accuracy" "precision")
                     robust (false)
                     weight_feature "case_weight"
                 ))
@@ -93,10 +93,10 @@
         thresh 0.005
     ))
 
-    (print "Recall is as expected: ")
+    (print "exp_precision is as expected: ")
     (call assert_approximate (assoc
-        exp exp_recall
-        obs (get residuals (list "B" "recall"))
+        exp exp_precision
+        obs (get residuals (list "B" "precision"))
         thresh 0.005
     ))
 


### PR DESCRIPTION
Also fixes a bug where confusion matrices couldn't be returned for conditional prediction stats