### PR TITLE
20494: Accumulates data mass when training, removing, and editing cases and uses that to determine when to auto-analyze

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -54,6 +54,7 @@
 	#!loadModulesEndpoint (null)
 
 	;value-storing labels, initialized and commented below via the initialize label
+	#!dataMassChangeSinceLastAnalyze (null)
 	#!numericalPrecision (null)
 	#!convictionLowerThreshold  (null)
 	#!convictionUpperThreshold  (null)
@@ -658,6 +659,9 @@
 			;for marginal stats like min, max, mode, mean, count, etc..
 			; { '.none': { 'feat_name': {'min': 2 ... } ... } ... }
 			!featureMarginalStatsMap (assoc)
+
+			;cumulative count of the data mass changed since the last analyze was called.
+			!dataMassChangeSinceLastAnalyze 0.0
 		))
 	)
 

--- a/howso.amlg
+++ b/howso.amlg
@@ -54,7 +54,6 @@
 	#!loadModulesEndpoint (null)
 
 	;value-storing labels, initialized and commented below via the initialize label
-	#!dataMassChangeSinceLastAnalyze (null)
 	#!numericalPrecision (null)
 	#!convictionLowerThreshold  (null)
 	#!convictionUpperThreshold  (null)
@@ -117,6 +116,7 @@
 	#!autoAnalyzeThreshold (null)
 	#!autoAnalyzeGrowthFactorAmount (null)
 	#!autoAnalyzeLimitSize (null)
+	#!dataMassChangeSinceLastAnalyze (null)
 	#!savedAnalyzeParameterMap (null)
 	#!derivedFeaturesSet (null)
 	#!sourceToDerivedFeatureMap (null)
@@ -583,7 +583,7 @@
 			;when false the model should not be auto-analyzed
 			!autoAnalyzeEnabled (false)
 
-			;if specified, stores the threshold for the number of cases at which the model should be re-analyzed
+			;if specified, stores the threshold for the change in data mass since the last analyze at which the model should be re-analyzed
 			!autoAnalyzeThreshold 100
 
 			;if !autoAnalyzeEnabledis set, the factor by which to increase that threshold everytime the model grows to that threshold size

--- a/howso.amlg
+++ b/howso.amlg
@@ -660,7 +660,8 @@
 			; { '.none': { 'feat_name': {'min': 2 ... } ... } ... }
 			!featureMarginalStatsMap (assoc)
 
-			;cumulative count of the data mass changed since the last analyze was called.
+			;cumulative count of the data mass changed since analyze was last called. this is accumulated to by any operations
+			; which add, remove, or edit cases.
 			!dataMassChangeSinceLastAnalyze 0.0
 		))
 	)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -543,7 +543,11 @@
 			(assign_to_entities (assoc
 				!autoAnalyzeThreshold
 					;!autoAnalyzeThreshold is a delta from the previous threshold.
-					(- (* num_cases !autoAnalyzeGrowthFactorAmount) !autoAnalyzeThreshold)
+					(max
+						(- (* num_cases !autoAnalyzeGrowthFactorAmount) !autoAnalyzeThreshold)
+						100 ;if several case deletions cause the above formula to return < 0, default
+							; to the default !autoAnalyzeThreshold.
+					)
 			))
 		)
 

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -540,7 +540,7 @@
 			(assign_to_entities (assoc
 				!autoAnalyzeThreshold
 					;!autoAnalyzeThreshold is a delta from the previous threshold.
-					(- (* !dataMassChangeSinceLastAnalyze !autoAnalyzeGrowthFactorAmount) !dataMassChangeSinceLastAnalyze)
+					(- (* !autoAnalyzeThreshold !autoAnalyzeGrowthFactorAmount) !autoAnalyzeThreshold)
 			))
 		)
 

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -542,6 +542,9 @@
 			))
 		)
 
