### PR TITLE
20535: Fixes incorrect min nominal residual computation

### DIFF
--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -94,15 +94,16 @@
 			!cachedFeatureMinResidualMap
 				(map
 					(lambda
-						;For unique features:
-						;Using n+1, n+2, or n+.5 are all possible considerations of Laplacian smoothing to apply a Bayesian approach for
-						;estimating the probability of having no incorrect predictions. We chose .5 assuming the Jeffreys prior approach
-						(if (contains_index !uniqueNominalsSet (current_index))
-							(/ 1 (+ 0.5 num_training_cases))
-
-							;empty datasets set minimal residual to be half a gap
-							(= 0 num_training_cases)
+						;empty datasets set minimal residual to be half a gap
+						(if (= 0 num_training_cases)
 							0.5
+
+							;For unique features:
+							;Using n+1, n+2, or n+.5 are all possible considerations of Laplacian smoothing to apply a Bayesian approach for
+							;estimating the probability of having no incorrect predictions. We chose .5 assuming the Jeffreys prior approach
+							;ensure value is computed for at least 2 cases
+							(contains_index !uniqueNominalsSet (current_index))
+							(/ 1 (+ 0.5 (max num_training_cases 2)) )
 
 							;else set nominal lower residual bound to:  gap / (num_cases + 1)
 							(contains_index !nominalsMap (current_index))

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -101,9 +101,9 @@
 							;For unique features:
 							;Using n+1, n+2, or n+.5 are all possible considerations of Laplacian smoothing to apply a Bayesian approach for
 							;estimating the probability of having no incorrect predictions. We chose .5 assuming the Jeffreys prior approach
-							;ensure value is computed for at least 2 cases
+							;ensure value is not larger than 0.5
 							(contains_index !uniqueNominalsSet (current_index))
-							(/ 1 (+ 0.5 (max num_training_cases 2)) )
+							(min 0.5 (/ 1 (+ 0.5 num_training_cases)) )
 
 							;else set nominal lower residual bound to:  gap / (num_cases + 1)
 							(contains_index !nominalsMap (current_index))

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -911,8 +911,8 @@
 
 							;Using n+1, n+2, or n+.5 are all possible considerations of Laplacian smoothing to apply a Bayesian approach for
 							;estimating the probability of having no incorrect predictions. We chose .5 assuming the Jeffreys prior approach
-							;ensure value is computed for at least 2 cases
-							(/ 1 (+ 0.5 (max (call !GetNumTrainingCases) 2)) )
+							;ensure value is not larger than 0.5
+							(min 0.5 (/ 1 (+ 0.5 (call !GetNumTrainingCases))) )
 						)
 				))
 			)

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -911,9 +911,8 @@
 
 							;Using n+1, n+2, or n+.5 are all possible considerations of Laplacian smoothing to apply a Bayesian approach for
 							;estimating the probability of having no incorrect predictions. We chose .5 assuming the Jeffreys prior approach
-							(- 1
-								(/ 1 (+ 0.5 (call !GetNumTrainingCases)))
-							)
+							;ensure value is computed for at least 2 cases
+							(/ 1 (+ 0.5 (max (call !GetNumTrainingCases) 2)) )
 						)
 				))
 			)


### PR DESCRIPTION
using 1/ (0.5 + num_cases) has to be limited when num_cases is 0 or 1, because that'll result in values > 0.5