### PR TITLE
20608: Fixes reduce data removing all cases occasionally

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -575,7 +575,7 @@
 			!autoAblationConvictionLowerThreshold (null)
 
 			;the name of the weight feature to use for auto ablation.
-			!autoAblationWeightFeature (null)
+			!autoAblationWeightFeature ".case_weight"
 
 			;whether this Trainee has had influence weight entropies computed and stored for its trained cases.
 			!hasInfluenceWeightEntropies (false)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -117,11 +117,7 @@
 
 		(call !StoreCaseValues (assoc
 			case_values_map influence_weight_entropy_map
-			label_name
-				(if (= (null) label_name)
-					!internalLabelInfluenceWeightEntropy
-					label_name
-				)
+			label_name (or label_name !internalLabelInfluenceWeightEntropy)
 		))
 
 		(accum_to_entities (assoc !revision 1))
@@ -159,16 +155,23 @@
 		)
 
 		(if (not !hasPopulatedCaseWeight)
-			(call !InitializeAutoAblation)
+			(call !InitializeAutoAblation (assoc
+				weight_feature distribute_weight_feature
+			))
 		)
 		(if (not !hasInfluenceWeightEntropies)
-			(call !ComputeAndStoreInfluenceWeightEntropies)
+			(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+				features features
+				weight_feature distribute_weight_feature
+				use_case_weights (true)
+			))
 		)
 
 		(assign (assoc
 			max_influence_weight_entropy_to_keep
 				(compute_on_contained_entities (list
 					(query_exists !internalLabelInfluenceWeightEntropy)
+					(query_not_equals !internalLabelInfluenceWeightEntropy 0)
 					(query_quantile
 						!internalLabelInfluenceWeightEntropy
 						influence_weight_entropy_threshold
@@ -224,7 +227,12 @@
 			max_influence_weight_entropy_to_keep
 				(compute_on_contained_entities (list
 					(query_exists !internalLabelInfluenceWeightEntropy)
-					(query_quantile !internalLabelInfluenceWeightEntropy !autoAblationInfluenceWeightEntropyThreshold ".case_weight")
+					(query_not_equals !internalLabelInfluenceWeightEntropy 0)
+					(query_quantile
+						!internalLabelInfluenceWeightEntropy
+						!autoAblationInfluenceWeightEntropyThreshold
+						!autoAblationWeightFeature
+					)
 				))
 		))
 

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -169,14 +169,9 @@
 
 		(assign (assoc
 			max_influence_weight_entropy_to_keep
-				(compute_on_contained_entities (list
-					(query_exists !internalLabelInfluenceWeightEntropy)
-					(query_not_equals !internalLabelInfluenceWeightEntropy 0)
-					(query_quantile
-						!internalLabelInfluenceWeightEntropy
-						influence_weight_entropy_threshold
-						distribute_weight_feature
-					)
+				(call !MaxInfluenceWeightEntropyToKeepQuery (assoc
+					influence_weight_entropy_threshold influence_weight_entropy_threshold
+					weight_feature distribute_weight_feature
 				))
 		))
 
@@ -194,6 +189,24 @@
 
 		(accum_to_entities (assoc !revision 1))
 		(call !Return)
+	)
+
+	#!MaxInfluenceWeightEntropyToKeepQuery
+	(declare
+		(assoc
+			influence_weight_entropy_threshold !autoAblationInfluenceWeightEntropyThreshold
+			weight_feature !autoAblationWeightFeature
+		)
+
+		(compute_on_contained_entities (list
+			(query_exists !internalLabelInfluenceWeightEntropy)
+			(query_not_equals !internalLabelInfluenceWeightEntropy 0)
+			(query_quantile
+				!internalLabelInfluenceWeightEntropy
+				influence_weight_entropy_threshold
+				weight_feature
+			)
+		))
 	)
 
 	;determine whether a new case (one that is not in the Trainee) should be ablated (trained as weights) or kept.
@@ -225,15 +238,7 @@
 
 		(assign (assoc
 			max_influence_weight_entropy_to_keep
-				(compute_on_contained_entities (list
-					(query_exists !internalLabelInfluenceWeightEntropy)
-					(query_not_equals !internalLabelInfluenceWeightEntropy 0)
-					(query_quantile
-						!internalLabelInfluenceWeightEntropy
-						!autoAblationInfluenceWeightEntropyThreshold
-						!autoAblationWeightFeature
-					)
-				))
+				(call !MaxInfluenceWeightEntropyToKeepQuery)
 		))
 
 		(+

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -191,6 +191,11 @@
 		(call !Return)
 	)
 
+	;helper method which queries and returns the specified quantile of influence weight entropies
+	; for use in data reduction and auto-ablation.
+	; influence_weight_entropy_threshold: optional, default !autoAblationInfluenceWeightEntropyThreshold. cases with
+	; 	influence weight entropy above this quantile will be removed
+	; weight_feature: optional, default !autoAblationWeightFeature. name of feature whose values to use as case weights
 	#!MaxInfluenceWeightEntropyToKeepQuery
 	(declare
 		(assoc


### PR DESCRIPTION
Fixes `reduce_data` for datasets where most cases have an `influence_weight_entropy` of 0. Previously, if too many cases had an `influence_weight_entropy` of 0 when `reduce_data` was called the threshold percentile had a chance of being equal to 0 which would remove all of the cases in the model.

Also does parameter cleanup and moves the query that is shared by data reduction and auto-ablation into its own method, to ensure unity.