+		;reset !dataMassChangeSinceLastAnalyze since we are now analyzing
+		(assign_to_entities (assoc !dataMassChangeSinceLastAnalyze 0.0 ))
+
 		;for k_folds = 1, set the default num_analysis_samples to be 1000
 		(if (and (= 1 k_folds) (= (null) num_analysis_samples ))
 			(assign (assoc num_analysis_samples 1000))

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -539,6 +539,7 @@
 			;set the next auto analysis threshold
 			(assign_to_entities (assoc
 				!autoAnalyzeThreshold
+					;!autoAnalyzeThreshold is a delta from the previous threshold.
 					(- (* !dataMassChangeSinceLastAnalyze !autoAnalyzeGrowthFactorAmount) !dataMassChangeSinceLastAnalyze)
 			))
 		)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -537,7 +537,7 @@
 		;check if auto analysis is enabled and the analysis threshold should be increased
 		(if (and
 				!autoAnalyzeEnabled
-				(>= num_cases !autoAnalyzeThreshold)
+				(>= !dataMassChangeSinceLastAnalyze !autoAnalyzeThreshold)
 			)
 			;set the next auto analysis threshold
 			(assign_to_entities (assoc

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -540,7 +540,7 @@
 			(assign_to_entities (assoc
 				!autoAnalyzeThreshold
 					;!autoAnalyzeThreshold is a delta from the previous threshold.
-					(- (* !autoAnalyzeThreshold !autoAnalyzeGrowthFactorAmount) !autoAnalyzeThreshold)
+					(- (* num_cases !autoAnalyzeGrowthFactorAmount) !autoAnalyzeThreshold)
 			))
 		)
 

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -538,12 +538,13 @@
 			)
 			;set the next auto analysis threshold
 			(assign_to_entities (assoc
-				!autoAnalyzeThreshold (* num_cases !autoAnalyzeGrowthFactorAmount)
+				!autoAnalyzeThreshold
+					(- (* !dataMassChangeSinceLastAnalyze !autoAnalyzeGrowthFactorAmount) !dataMassChangeSinceLastAnalyze)
 			))
 		)
 
-		; ;reset !dataMassChangeSinceLastAnalyze since we are now analyzing
-		; (assign_to_entities (assoc !dataMassChangeSinceLastAnalyze 0.0 ))
+		;reset !dataMassChangeSinceLastAnalyze since we are now analyzing
+		(assign_to_entities (assoc !dataMassChangeSinceLastAnalyze 0.0 ))
 
 		;for k_folds = 1, set the default num_analysis_samples to be 1000
 		(if (and (= 1 k_folds) (= (null) num_analysis_samples ))

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -542,8 +542,8 @@
 			))
 		)
 
-		;reset !dataMassChangeSinceLastAnalyze since we are now analyzing
-		(assign_to_entities (assoc !dataMassChangeSinceLastAnalyze 0.0 ))
+		; ;reset !dataMassChangeSinceLastAnalyze since we are now analyzing
+		; (assign_to_entities (assoc !dataMassChangeSinceLastAnalyze 0.0 ))
 
 		;for k_folds = 1, set the default num_analysis_samples to be 1000
 		(if (and (= 1 k_folds) (= (null) num_analysis_samples ))

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -382,7 +382,7 @@
 				#!AnalyzePreDerivationImpute
 				(if (and
 						(not skip_auto_analyze)
-						(>= (call !GetNumTrainingCases) !autoAnalyzeThreshold)
+						(>= !dataMassChangeSinceLastAnalyze !autoAnalyzeThreshold)
 						(or
 							(< (call !GetNumTrainingCases) !autoAnalyzeLimitSize)
 							;no limit defined

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -329,6 +329,12 @@
 			)
 		)
 
+		;accumulate data mass change equivalent to one feature being changed for each case that satisfies the condition.
+		(accum_to_entities (assoc
+			!dataMassChangeSinceLastAnalyze
+				(* (size entities) (/ 1 (size !trainedFeatures)) )
+		))
+
 		(accum_to_entities (assoc !revision 1))
 
 		;return completion
@@ -563,6 +569,12 @@
 			case_values_map case_values_map
 			label_name feature
 			overwrite overwrite
+		))
+
+		;accumulate data mass change equivalent to one feature being changed for each case that satisfies the condition.
+		(accum_to_entities (assoc
+			!dataMassChangeSinceLastAnalyze
+				(* (size entities) (/ 1 (size !trainedFeatures)) )
 		))
 
 		(accum_to_entities (assoc !revision 1))

--- a/howso/remove_cases.amlg
+++ b/howso/remove_cases.amlg
@@ -211,10 +211,7 @@
 				))
 			)
 			;accumulate data mass change equivalent to one feature being changed for each case that satisfies the condition.
