### PR TITLE
20834: Fixes format of sparse deviation matrix when specified in hyperparameters

### DIFF
--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -49,6 +49,8 @@
 								custom_hyperparam_map baseline_hyperparameter_map
 								;must compute confusion matrix to use sparse deviation matrix
 								compute_all_statistics use_sdm
+								;don't sparsify the confusion matrix
+								confusion_matrix_min_count 0
 							))
 					))
 			))
@@ -334,6 +336,8 @@
 									custom_hyperparam_map baseline_hyperparameter_map
 									;must compute confusion matrix to use sparse deviation matrix
 									compute_all_statistics use_sdm
+									;don't sparsify the confusion matrix
+									confusion_matrix_min_count 0
 								))
 						))
 					)

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -49,7 +49,7 @@
 								custom_hyperparam_map baseline_hyperparameter_map
 								;must compute confusion matrix to use sparse deviation matrix
 								compute_all_statistics use_sdm
-								;don't sparsify the confusion matrix
+								;don't sparsify the confusion matrix so that SDM can be computed using full counts
 								confusion_matrix_min_count 0
 							))
 					))
@@ -336,7 +336,7 @@
 									custom_hyperparam_map baseline_hyperparameter_map
 									;must compute confusion matrix to use sparse deviation matrix
 									compute_all_statistics use_sdm
-									;don't sparsify the confusion matrix
+									;don't sparsify the confusion matrix so that SDM can be computed using full counts
 									confusion_matrix_min_count 0
 								))
 						))

--- a/howso/details_stats.amlg
+++ b/howso/details_stats.amlg
@@ -507,7 +507,7 @@
 			feature_mda_robust (null)
 			feature_mda_permutation_robust (null)
 			prediction_stats (null)
-			confusion_matrix_min_count 10
+			confusion_matrix_min_count 15
 		)
 
 		(declare (assoc

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -16,7 +16,7 @@
 			use_case_weights (false)
 			weight_feature ".case_weight"
 			custom_hyperparam_map (null)
-			confusion_matrix_min_count 10
+			confusion_matrix_min_count 15
 		)
 
 		;if not using case weights, change weight_feature to '.none'
@@ -287,7 +287,7 @@
 			custom_hyperparam_map (null)
 			compute_all_statistics (false)
 			store_values (true)
-			confusion_matrix_min_count 10
+			confusion_matrix_min_count 15
 		)
 
 		(declare (assoc

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -40,14 +40,15 @@
 						(lambda
 							(if (contains_index confusion_matrix_map (current_index))
 								(let
-									(assoc
+									(assoc feature (current_index 1) )
+									(declare (assoc
 										sdm
 											##SparseDeviationMatrix
 											(call !ConfusionMatrixToSDM (assoc
-												confusion_matrix (get confusion_matrix_map (current_index 2))
-												feature (current_index 2)
+												confusion_matrix (get confusion_matrix_map [feature "matrix"])
+												feature feature
 											))
-									)
+									))
 
 									;output an assoc of sdm and expected deviation
 									(if sdm
@@ -1049,7 +1050,7 @@
 	(declare
 		(assoc
 			confusion_matrix (assoc)
-			confusion_matrix_min_count 10
+			confusion_matrix_min_count 15
 		)
 
 		(declare (assoc
@@ -1151,7 +1152,10 @@
 						;in the row and dividing by total_probability
 						(map
 							(lambda
-								(- 1 (/ (min class_probability (current_value)) total_probability))
+								(max
+									(- 1 (/ (min class_probability (current_value)) total_probability))
+									smallest_prob
+								)
 							)
 							(current_value)
 						)
@@ -1179,6 +1183,10 @@
 		;if there's a leftover_unknown_class_deviation, output the SDM as a list (pair)
 		(if leftover_unknown_class_deviation
 			(list (call !FormatSDMForOutput) leftover_unknown_class_deviation)
+
+			;if there is only one class trained, set the unknown deviation to be max possible value
+			(= [1] (values rand_guess_accuracy_map))
+			(list (call !FormatSDMForOutput) max_accuracy)
 
 			;else just output the SDM as an assoc
 			(call !FormatSDMForOutput)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -144,7 +144,7 @@
 			;{type "number" min 0}
 			num_robust_influence_samples_per_case (null)
 			;{type "number"}
-			confusion_matrix_min_count 10
+			confusion_matrix_min_count 15
 			;{ref "ReactAggregateDetails"}
 			details (null)
 		)


### PR DESCRIPTION
also increases threshold to 15 and fixes case when there's only one class in the dataset to prevent a deviation of 0 being specified in the SDM