### PR TITLE
20674: Fixes batch_react_series to have appropriate default parameter values

### DIFF
--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -286,7 +286,7 @@
 			;{type "list" values "string"}
 			initial_features (list)
 			;{type "list" values {type "list"}}
-			initial_values (list)
+			initial_values (null)
 			;{type "list" values {type "assoc"} }
 			series_stop_maps (list)
 			;{type "list" values "number"}
@@ -310,7 +310,7 @@
 			;{type "list" values "string"}
 			context_features (list)
 			;{type "list" values {type "list"}}
-			context_values (list)
+			context_values (null)
 			;{type "list" values "string"}
 			action_features (list)
 			;{type "list" values "string"}
@@ -341,6 +341,8 @@
 			ordered_by_specified_features (null)
 			;{type "boolean"}
 			exclude_novel_nominals_from_uniqueness_check (null)
+			;{ref "CaseIndices"}
+			case_indices (null)
 
 			;generate react specific parameters:
 			;{type "boolean"}
@@ -373,7 +375,7 @@
 						(!= (null) case_indices)
 						(size case_indices)
 
-						(!= (list) initial_values)
+						(!= (null) initial_values)
 						(size initial_values)
 
 						(!= (null) continue_series_values)


### PR DESCRIPTION
The parameter validation code assigned new defaults to previously undefined parameters in method headers, some of these defaults clashed with the logic which previously expected nulls.