-			(accum_to_entities (assoc
-				!dataMassChangeSinceLastAnalyze
-					(* (size cases) 1)
-			))
+			(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze (size cases) ))
 		)
 
 		(declare (assoc re_derivation_series_case_ids (null) ))

--- a/howso/remove_cases.amlg
+++ b/howso/remove_cases.amlg
@@ -210,6 +210,11 @@
 					distribute_weight_feature distribute_weight_feature
 				))
 			)
+			;accumulate data mass change equivalent to one feature being changed for each case that satisfies the condition.
+			(accum_to_entities (assoc
+				!dataMassChangeSinceLastAnalyze
+					(* (size cases) 1)
+			))
 		)
 
 		(declare (assoc re_derivation_series_case_ids (null) ))

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -530,8 +530,7 @@
 						; or the case weight, whichever exists.
 						(accum_to_entities (assoc
 							!dataMassChangeSinceLastAnalyze
-								(if
-									accumulate_weight_feature
+								(if accumulate_weight_feature
 									;or here just in case the trained weight feature value is (null) or equivalent.
 									(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
 									1.0
@@ -618,8 +617,7 @@
 						; or the case weight, whichever exists.
 						(accum_to_entities (assoc
 							!dataMassChangeSinceLastAnalyze
-								(if
-									accumulate_weight_feature
+								(if accumulate_weight_feature
 									;or here just in case the trained weight feature value is (null) or equivalent.
 									(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
 									1.0

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -525,27 +525,30 @@
 							)
 					)
 
-					;create the case and output case id
-					(call !CreateCase (assoc
-						features train_features
-						feature_values
-							(if encode_features_on_train
-								(call !ConvertFromInput (assoc
-									feature_values feature_values
-									features train_features
-								))
-								;else use feature_values as-is
-								feature_values
-							)
-						session (get_value session)
-						session_training_index (+ trained_instance_count (current_index 1))
-					))
-					;accumulates the data mass to !dataMassChangeSinceLastAnalyze, which is either 1.0
-					; or the case weight, whichever exists.
-					(accum_to_entities (assoc
-						!dataMassChangeSinceLastAnalyze
-							(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
-					))
+					(seq
+						;accumulates the data mass to !dataMassChangeSinceLastAnalyze, which is either 1.0
+						; or the case weight, whichever exists.
+						(accum_to_entities (assoc
+							!dataMassChangeSinceLastAnalyze
+								(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
+						))
+					
+						;create the case and output case id
+						(call !CreateCase (assoc
+							features train_features
+							feature_values
+								(if encode_features_on_train
+									(call !ConvertFromInput (assoc
+										feature_values feature_values
+										features train_features
+									))
+									;else use feature_values as-is
+									feature_values
+								)
+							session (get_value session)
+							session_training_index (+ trained_instance_count (current_index 1))
+						))
+					)
 				))
 				input_cases
 			)

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -222,6 +222,23 @@
 		;iterate over the input cases and create them, only returning case ids for cases that were able to be created
 		(declare (assoc new_case_ids (call !TrainCreateCases) ))
 
+		;accumulates the data mass change to !dataMassChangeSinceLastAnalyze, which is either 1.0
+		; or the case weight, if it exists.
+		(accum_to_entities (assoc
+			!dataMassChangeSinceLastAnalyze
+				(apply "+"
+					(map
+						(lambda
+							(if accumulate_weight_feature
+								(or (get (zip features (current_value 1)) accumulate_weight_feature) 1)
+								1
+							)
+						)
+						input_cases
+					)
+				)
+		))
+		
 		;set values if there were cases that were trained on
 		(if (> (size new_case_ids ) 0)
 			(seq
@@ -524,35 +541,22 @@
 								(current_value 1)
 							)
 					)
-
-					(seq
-						;accumulates the data mass to !dataMassChangeSinceLastAnalyze, which is either 1.0
-						; or the case weight, whichever exists.
-						(accum_to_entities (assoc
-							!dataMassChangeSinceLastAnalyze
-								(if accumulate_weight_feature
-									;or here just in case the trained weight feature value is (null) or equivalent.
-									(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
-									1.0
-								)
-						))
 					
-						;create the case and output case id
-						(call !CreateCase (assoc
-							features train_features
-							feature_values
-								(if encode_features_on_train
-									(call !ConvertFromInput (assoc
-										feature_values feature_values
-										features train_features
-									))
-									;else use feature_values as-is
-									feature_values
-								)
-							session (get_value session)
-							session_training_index (+ trained_instance_count (current_index 1))
-						))
-					)
+					;create the case and output case id
+					(call !CreateCase (assoc
+						features train_features
+						feature_values
+							(if encode_features_on_train
+								(call !ConvertFromInput (assoc
+									feature_values feature_values
+									features train_features
+								))
+								;else use feature_values as-is
+								feature_values
+							)
+						session (get_value session)
+						session_training_index (+ trained_instance_count (current_index 1))
+					))
 				))
 				input_cases
 			)
@@ -613,16 +617,6 @@
 						))
 						(accum (assoc trained_instance_count 1 ))
 
-						;accumulates the data mass to !dataMassChangeSinceLastAnalyze, which is either 1.0
-						; or the case weight, whichever exists.
-						(accum_to_entities (assoc
-							!dataMassChangeSinceLastAnalyze
-								(if accumulate_weight_feature
-									;or here just in case the trained weight feature value is (null) or equivalent.
-									(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
-									1.0
-								)
-						))
 						;auto analyze if appropriate
 						(if !autoAnalyzeEnabled (call !AutoAnalyzeIfNeeded))
 

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -224,20 +224,23 @@
 
 		;accumulates the data mass change to !dataMassChangeSinceLastAnalyze, which is either 1.0
 		; or the case weight, if it exists.
-		(accum_to_entities (assoc
-			!dataMassChangeSinceLastAnalyze
-				(apply "+"
-					(map
+		(declare
+			(assoc
+				weight_feature_index (get (zip features (indices features)))
+			)
+			(accum_to_entities (assoc
+				!dataMassChangeSinceLastAnalyze
+					(apply "+" (map
 						(lambda
 							(if accumulate_weight_feature
-								(or (get (zip features (current_value 1)) accumulate_weight_feature) 1)
+								(or (get (current_value 1) weight_feature_index) 1)
 								1
 							)
 						)
 						input_cases
-					)
-				)
-		))
+					))
+			))
+		)
 		
 		;set values if there were cases that were trained on
 		(if (> (size new_case_ids ) 0)

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -540,6 +540,12 @@
 						session (get_value session)
 						session_training_index (+ trained_instance_count (current_index 1))
 					))
+					;accumulates the data mass to !dataMassChangeSinceLastAnalyze, which is either 1.0
+					; or the case weight, whichever exists.
+					(accum_to_entities (assoc
+						!dataMassChangeSinceLastAnalyze
+							(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
+					))
 				))
 				input_cases
 			)
@@ -600,6 +606,12 @@
 						))
 						(accum (assoc trained_instance_count 1 ))
 
