### PR TITLE
20591: Filters case weight feature from being in query context

### DIFF
--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -438,12 +438,13 @@
 				(if (contains_value features accumulate_weight_feature)
 					(get (zip features (indices features)) accumulate_weight_feature)
 				)
+			context_features (filter (lambda (!= (current_value) accumulate_weight_feature)) features)
 		))
 
 		(map
 			(lambda (let
 				(assoc
-					case_values (current_value 1)
+					case_value_map (zip features (current_value 1))
 					closest_cases_map (assoc)
 					total_weight 0
 					case_weight
@@ -460,8 +461,8 @@
 						(compute_on_contained_entities (list
 							(query_nearest_generalized_distance
 								(get hyperparam_map "k")
-								features
-								case_values
+								context_features
+								(unzip case_value_map context_features)
 								(get hyperparam_map "featureWeights")
 								!queryDistanceTypeMap
 								(get hyperparam_map "featureDomainAttributes")


### PR DESCRIPTION
AccumulateCaseInfluenceWeights was updated to support the case weight feature/values but there was no check/logic around ensuring the case weight feature is not used as a context feature.

This checks/fixes that.