### PR TITLE
20609: Updates to replace `.nan` and `.nas` with `(null)`

### DIFF
--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -162,7 +162,7 @@
 						(call !GetCasesByCondition (assoc
 							condition
 								(associate
-									!internalLabelInfluenceWeightEntropy 
+									!internalLabelInfluenceWeightEntropy
 										(list max_influence_weight_entropy_to_keep .infinity)
 								)
 							num_cases !autoAnalyzeThreshold
@@ -255,7 +255,7 @@
 				)
 				; This is probably unnecessary but in case we cannot compute the requested influence weight
 				; quantile return 1 as well.
-				(= max_influence_weight_entropy_to_keep .nan)
+				(= max_influence_weight_entropy_to_keep (null))
 			)
 		)
 	)

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -286,7 +286,7 @@
 
 
 									;infinity means there was no gap, and nan means all values are null and can't compute gap
-									(if (or (= .nan min_gap) (= .infinity min_gap) (= .infinity max_gap))
+									(if (or (= (null) min_gap) (= .infinity min_gap) (= .infinity max_gap))
 										1
 										;use average of max_gap/2 and min_gap/2
 										(/ (+ (/ max_gap 2) (/ min_gap 2)) 2)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -744,15 +744,15 @@
 			value_feature_nulls_are_dependent (get !featureAttributes (list value_feature "null_is_dependent"))
 		))
 
-		;if the continuous feature's attribute is to treat null as dependent, add .nas as a valid value for this dependent nominal feature if it has nulls
+		;if the continuous feature's attribute is to treat null as dependent, add (null) as a valid value for this dependent nominal feature if it has nulls
 		(if value_feature_nulls_are_dependent
-			;if this feature has any nulls, add .nas as a unique nominal feature value for which to compute boundaries
+			;if this feature has any nulls, add (null) as a unique nominal feature value for which to compute boundaries
 			(if
 				(compute_on_contained_entities (list
 					(query_equals feature (null))
 					(query_count)
 				))
-				(accum (assoc feature_values .nas))
+				(accum (assoc feature_values (list (null)) ))
 			)
 		)
 