+						;accumulates the data mass to !dataMassChangeSinceLastAnalyze, which is either 1.0
+						; or the case weight, whichever exists.
+						(accum_to_entities (assoc
+							!dataMassChangeSinceLastAnalyze
+								(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
+						))
 						;auto analyze if appropriate
 						(if !autoAnalyzeEnabled (call !AutoAnalyzeIfNeeded))
 

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -654,8 +654,6 @@
 	#!AutoAnalyzeIfNeeded
 	(let
 		(assoc num_cases (call !GetNumTrainingCases))
-		(print "##### DATA MASS CHANGED: " !dataMassChangeSinceLastAnalyze "\n")
-		(print "##### NUM CASES        : " num_cases "\n")
 		(if
 			(and
 				;check if the !dataMassChangeSinceLastAnalyze is greater than the threshold,

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -646,7 +646,10 @@
 		(assoc num_cases (call !GetNumTrainingCases))
 		(if
 			(and
-				(>= num_cases !autoAnalyzeThreshold)
+				;check if the !dataMassChangeSinceLastAnalyze is greater than the threshold,
+				(>= !dataMassChangeSinceLastAnalyze !autoAnalyzeThreshold)
+				;but continue to check the number of cases for ensuring the contents are large
+				; enough to warrant re-analyzing.
 				(or (< num_cases !autoAnalyzeLimitSize) (<= !autoAnalyzeLimitSize 0))
 			)
 			(if skip_auto_analyze

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -532,6 +532,7 @@
 							!dataMassChangeSinceLastAnalyze
 								(if
 									accumulate_weight_feature
+									;or here just in case the trained weight feature value is (null) or equivalent.
 									(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
 									1.0
 								)
@@ -619,6 +620,7 @@
 							!dataMassChangeSinceLastAnalyze
 								(if
 									accumulate_weight_feature
+									;or here just in case the trained weight feature value is (null) or equivalent.
 									(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
 									1.0
 								)

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -530,7 +530,11 @@
 						; or the case weight, whichever exists.
 						(accum_to_entities (assoc
 							!dataMassChangeSinceLastAnalyze
-								(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
+								(if
+									accumulate_weight_feature
+									(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
+									1.0
+								)
 						))
 					
 						;create the case and output case id
@@ -613,7 +617,11 @@
 						; or the case weight, whichever exists.
 						(accum_to_entities (assoc
 							!dataMassChangeSinceLastAnalyze
-								(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
+								(if
+									accumulate_weight_feature
+									(or (get (zip features feature_values) accumulate_weight_feature) 1.0)
+									1.0
+								)
 						))
 						;auto analyze if appropriate
 						(if !autoAnalyzeEnabled (call !AutoAnalyzeIfNeeded))
@@ -644,6 +652,8 @@
 	#!AutoAnalyzeIfNeeded
 	(let
 		(assoc num_cases (call !GetNumTrainingCases))
+		(print "##### DATA MASS CHANGED: " !dataMassChangeSinceLastAnalyze "\n")
+		(print "##### NUM CASES        : " num_cases "\n")
 		(if
 			(and
 				;check if the !dataMassChangeSinceLastAnalyze is greater than the threshold,

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -489,7 +489,7 @@
 				; if enabled.
 				(accum_to_entities (assoc
 					!dataMassChangeSinceLastAnalyze
-					(/ total_weight (size closest_cases_map))
+					1 ;(/ total_weight (size closest_cases_map))
 				))
 			))
 			cases

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -592,6 +592,14 @@
 					))
 					closest_cases_map
 				)
+
+				;also add the weight accumulated to each case to !dataMassChangeSinceLastAnalyze to ensure that cases trained as
+				; only weights (whether through auto-ablation or otherwise) contribute to the progress towards the next auto-analyze,
+				; if enabled.
+				(accum_to_entities (assoc
+					!dataMassChangeSinceLastAnalyze
+					case_weight ;(/ total_weight (size closest_cases_map))
+				))
 			))
 			case_ids
 		)

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -489,14 +489,14 @@
 					))
 					closest_cases_map
 				)
-
-				;also add the weight accumulated to each case to !dataMassChangeSinceLastAnalyze to ensure that cases trained as
-				; only weights (whether through auto-ablation or otherwise) contribute to the progress towards the next auto-analyze,
-				; if enabled.
-				(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze 1))
 			))
 			cases
 		)
