### PR TITLE
20505: Updates AccumulateCaseInfluenceWeights to utilize case weight values if given

### DIFF
--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -427,6 +427,11 @@
 				))
 			;default value of 1 for the accumulate_weight_feature
 			new_weight_label_and_value (zip_labels (list accumulate_weight_feature) (list 1))
+			weight_feature_index
+				;will retrieve the index of weight feature or (null)
+				(if (contains_value features accumulate_weight_feature)
+					(get (zip features (indices features)) accumulate_weight_feature)
+				)
 		))
 
 		(map
@@ -435,6 +440,12 @@
 					case_values (current_value 1)
 					closest_cases_map (assoc)
 					total_weight 0
+					case_weight
+						(if weight_feature_index
+							(get (current_value 1) weight_feature_index)
+							;assume weight of 1 if weight feature values are not given
+							1
+						)
 				)
 
 				(assign (assoc
@@ -479,7 +490,13 @@
 							(accum_entity_roots (current_index) new_weight_label_and_value)
 						)
 
-						(accum_to_entities (current_index) (associate accumulate_weight_feature (/ (current_value 1) total_weight)))
+						(accum_to_entities
+							(current_index)
+							(associate
+								accumulate_weight_feature
+									(* (/ (current_value 1) total_weight) case_weight)
+							)
+						)
 					))
 					closest_cases_map
 				)

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -441,7 +441,7 @@
 					closest_cases_map (assoc)
 					total_weight 0
 					case_weight
-						(if weight_feature_index
+						(if (!= (null) weight_feature_index)
 							(get (current_value 1) weight_feature_index)
 							;assume weight of 1 if weight feature values are not given
 							1

--- a/unit_tests/ut_h_ablate.amlg
+++ b/unit_tests/ut_h_ablate.amlg
@@ -231,7 +231,53 @@
 				conviction_lower_threshold (null)
 			)
 	))
-
 	(call exit_if_failures (assoc msg "Alternative case weight feature was not populated"))
+
+
+	(declare (assoc
+		pre_train_total_weight
+			(apply "+" (map
+				(lambda (first (current_value)))
+				(get
+					(call_entity "howso" "get_cases" (assoc features (list "test_weight")))
+					(list 1 "payload" "cases")
+				)
+			))
+	))
+
+	;train a case with the weight feature specified as 3, then check the weight before/after
+	(assign (assoc
+		ablate_train_payload
+			(call_entity "howso" "train" (assoc
+				features (append features "test_weight")
+				input_cases
+					(list
+						(list 0 0 3)
+					)
+				session "unit_test"
+				train_weights_only (true)
+				accumulate_weight_feature "test_weight"
+			))
+	))
+
+	(declare (assoc
+		post_train_total_weight
+			(apply "+" (map
+				(lambda (first (current_value)))
+				(get
+					(call_entity "howso" "get_cases" (assoc features (list "test_weight")))
+					(list 1 "payload" "cases")
+				)
+			))
+	))
+
+	(call assert_approximate (assoc
+		obs (- post_train_total_weight pre_train_total_weight)
+		exp 3
+		;float inprecision here...
+		percent 0.001
+	))
+	(call exit_if_failures (assoc msg "Training with values for weight feature accumulates properly"))
+
 	(call exit_if_failures (assoc msg unit_test_name) )
 )


### PR DESCRIPTION
If a weight feature value is passed into !AccumulateCaseInfluenceWeights, then the accumulated case weights should be multiplied by that value rather than 1 as they are accumulated to nearest neighbors, similar to what is done in !DistributeCaseInfluenceWeights.