@@ -768,14 +768,10 @@
 							(append base_query_among_statements (list
 								(query_among feature
 									(list
-										;convert .nas to (null) for query_among usage
-										(if (= .nas (current_index 3))
-											(null)
-											;ensure that the value in the query_among is a number by wrapping it in a (+) if the nominal is not a string
-											(if (contains_index !numericNominalFeaturesMap feature)
-												(+ (current_index 3))
-												(current_index 3)
-											)
+										;ensure that the value in the query_among is a number by wrapping it in a (+) if the nominal is not a string
+										(if (contains_index !numericNominalFeaturesMap feature)
+											(+ (current_index 3))
+											(current_index 3)
 										)
 									)
 								)
@@ -800,14 +796,10 @@
 							(append base_query_among_statements (list
 								(query_among feature
 									(list
-										;convert .nas to (null) for query_among usage
-										(if (= .nas (current_index 3))
-											(null)
-											;ensure that the value in the query_among is a number by wrapping it in a (+) if the nominal is not a string
-											(if (contains_index !numericNominalFeaturesMap feature)
-												(+ (current_index 3))
-												(current_index 3)
-											)
+										;ensure that the value in the query_among is a number by wrapping it in a (+) if the nominal is not a string
+										(if (contains_index !numericNominalFeaturesMap feature)
+											(+ (current_index 3))
+											(current_index 3)
 										)
 									)
 								)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -769,6 +769,7 @@
 								(query_among feature
 									(list
 										;ensure that the value in the query_among is a number by wrapping it in a (+) if the nominal is not a string
+										;if the value is (null), it will still be (null) after the (+)
 										(if (contains_index !numericNominalFeaturesMap feature)
 											(+ (current_index 3))
 											(current_index 3)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -187,15 +187,15 @@
 		(declare (assoc directional_contributions_map (map (lambda (last (current_value))) feature_contributions_map) ))
 		(assign (assoc feature_contributions_map  (map (lambda (first (current_value))) feature_contributions_map) ))
 
-		;replace .nan with 0 to prevent .nan output, in situations where there were not enough samples to compute a contribution for a feature
-		(if (contains_value feature_contributions_map .nan)
+		;replace (null) with 0 to prevent (null) output, in situations where there were not enough samples to compute a contribution for a feature
+		(if (contains_value feature_contributions_map (null))
 			(assign (assoc
-				feature_contributions_map (map (lambda (if (= .nan (current_value)) 0 (current_value) )) feature_contributions_map)
+				feature_contributions_map (map (lambda (if (= (null) (current_value)) 0 (current_value) )) feature_contributions_map)
 			))
 		)
-		(if (contains_value directional_contributions_map .nan)
+		(if (contains_value directional_contributions_map (null))
 			(assign (assoc
-				directional_contributions_map (map (lambda (if (= .nan (current_value)) 0 (current_value) )) directional_contributions_map)
+				directional_contributions_map (map (lambda (if (= (null) (current_value)) 0 (current_value) )) directional_contributions_map)
 			))
 		)
 

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -160,15 +160,6 @@
 						))
 				))
 
-				;replace .nan with (null).  .nan are possible for initial cases in a series since they don't have any lags
-				(assign (assoc
-					series_data
-						(map
-							(lambda (if (= .nan (current_value)) (null) (current_value)))
-							series_data
-						)
-				))
-
 				;null out rate and delta features for the initial case in a series so it can be imputed below since those derived values
 				;may be quite inaccurate. Run only on the first 'feature_time_series_order' cases in the series (i.e., 2 cases for rate_2)
 				(if (or (= "rate" feature_time_series_type) (= "delta" feature_time_series_type))
@@ -698,11 +689,6 @@
 											(call_sandboxed new_feature_transform_processed (assoc feature_values_map feature_values_map) op_limit !sandboxedMemoryLimit)
 										)
 								))
-
-								;prevent output of .nan, replace with null if any encountered
-								(if (= .nan output_value)
-									(assign (assoc output_value (null)))
-								)
 
 								;append derived feature and value to the input features and values so that they could be used by the next derived feature
 								(accum (assoc feature_values_map (associate (current_value 2) output_value)))

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -182,11 +182,6 @@
 				)
 		))
 
-		;replace .nan with (null).  .nan are possible for initial cases in a series since they don't have any lags
-		(if (= .nan derived_feature_value)
-			(assign (assoc derived_feature_value (null)))
-		)
-
 		(declare (assoc
 			bounds_map
 				;if specific bounds were passed in, use those, else use globally specified feature bounds

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -678,6 +678,7 @@
 
 						;indices of a map are all strings, so convert them to correct types if necessary
 						(assign "hypothetical_action_values_map" (list feature)
+							;convert the values to numbers if the feature is numeric, (null)'s will be unaffected
 							(if (contains_index !numericNominalFeaturesMap action_feature)
 								(+ output_value)
 

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -89,15 +89,15 @@
 	;						locally around the prediction. Uses only the context features of the reacted case to
 	;						determine that area. Relies on 'robust_residuals' flag.
 	;
-	;		 "prediction_stats" true or false. If true outputs feature prediction stats for all (context and action) 
+	;		 "prediction_stats" true or false. If true outputs feature prediction stats for all (context and action)
 	;						features locally around the prediction. The stats returned are ("r2", "rmse", "spearman_coeff",
 	;						"precision", "recall", "accuracy", "mcc"). Confusion matrices may also be returned by setting
-	;						'confusion_matrices' to true. Uses only the context features of the reacted case to determine that 
+	;						'confusion_matrices' to true. Uses only the context features of the reacted case to determine that
 	;						area. Relies on 'robust_residuals' flag.
 	;
-	;		 "confusion_matrices" true or false. If true, will automatically set 'prediction_stats' to true and return the 
-	;						confusion matrices alongside all of the other prediction stats from 'prediction_stats' for all 
-	;						(context and action) features locally around the prediction. Uses only the context features of 
+	;		 "confusion_matrices" true or false. If true, will automatically set 'prediction_stats' to true and return the
+	;						confusion matrices alongside all of the other prediction stats from 'prediction_stats' for all
+	;						(context and action) features locally around the prediction. Uses only the context features of
 	;						the reacted case to determine that area. Relies on 'robust_residuals' flag.
 	;
 	;		 "feature_mda" true or false. If true outputs each context feature's mean decrease in accuracy of predicting
@@ -444,8 +444,8 @@
 
 		;append feature errors and deviations
 		(if (or (get details "prediction_stats") (get details "feature_residuals"))
-			(declare 
-				(assoc 
+			(declare
+				(assoc
 					compute_all_statistics (false)
 					store_values (false)
 				)
@@ -678,10 +678,7 @@
 
 						;indices of a map are all strings, so convert them to correct types if necessary
 						(assign "hypothetical_action_values_map" (list feature)
-							(if (= .nas output_value)
-								(null)
-
-								(contains_index !numericNominalFeaturesMap action_feature)
+							(if (contains_index !numericNominalFeaturesMap action_feature)
 								(+ output_value)
 
 								(contains_index !ordinalNumericFeaturesSet action_feature)

--- a/howso/distances.amlg
+++ b/howso/distances.amlg
@@ -150,13 +150,13 @@
 			output
 				(assoc
 					distance_ratio
-						;The distance_ratio can be .infinity or .nan if there are no cases
+						;The distance_ratio can be .infinity or (null) if there are no cases
 						;in the model which are different from the cases being reacted to.
 						;Since these are effectively no different from duplicates, from a
 						;privacy standpoint, we return 0 in these cases.
 						(if (= distance_ratio .infinity)
 							0
-							(= distance_ratio .nan)
+							(= distance_ratio (null))
 							0
 							distance_ratio
 						)

--- a/howso/impute.amlg
+++ b/howso/impute.amlg
@@ -151,7 +151,6 @@
 										)
 								)
 								;if entropy is ever (null), set the value to 1 so that only the number of nulls matters
-								;TODO: remove this statement after implementing 2992
 								(if (= (null) entropy_of_row )
 									(assign (assoc entropy_of_row 1))
 								)

--- a/howso/impute.amlg
+++ b/howso/impute.amlg
@@ -150,9 +150,9 @@
 											))
 										)
 								)
-								;if entropy is ever nan, set the value to 1 so that only the number of nulls matters
+								;if entropy is ever (null), set the value to 1 so that only the number of nulls matters
 								;TODO: remove this statement after implementing 2992
-								(if (= .nan entropy_of_row )
+								(if (= (null) entropy_of_row )
 									(assign (assoc entropy_of_row 1))
 								)
 
@@ -231,9 +231,9 @@
 									context_features non_null_features
 									context_values (unzip context_values_map non_null_features)
 									;passing in raw feature values, so skip nominal encoding
-									skip_encoding 1
+									skip_encoding (true)
 									;output raw values as well
-									skip_decoding 1
+									skip_decoding (true)
 									;since we're imputing we want to explicitly only find neighbors that have matching (non-null) features
 									match_on_context_features (true)
 									substitute_output (false)
@@ -241,31 +241,6 @@
 									ignore_case case_entity_id
 								))
 						))
-
-						;.nan value could possibly happen if either tiny or extremely sparse dataset can't find matching cases with valid distances to cases with filled
-						;feature value due to not having matching filled features, thus replace any .nan with the feature expected value
-						(if (contains_value action_values .nan)
-							(assign (assoc
-								action_values
-									(map
-										(lambda
-											(if (= .nan (current_value))
-												(get
-													(call !CalculateFeatureExpectedValue (assoc
-														feature (get fill_features (current_index 1))
-														output_instead_of_store (true)
-													))
-													"expected_value"
-												)
-
-												;leave it as-is
-												(current_value)
-											)
-										)
-										action_values
-									)
-							))
-						)
 
 						(if (contains_value action_values (null))
 							(assign (assoc has_remaining_null 1))

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -251,7 +251,7 @@
 
 								;output the decrease in accuracy as a ratio of the feature / baseline MAE
 								(if output_ratio
-									;prevent output of .nan in case all maes are 0
+									;prevent output of (null) in case all maes are 0
 									(if (= 0 baseline_error)
 										.infinity
 

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -285,7 +285,7 @@
 									;uses typing_map, method_name, and parameter_name. accums to invalid_type_hints
 									#!CheckTypingMap
 									(seq
-										(if (or (= (null) typing_map) (= .nas typing_map))
+										(if (= (null) typing_map)
 											(accum (assoc invalid_type_hints (list (concat method_name "/" parameter_name))))
 										)
 

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -99,9 +99,9 @@
 							))
 					)
 
-					;store count of nulls as .nas into the map
+					;store count of nulls as (null) into the map
 					(if feature_null_count
-						(accum (assoc feature_value_count_map (assoc .nas feature_null_count)))
+						(accum (assoc feature_value_count_map (assoc (null) feature_null_count)))
 					)
 
 					;store the value into cache if needed, specifically every time this method is called on the whole model,
@@ -116,11 +116,6 @@
 										(query_mode feature query_weight_feature (contains_index !numericNominalFeaturesMap feature))
 									))
 							))
-
-							;value maybe .nan if model is empty, prevent output by converting to null
-							(if (= feature_mode .nan)
-								(assign (assoc feature_mode (null)))
-							)
 
 							(if (not output_instead_of_store)
 								(assign_to_entities (assoc
@@ -153,20 +148,10 @@
 
 						;else, figure out which nominal value has the highest count and output that one as the expected
 						(if (= (null) feature_mode)
-							(seq
-								(assign (assoc
-									feature_mode
-										(compute_on_contained_entities (list
-											(query_in_entity_list case_ids)
-											(query_mode feature query_weight_feature (contains_index !numericNominalFeaturesMap feature))
-										))
-								))
-								;value maybe .nan if model is empty, prevent output by converting to null
-								(if (= feature_mode .nan)
-									(null)
-									feature_mode
-								)
-							)
+							(compute_on_contained_entities (list
+								(query_in_entity_list case_ids)
+								(query_mode feature query_weight_feature (contains_index !numericNominalFeaturesMap feature))
+							))
 
 							;else output the feature value with the max count that was already already calculated above
 							feature_mode
@@ -184,11 +169,6 @@
 								;calculate arithmetic average
 								(query_generalized_mean feature 1 query_weight_feature)
 							))
-					)
-
-					;value maybe .nan if model is empty, prevent output by converting to null
-					(if (= avg_feature_value .nan)
-						(assign (assoc avg_feature_value (null)))
 					)
 
 					(if output_instead_of_store
@@ -489,7 +469,7 @@
 								;true means there are nulls, false means no nulls, null means unknown whether there are nulls
 								"has_nulls" (> num_nulls 0)
 								"null_residual"
-									(if (!= .nan (- max min))
+									(if (!= (null) (- max min))
 										(- max min)
 										0
 									)
@@ -790,23 +770,23 @@
 								))
 							)
 
-							;output assoc of marginal stats for the feature, replace .nan with null if needed
+							;output assoc of marginal stats for the feature
 							(assoc
-								min (if (!= .nan min) min)
-								max (if (!= .nan max) max)
-								mean (if (!= .nan mean) mean)
-								median (if (!= .nan median) median)
-								percentile_25 (if (!= .nan percentile_25) percentile_25)
-								percentile_75 (if (!= .nan percentile_75) percentile_75)
-								mode (if (!= .nan mode) mode)
+								min min
+								max max
+								mean mean
+								median median
+								percentile_25 percentile_25
+								percentile_75 percentile_75
+								mode mode
 								count count
 								uniques uniques
-								mean_absdev (if (!= .nan mean_absdev) mean_absdev)
-								variance (if (!= .nan variance) variance)
-								stddev (if (!= .nan stddev) stddev)
-								skew (if (!= .nan skew) skew)
-								kurtosis (if (!= .nan kurtosis) kurtosis)
-								entropy (if (!= .nan entropy) entropy)
+								mean_absdev mean_absdev
+								variance variance
+								stddev stddev
+								skew skew
+								kurtosis kurtosis
+								entropy entropy
 							)
 						))
 						(zip !trainedFeatures)

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1002,8 +1002,11 @@
 		;populate filtering_queries for details if necessary
 		(call !PopulateFilteringQueriesForDetails)
 
-		;if there is no context, calculate the expected value
-		(if (= (list) context_features)
+		;if there is no context or local model, calculate the expected value
+		(if (or
+				(= (list) context_features)
+				(= 0 (size (first candidate_cases_lists)))
+			)
 			(call !CalculateFeatureExpectedValue (assoc feature (first action_features) allow_nulls (false)))
 
 			;else interpolate the result from the nearest neighbors

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -701,12 +701,7 @@
 						)
 				))
 