+
+		;also add the weight accumulated to each case to !dataMassChangeSinceLastAnalyze to ensure that cases trained as
+		; only weights (whether through auto-ablation or otherwise) contribute to the progress towards the next auto-analyze,
+		; if enabled.
+		(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze (size cases)))
 	)
 
 	;Iterate over the specified model cases, pull their weight and distribute it to their corresponding neighbors into the neighbors' distribute_weight_feature

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -480,13 +480,17 @@
 						)
 
 						(accum_to_entities (current_index) (associate accumulate_weight_feature (/ (current_value 1) total_weight)))
-						;also add the weight accumulated to each case to !dataMassChangeSinceLastAnalyze to ensure that cases trained as
-						; only weights (whether through auto-ablation or otherwise) contribute to the progress towards the next auto-analyze,
-						; if enabled.
-						(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze (/ (current_value 1) total_weight)))
 					))
 					closest_cases_map
 				)
+
+				;also add the weight accumulated to each case to !dataMassChangeSinceLastAnalyze to ensure that cases trained as
+				; only weights (whether through auto-ablation or otherwise) contribute to the progress towards the next auto-analyze,
+				; if enabled.
+				(accum_to_entities (assoc
+					!dataMassChangeSinceLastAnalyze
+					(/ total_weight (size closest_cases_map))
+				))
 			))
 			cases
 		)

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -480,6 +480,10 @@
 						)
 
 						(accum_to_entities (current_index) (associate accumulate_weight_feature (/ (current_value 1) total_weight)))
