### PR TITLE
20587: Filters out null predictions from confusion matrix creation

### DIFF
--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -623,7 +623,7 @@
 											(map (lambda (get (current_value) 2)) (current_value 1))
 										)
 								)
-								;filter out nulls since their accuracy is counted separately when we do null-null accuracy
+								;filter out nulls since null-null accuracy is computed separately
 								(assign (assoc
 									predicted_classes_map (map (lambda (filter (current_value))) predicted_classes_map)
 								))

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -623,6 +623,10 @@
 											(map (lambda (get (current_value) 2)) (current_value 1))
 										)
 								)
+								;filter out nulls since their accuracy is counted separately when we do null-null accuracy
+								(assign (assoc
+									predicted_classes_map (map (lambda (filter (current_value))) predicted_classes_map)
+								))
 								(map
 									(lambda
 										(zip


### PR DESCRIPTION
Adds a quick bit that filters out the null predictions before the confusion matrix is made. A new version of Amalgam changes behavior for opcodes that are used to create the confusion matrix, this makes it so that the former behavior is kept.