-				;parse the categorical neighbor value to handle the situation where the value is the string .nas
-				;and convert it to an actual (null), all other numerical or string literals will remain unchanged
-				(if (= .nas output_value)
-					(null)
-
-					(contains_index !numericNominalFeaturesMap action_feature)
+				(if (contains_index !numericNominalFeaturesMap action_feature)
 					(+ output_value)
 
 					(contains_index !ordinalNumericFeaturesSet action_feature)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -75,9 +75,9 @@
 						(if (= .infinity smallest_gap)
 							0
 
-							;nan means that all values are nulls and a gap couldn't be computed
+							;(null) means that all values are nulls and a gap couldn't be computed
 							;set it to be 0.1 for edit distance feature, and zero for all other continuous
-							(= .nan smallest_gap)
+							(= (null) smallest_gap)
 							(if (contains_index !editDistanceFeatureTypesMap (current_index))
 								0.1
 								0
@@ -962,7 +962,7 @@
 
 				;else continuous, output [diff, ordinal_diff, actual, predicted] for computing MAE, RSME, R^2
 				(and
-					(= .nan (- case_feature_value interpolated_value))
+					(= (null) (- case_feature_value interpolated_value))
 					(not feature_is_edit_distance)
 				)
 				(null)
@@ -1008,8 +1008,8 @@
 						)
 				))
 
-				;output the residual. if it's .nan, output null for non-nominals, and 1 (or case weight) for nominals
-				(if (= .nan diff)
+				;output the residual. if it's (null), output null for non-nominals, and 1 (or case weight) for nominals
+				(if (= (null) diff)
 					(if feature_is_nominal 1)
 
 					;else output tuple [diff, ordinal_diff] for ordinals, and diff for continuous if applicable

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -309,11 +309,6 @@
 							))
 						)
 