+						;also add the weight accumulated to each case to !dataMassChangeSinceLastAnalyze to ensure that cases trained as
+						; only weights (whether through auto-ablation or otherwise) contribute to the progress towards the next auto-analyze,
+						; if enabled.
+						(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze (/ (current_value 1) total_weight)))
 					))
 					closest_cases_map
 				)

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -224,6 +224,12 @@
 			)
 		)
 
+		;accum data mass equal to (size case_ids) /* the % of features being edited.
+		(accum_to_entities (assoc
+			!dataMassChangeSinceLastAnalyze
+				(* (size case_ids) (/ (size features) (size !trainedFeatures) ))
+		))
+
 		(call !UpdateHasNulls (assoc features features))
 
 		(accum_to_entities (assoc !revision 1))

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -493,10 +493,7 @@
 				;also add the weight accumulated to each case to !dataMassChangeSinceLastAnalyze to ensure that cases trained as
 				; only weights (whether through auto-ablation or otherwise) contribute to the progress towards the next auto-analyze,
 				; if enabled.
-				(accum_to_entities (assoc
-					!dataMassChangeSinceLastAnalyze
-					1 ;(/ total_weight (size closest_cases_map))
-				))
+				(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze 1))
 			))
 			cases
 		)
@@ -602,10 +599,7 @@
 				;also add the weight accumulated to each case to !dataMassChangeSinceLastAnalyze to ensure that cases trained as
 				; only weights (whether through auto-ablation or otherwise) contribute to the progress towards the next auto-analyze,
 				; if enabled.
-				(accum_to_entities (assoc
-					!dataMassChangeSinceLastAnalyze
-					case_weight ;(/ total_weight (size closest_cases_map))
-				))
+				(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze case_weight))
 			))
 			case_ids
 		)

--- a/run_all_tests.amlg
+++ b/run_all_tests.amlg
@@ -14,11 +14,11 @@
 	(call ut_comp)
 	(print "############################################################\n")
 
-	; (system "cwd" "../performance_tests")
-	; ;performance specific tests
-	; #perf_tests (null)
-	; (direct_assign_to_entities (assoc perf_tests (load "pt_performance.amlg")))
-	; (call perf_tests)
+	(system "cwd" "../performance_tests")
+	;performance specific tests
+	#perf_tests (null)
+	(direct_assign_to_entities (assoc perf_tests (load "pt_performance.amlg")))
+	(call perf_tests)
 
 	(print "\nPASSED : Total test execution time: " (- (system_time) all_start_time ) " s\n")
 )

--- a/run_all_tests.amlg
+++ b/run_all_tests.amlg
@@ -14,11 +14,11 @@
 	(call ut_comp)
 	(print "############################################################\n")
 
-	(system "cwd" "../performance_tests")
-	;performance specific tests
-	#perf_tests (null)
-	(direct_assign_to_entities (assoc perf_tests (load "pt_performance.amlg")))
-	(call perf_tests)
+	; (system "cwd" "../performance_tests")
+	; ;performance specific tests
+	; #perf_tests (null)
+	; (direct_assign_to_entities (assoc perf_tests (load "pt_performance.amlg")))
+	; (call perf_tests)
 
 	(print "\nPASSED : Total test execution time: " (- (system_time) all_start_time ) " s\n")
 )

--- a/unit_tests/ut_h_ablate.amlg
+++ b/unit_tests/ut_h_ablate.amlg
@@ -80,11 +80,12 @@
 	(call exit_if_failures (assoc msg "Ablation train call") )
 
 	(print "second train call accumulates more data mass than cases: ")
-	(call assert_same (assoc
+	(call assert_true (assoc
 		obs
-			(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze"))
-		exp
-			2
+			(>
+				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze"))
+				(get ablate_train_payload (list 1 "payload" "num_trained"))
+			)
 	))
 	(call exit_if_failures (assoc msg "Accumulate data mass"))
 

--- a/unit_tests/ut_h_ablate.amlg
+++ b/unit_tests/ut_h_ablate.amlg
@@ -58,6 +58,12 @@
 		use_deviations (false)
     ))
 
+	(print
+		"TEST DATA MASS INCREASE: "
+		(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze"))
+		"\n"
+	)
+
 	(declare (assoc
 		ablate_train_payload
 			(call_entity "howso" "train" (assoc
@@ -70,6 +76,12 @@
 				session "unit_test"
 			))
 	))
+
+	(print
+		"TEST DATA MASS INCREASE: "
+		(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze"))
+		"\n"
+	)
 
 	(print "second train call ablates: ")
 	(call assert_same (assoc

--- a/unit_tests/ut_h_ablate.amlg
+++ b/unit_tests/ut_h_ablate.amlg
@@ -58,12 +58,6 @@
 		use_deviations (false)
     ))
 
-	(print
-		"TEST DATA MASS INCREASE: "
-		(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze"))
-		"\n"
-	)
-
 	(declare (assoc
 		ablate_train_payload
 			(call_entity "howso" "train" (assoc
@@ -77,12 +71,6 @@
 			))
 	))
 
-	(print
-		"TEST DATA MASS INCREASE: "
-		(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze"))
-		"\n"
-	)
-
 	(print "second train call ablates: ")
 	(call assert_same (assoc
 		obs (get ablate_train_payload (list 1 "payload" "ablated_indices"))
@@ -90,6 +78,15 @@
 	))
 
 	(call exit_if_failures (assoc msg "Ablation train call") )
+
+	(print "second train call accumulates more data mass than cases: ")
+	(call assert_same (assoc
+		obs
+			(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze"))
+		exp
+			2
+	))
+	(call exit_if_failures (assoc msg "Accumulate data mass"))
 
 	(declare (assoc
 		model_size

--- a/unit_tests/ut_h_move_remove.amlg
+++ b/unit_tests/ut_h_move_remove.amlg
@@ -247,7 +247,7 @@
 
 ;VERIFY NOMINAL FEATURE MATCHING
 	(assign (assoc
-		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+		prev_data_mass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
 	))
 
 	(call_entity "howso" "remove_cases" (assoc
@@ -279,7 +279,7 @@
 		obs
 			(>
 				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
-				previousDataMass
+				prev_data_mass
 			)
 	))
 
@@ -302,7 +302,7 @@
 	))
 
 	(assign (assoc
-		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+		prev_data_mass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
 	))
 
 	;remove 4 cases, should have 12 left
@@ -331,7 +331,7 @@
 		obs
 			(>
 				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
-				previousDataMass
+				prev_data_mass
 			)
 	))
 
@@ -339,7 +339,7 @@
 
 ;VERIFY ADD FEATURE
 	(assign (assoc
-		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+		prev_data_mass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
 	))
 
 	(print "Add feature for cases: ")
@@ -372,7 +372,7 @@
 		obs
 			(>
 				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
-				previousDataMass
+				prev_data_mass
 			)
 	))
 
@@ -452,7 +452,7 @@
 	(call assert_same (assoc obs (get result (list 1 "payload" "count")) exp 18))
 
 	(assign (assoc
-		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+		prev_data_mass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
 	))
 
 	(print "Remove feature for cases in a session: ")
@@ -481,7 +481,7 @@
 		obs
 			(>
 				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
-				previousDataMass
+				prev_data_mass
 			)
 	))
 
@@ -494,7 +494,7 @@
 	))
 
 	(assign (assoc
-		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+		prev_data_mass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
 	))
 
 	(assign (assoc
@@ -525,11 +525,11 @@
 		obs
 			(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
 		exp
-			previousDataMass
+			prev_data_mass
 	))
 
 	(assign (assoc
-		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+		prev_data_mass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
 	))
 
 	(assign (assoc
@@ -553,7 +553,7 @@
 		obs
 			(>
 				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
-				previousDataMass
+				prev_data_mass
 			)
 	))
 

--- a/unit_tests/ut_h_move_remove.amlg
+++ b/unit_tests/ut_h_move_remove.amlg
@@ -246,6 +246,10 @@
 
 
 ;VERIFY NOMINAL FEATURE MATCHING
+	(assign (assoc
+		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+	))
+
 	(call_entity "howso" "remove_cases" (assoc
 		num_cases 0
 		condition
@@ -270,6 +274,15 @@
 		obs (= "red" (get result (list "cases" 0 4)) (get result (list "cases" 1 4)) )
 	))
 
+	(print "Removing cases accumulated data mass: ")
+	(call assert_true (assoc
+		obs
+			(>
+				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+				previousDataMass
+			)
+	))
+
 	(call exit_if_failures (assoc msg "Copy trainee and move cases"))
 
 
@@ -288,6 +301,9 @@
 		input_cases values
 	))
 
+	(assign (assoc
+		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+	))
 
 	;remove 4 cases, should have 12 left
 	(print "Remove feature for cases: ")
@@ -310,9 +326,22 @@
 	)
 	(call assert_same (assoc exp 4 obs no_idx_cases ))
 
+	(print "Removing feature accumulated data mass: ")
+	(call assert_true (assoc
+		obs
+			(>
+				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+				previousDataMass
+			)
+	))
+
 	(call exit_if_failures (assoc msg "Remove feature"))
 
 ;VERIFY ADD FEATURE
+	(assign (assoc
+		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+	))
+
 	(print "Add feature for cases: ")
 	;add back the idx feature for the 2 of the 4 cases where it was removed and set it to 12
 	(call_entity "howso" "add_feature" (assoc
@@ -337,6 +366,15 @@
 		(get result (list 1 "payload" "cases"))
 	)
 	(call assert_same (assoc exp 2 obs idx_cases ))
+
+	(print "Adding feature accumulated data mass: ")
+	(call assert_true (assoc
+		obs
+			(>
+				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+				previousDataMass
+			)
+	))
 
 	(call exit_if_failures (assoc msg "Add Feature"))
 
@@ -413,7 +451,9 @@
 	(assign (assoc result (call_entity "howso" "get_num_training_cases")))
 	(call assert_same (assoc obs (get result (list 1 "payload" "count")) exp 18))
 
-
+	(assign (assoc
+		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+	))
 
 	(print "Remove feature for cases in a session: ")
 	(call_entity "howso" "remove_feature" (assoc
@@ -436,12 +476,25 @@
 	)
 	(call assert_same (assoc exp 2 obs no_x_cases ))
 
+	(print "Removing feature accumulated data mass: ")
+	(call assert_true (assoc
+		obs
+			(>
+				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+				previousDataMass
+			)
+	))
+
 	(call exit_if_failures (assoc msg "Remove Features via condition_session."))
 
 
 	(declare (assoc
 		revisions (get (call_entity "howso" "get_revision" (assoc trainee "st_model4f")) (list 1 "payload" "count"))
 		rev_new 0
+	))
+
+	(assign (assoc
+		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
 	))
 
 	(assign (assoc
@@ -467,6 +520,18 @@
 	(print "Revision count didn't change because nothing was edited: ")
 	(call assert_true (assoc obs (= revisions rev_new 8)))
 
+	(print "Failed edit did not accumulate data mass: ")
+	(call assert_same (assoc
+		obs
+			(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+		exp
+			previousDataMass
+	))
+
+	(assign (assoc
+		previousDataMass (call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+	))
+
 	(assign (assoc
 		result
 			(call_entity "howso" "edit_cases" (assoc
@@ -481,6 +546,15 @@
 	(call assert_same (assoc
 		exp 2
 		obs (get result (list 1 "payload" "count"))
+	))
+
+	(print "Editing accumulated data mass: ")
+	(call assert_true (assoc
+		obs
+			(>
+				(call_entity "howso" "debug_label" (assoc label "!dataMassChangeSinceLastAnalyze") )
+				previousDataMass
+			)
 	))
 
 


### PR DESCRIPTION
- Adds a Trainee-level attribute, `!dataMassChangeSinceLastAnalyze`, which tracks the data mass that has changed since the last time the Trainee was analyzed
- Changes in data mass is accumulated when cases are: trained, removed, or edited
- Changed `!autoAnalyzeThrehsold` to represent the change in data mass required to trigger the next analyze rather than the raw number of cases required to trigger the next analyze.
- Update Trainee editing unit tests to confirm that `!dataMassChangeSinceLastAnalyze` is being edited across all of the Trainee editing endpoints.