-						;prevent nan from output by converting to null
-						(if (= .nan new_feature_value)
-							(assign (assoc new_feature_value (null)))
-						)
-
 						;wrap code in a list so it can be appended correctly to the list of context_values
 						(if edit_distance_code_feature
 							(assign (assoc new_feature_value (list new_feature_value) ))
@@ -862,7 +857,7 @@
 
 		;if feature_residual is null but there is an action value, this may generate a 'nan' value for this feature
 		;to prevent that, set the residual to: boundary_max - boundary_min (if boundaries are specified)
-		(if (and (or (= (null) feature_residual) (= .nan feature_residual)) (!= (null) action_value))
+		(if (and (= (null) feature_residual) (!= (null) action_value))
 			(let
 				(assoc
 					boundaries_tuple
@@ -960,12 +955,9 @@
 						(assoc
 							unique_local_ordinal_values
 								(map
-									;convert the indices to numbers since ordinals are numeric, convert .nas back to null
+									;convert the indices to numbers since ordinals are numeric
 									(lambda
-										(if (= .nas (current_value))
-											(null)
-											(+ (current_value))
-										)
+										(+ (current_value))
 									)
 									;grab unique values only by taking the indices of the assoc of ordinal values in the local model
 									(values

--- a/howso/synthesis_bounds.amlg
+++ b/howso/synthesis_bounds.amlg
@@ -235,7 +235,7 @@
 									(get data_map (lambda label_name))
 
 									;else feature hasn't been generated yet
-									.nas
+									(null)
 								)
 							)
 					))
@@ -382,7 +382,7 @@
 													)
 
 													;else feature hasn't been generated yet
-													.nas
+													(null)
 												)
 											)
 									))

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -125,10 +125,10 @@
 						(if (= 0 (size class_probabilities_map))
 							(assign (assoc
 								class_probabilities_map
-									;nominals are enumerated, if there happens to be a class value of .nas it will be enumerated in the map and
-									;treated like any other string.  Must use lambda in filter specifically to filter out .nas indices.
+									;nominals are enumerated, if there happens to be a class value of (null) it will be enumerated in the map and
+									;treated like any other string.  Must use lambda in filter specifically to filter out (null) indices.
 									(filter
-										(lambda (!= (current_index) .nas))
+										(lambda (!= (current_index) (null)))
 										(call !ComputeModelNominalClassProbabilities (assoc feature feature))
 									)
 
@@ -146,15 +146,10 @@
 					(let
 						(assoc output_value (weighted_rand class_probabilities_map))
 
-						;note: nulls stored as .nas, convert any .nas strings to an actual (null)
-						(if (= .nas output_value)
-							(null)
-
-							;non string nominals should be output as numeric
-							(if (contains_index !numericNominalFeaturesMap feature)
-								(+ output_value)
-								output_value
-							)
+						;non string nominals should be output as numeric
+						(if (contains_index !numericNominalFeaturesMap feature)
+							(+ output_value)
+							output_value
 						)
 					)
 				)
@@ -357,9 +352,9 @@
 
 		(if (= (false) allow_nulls )
 			(assign (assoc
-				;nominals are enumerated, if there happens to be a class value of .nas it will be enumerated in the map and treated
-				;like any other string. Must use lambda in filter specifically to filter out .nas indices.
-				local_class_probabilities_map (filter (lambda (!= (current_index) .nas)) local_class_probabilities_map )
+				;nominals are enumerated, if there happens to be a class value of (null) it will be enumerated in the map and treated
+				;like any other string. Must use lambda in filter specifically to filter out (null) indices.
+				local_class_probabilities_map (filter (lambda (!= (current_index) (null))) local_class_probabilities_map )
 			))
 		)
 
@@ -769,12 +764,6 @@
 							)
 						)
 				))
-
-				;parse the categorical neighbor value to handle the situation where the value is the string .nas
-				;and convert it to an actual (null), all other numerical or string literals will remain unchanged
-				(if (= .nas action_value)
-					(assign (assoc action_value (null)))
-				)
 
 				;categorical action feature output
 				(assoc

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -248,7 +248,7 @@
 											))
 
 											;else if either of the values is a null, it counts only the amount of its null_count_fraction
-											(= .nan diff)
+											(= (null) diff)
 											(assign (assoc
 												has_dupes (false)
 												num_diff_features (+ num_diff_features null_count_fraction)

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -82,7 +82,7 @@
 
 			(assign (assoc threshhold (abs percent)))
 
-			;if it's a string, convert it to number (.nan for string)
+			;if it's a string, convert it to number
 			(if (= (get_type_string obs) "string")
 				(assign (assoc obs (+ obs)))
 			)
@@ -91,10 +91,7 @@
 			)
 
 			(if (= (get_type_string obs) "number")
-				(if (and (= obs .nan) (= exp .nan))
-					(true)
-
-					(!= thresh (null)) ;if absolute threshhold is specified, the difference in the numbers must be less than that
+				(if (!= thresh (null)) ;if absolute threshhold is specified, the difference in the numbers must be less than that
 					(<= (abs (- exp obs)) (abs thresh))
 
 					(and (= obs .infinity) (= exp .infinity))
@@ -321,19 +318,6 @@
 				(call failed_assert_output (assoc msg "FAILED: assert_not_null"))
 			)
 			(if (call verbose_output) (print ", Expected: not null  Observed: " obs))
-			(print "\n")
-		)
-
-	;asserts that the obs parameter is not nan
-	; obs : item to check if not nan
-	#assert_not_nan
-		(seq
-			(if (!= .nan obs)
-				(print "PASSED (not nan)")
-
-				(call failed_assert_output (assoc msg "FAILED: assert_not_nan"))
-			)
-			(if (call verbose_output) (print ", Expected: not nan  Observed: " obs))
 			(print "\n")
 		)
 

--- a/unit_tests/ut_h_case_generation.amlg
+++ b/unit_tests/ut_h_case_generation.amlg
@@ -267,10 +267,10 @@
 	(call assert_true (assoc
 		obs
 			(and
-				(!= .nan (get result "strawberry" )) (!= (null) (get result "strawberry"))
-				(!= .nan (get result "apple" )) (!= (null) (get result "apple"))
-				(!= .nan (get result "pinapple" )) (!= (null) (get result "pinapple"))
-				(!= .nan (get result "peach" )) (!= (null) (get result "peach"))
+				(!= (null) (get result "strawberry"))
+				(!= (null) (get result "apple"))
+				(!= (null) (get result "pinapple"))
+				(!= (null) (get result "peach"))
 				(apply "!=" (values result))
 			)
 	))

--- a/unit_tests/ut_h_dependent_features.amlg
+++ b/unit_tests/ut_h_dependent_features.amlg
@@ -91,11 +91,11 @@
 
 	;null continuous values are explicitly allowed for these nominal combination
 	(call assert_same (assoc
-		obs (get result (list "measure_value" "bmi" .nas))
+		obs (get result (list "measure_value" "bmi" (null)))
 		exp (list 27 (null) 32)
 	))
 	(call assert_same (assoc
-		obs (get result (list "measure_value" .nas "ratio"))
+		obs (get result (list "measure_value" (null) "ratio"))
 		exp (list 17 (null) 17.5)
 	))
 	(call assert_same (assoc
@@ -119,8 +119,8 @@
 				(contains_value (get result "measure_value") (list "heartrate" "bpm"))
 				(contains_value (get result "measure_value") (list "creatine" "mg/dL"))
 				(contains_value (get result "measure_value") (list "bmi" "ratio"))
-				(contains_value (get result "measure_value") (list "bmi" .nas))
-				(contains_value (get result "measure_value") (list .nas "ratio"))
+				(contains_value (get result "measure_value") (list "bmi" (null)))
+				(contains_value (get result "measure_value") (list (null) "ratio"))
 				(contains_value (get result "measure_value") (list "xray" "mSv"))
 			)
 	))

--- a/unit_tests/ut_h_react_audit.amlg
+++ b/unit_tests/ut_h_react_audit.amlg
@@ -103,7 +103,7 @@
 	(call assert_not_null (assoc
 		obs (get result "similarity_conviction" )
 	))
-	(call assert_not_nan (assoc
+	(call assert_not_null (assoc
 		obs (get result "similarity_conviction" )
 	))
 

--- a/unit_tests/ut_h_react_distance_ratio.amlg
+++ b/unit_tests/ut_h_react_distance_ratio.amlg
@@ -39,7 +39,7 @@
 	))
 
 	;react to an identical case to the only one in the model
-	;normally this would produce a .infinity or .nan but the
+	;normally this would produce a .infinity or (null) but the
 	;ComputeDistanceRatio routine replaces those with 0, so
 	;we check if that is working as expected
 	(let

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
   "dependencies": {
-    "amalgam": "53.0.0"
+    "amalgam": "54.0.0"
   }
 }


### PR DESCRIPTION
Incoming Amalgam updates unify all nulls into the single `(null)`. With the removal of .nan and .nas, this PR update the Engine codebase to replace these values with `(null)`. Additionally simplifying the logic where possible.