### PR TITLE
20890: Removes need to call react_aggregate before requesting case feature residual convictions in react

### DIFF
--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -496,11 +496,7 @@
 						feature_residuals_robust (if robust_residuals (true))
 					)
 					use_case_weights (!= ".none" (last hp_param_path))
-					weight_feature weight_feature
-						(if (!= ".none" (last hp_param_path))
-							(last hp_param_path)
-							".case_weight"
-						)
+					weight_feature (if (!= ".none" (last hp_param_path)) (last hp_param_path) ".case_weight" )
 				))
 				(assign (assoc global_feature_residuals (get !residualsMap param_path)))
 			)

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -506,18 +506,16 @@
 									".case_weight"
 								)
 					)
-					(seq
-						(call react_aggregate (assoc
-							action_feature action_feature
-							details (assoc
-								feature_residuals_full (if (not robust_residuals) (true))
-								feature_residuals_robust (if robust_residuals (true))
-							)
-							use_case_weights use_case_weights
-							weight_feature weight_feature
-						))
-						(assign (assoc global_feature_residuals (get !residualsMap param_path)))
-					)
+					(call react_aggregate (assoc
+						action_feature action_feature
+						details (assoc
+							feature_residuals_full (if (not robust_residuals) (true))
+							feature_residuals_robust (if robust_residuals (true))
+						)
+						use_case_weights use_case_weights
+						weight_feature weight_feature
+					))
+					(assign (assoc global_feature_residuals (get !residualsMap param_path)))
 				)
 			)
 		)

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -489,34 +489,20 @@
 		(if (= 0 (size global_feature_residuals))
 			(let
 				(assoc hp_param_path (get hyperparam_map "paramPath"))
-				(let
-					(assoc
-						action_feature
-						 	(if (size action_features)
-								(first hp_param_path)
-							)
-						use_case_weights
-							(if (= ".none" (last hp_param_path))
-								(false)
-								(true)
-							)
-						weight_feature
-								(if (not (= ".none" (last hp_param_path)))
-									(last hp_param_path)
-									".case_weight"
-								)
+				(call react_aggregate (assoc
+					action_feature (if (size action_features) (first hp_param_path))
+					details (assoc
+						feature_residuals_full (if (not robust_residuals) (true))
+						feature_residuals_robust (if robust_residuals (true))
 					)
-					(call react_aggregate (assoc
-						action_feature action_feature
-						details (assoc
-							feature_residuals_full (if (not robust_residuals) (true))
-							feature_residuals_robust (if robust_residuals (true))
+					use_case_weights (!= ".none" (last hp_param_path))
+					weight_feature weight_feature
+						(if (!= ".none" (last hp_param_path))
+							(last hp_param_path)
+							".case_weight"
 						)
-						use_case_weights use_case_weights
-						weight_feature weight_feature
-					))
-					(assign (assoc global_feature_residuals (get !residualsMap param_path)))
-				)
+				))
+				(assign (assoc global_feature_residuals (get !residualsMap param_path)))
 			)
 		)
 

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -491,16 +491,16 @@
 				(assoc hp_param_path (get hyperparam_map "paramPath"))
 				(let
 					(assoc
-						react_aggregate_action_feature
+						action_feature
 						 	(if (size action_features)
 								(first hp_param_path)
 							)
-						react_aggregate_use_case_weights
+						use_case_weights
 							(if (= ".none" (last hp_param_path))
 								(false)
 								(true)
 							)
-						react_aggregate_weight_feature
+						weight_feature
 								(if (not (= ".none" (last hp_param_path)))
 									(last hp_param_path)
 									".case_weight"
@@ -508,13 +508,13 @@
 					)
 					(seq
 						(call react_aggregate (assoc
-							action_feature react_aggregate_action_feature
+							action_feature action_feature
 							details (assoc
 								feature_residuals_full (if (not robust_residuals) (true))
 								feature_residuals_robust (if robust_residuals (true))
 							)
-							use_case_weights react_aggregate_use_case_weights
-							weight_feature react_aggregate_weight_feature
+							use_case_weights use_case_weights
+							weight_feature weight_feature
 						))
 						(assign (assoc global_feature_residuals (get !residualsMap param_path)))
 					)

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -485,77 +485,80 @@
 		;pull the appropriate robust or standard residuals
 		(assign (assoc global_feature_residuals (get !residualsMap param_path)))
 
+		;if global_feature_residuals is empty, we call react_aggregate to cache the required residuals
 		(if (= 0 (size global_feature_residuals))
 			(let
 				(assoc hp_param_path (get hyperparam_map "paramPath"))
-				;output a detailed warning why global convictions aren't computed
-				(accum (assoc
-					warnings
-						(associate (concat
-							"Cannot compute 'global_case_feature_residual_convictions_full' because Full"
-							" global residuals have not been computed for action_feature "
-							(if (size action_features)
-								(concat "'" (first hp_param_path) "'")
-								"'.targetless'"
+				(let
+					(assoc
+						react_aggregate_action_feature
+						 	(if (size action_features)
+								(first hp_param_path)
 							)
+						react_aggregate_use_case_weights
 							(if (= ".none" (last hp_param_path))
-								" without case weights.\n"
-								(concat " with case weights from '" (last hp_param_path) "'.\n")
+								(false)
+								(true)
 							)
-							"Please call 'react_aggregate()', with "
-							(if robust_residuals "feature_residuals_robust=true" "feature_residuals_full=True")
-							(if (!= ".none" (last hp_param_path))
-								(concat ", use_case_weights=true, weight_feature='" (last hp_param_path) "'")
-								""
-							)
-							(if (!= ".targetless" (first hp_param_path))
-								(concat ", action_feature='" (first hp_param_path) "'.")
-								", action_feature='.targetless'."
-							)
-						))
-				))
-
-				(assign (assoc global_convictions_map (null) ))
-			)
-
-			;else compute the global conviction
-			(assign (assoc
-				global_convictions_map
-					(map
-						(lambda
-							;current_index is the feature
-							;current_value is a list of residuals [global, case]
-
-							;conviction is: model / case residual, prevent divide by 0 by using the minimum residual instead if necesssary
-							; conviction is expected surprisal E(I) divided by observed surprisal, I
-							; C = E(I) / I
-							; The expected surprisal E(I) is the model residual divided by the model residual: MR / MR = 1.0
-							; The observed surprisal I is the observed residual divded by the model residual: OR / MR
-							; So, E(I) / I = (MR / MR) / (OR / MR) = MR / OR
-							; In this way, we can directly divide the model (global or local) residual by the observed residual to get conviction
-							(if (= 0 (last (current_value)) )
-								(/ (first (current_value)) (get !cachedFeatureMinResidualMap (current_index)))
-
-								;prevent nan from divide by null, output null as-is when nulls are allowed
-								(or (= (null) (last (current_value))) (= (null) (first (current_value))) )
-								(seq
-									(if (= (null) (first (current_value)))
-										(accum (assoc
-											warnings (associate (concat "Global residual was not computed for feature: " (current_index 2)) )
-										))
-									)
-									(null)
+						react_aggregate_weight_feature
+								(if (not (= ".none" (last hp_param_path)))
+									(last hp_param_path)
+									".case_weight"
 								)
-
-								(/ (first (current_value)) (last (current_value)))
-							)
-						)
-						;remove built-in keys from residuals map, leaving only feature-residual values
-						(keep global_feature_residuals (indices case_residuals_map))
-						case_residuals_map
 					)
-			))
+					(seq
+						(call react_aggregate (assoc
+							action_feature react_aggregate_action_feature
+							details (assoc
+								feature_residuals_full (if (not robust_residuals) (true))
+								feature_residuals_robust (if robust_residuals (true))
+							)
+							use_case_weights react_aggregate_use_case_weights
+							weight_feature react_aggregate_weight_feature
+						))
+						(assign (assoc global_feature_residuals (get !residualsMap param_path)))
+					)
+				)
+			)
 		)
+
+		;compute the global conviction
+		(assign (assoc
+			global_convictions_map
+				(map
+					(lambda
+						;current_index is the feature
+						;current_value is a list of residuals [global, case]
+
+						;conviction is: model / case residual, prevent divide by 0 by using the minimum residual instead if necesssary
+						; conviction is expected surprisal E(I) divided by observed surprisal, I
+						; C = E(I) / I
+						; The expected surprisal E(I) is the model residual divided by the model residual: MR / MR = 1.0
+						; The observed surprisal I is the observed residual divded by the model residual: OR / MR
+						; So, E(I) / I = (MR / MR) / (OR / MR) = MR / OR
+						; In this way, we can directly divide the model (global or local) residual by the observed residual to get conviction
+						(if (= 0 (last (current_value)) )
+							(/ (first (current_value)) (get !cachedFeatureMinResidualMap (current_index)))
+
+							;prevent nan from divide by null, output null as-is when nulls are allowed
+							(or (= (null) (last (current_value))) (= (null) (first (current_value))) )
+							(seq
+								(if (= (null) (first (current_value)))
+									(accum (assoc
+										warnings (associate (concat "Global residual was not computed for feature: " (current_index 2)) )
+									))
+								)
+								(null)
+							)
+
+							(/ (first (current_value)) (last (current_value)))
+						)
+					)
+					;remove built-in keys from residuals map, leaving only feature-residual values
+					(keep global_feature_residuals (indices case_residuals_map))
+					case_residuals_map
+				)
+		))
 
 		;can only scale global convictions if both convictions and ratios maps are defined
 		; convictions are multiplied by the null_conviction_ratios, which are (num_cases / num_not_null_cases)

--- a/howso/details_stats.amlg
+++ b/howso/details_stats.amlg
@@ -170,7 +170,7 @@
 								)
 								(call !GetFeatureResiduals (assoc
 									robust (false)
-									action_feature prediction_stats_action_feature
+									prediction_stats_action_feature prediction_stats_action_feature
 									robust_hyperparameters robust_hyperparameters
 									weight_feature weight_feature
 								))
@@ -200,7 +200,7 @@
 								)
 								(call !GetFeatureResiduals (assoc
 									robust (true)
-									action_feature prediction_stats_action_feature
+									prediction_stats_action_feature prediction_stats_action_feature
 									robust_hyperparameters robust_hyperparameters
 									weight_feature weight_feature
 								))
@@ -232,7 +232,7 @@
 										)
 										(call !GetFeatureResiduals (assoc
 											robust (false)
-											action_feature prediction_stats_action_feature
+											prediction_stats_action_feature prediction_stats_action_feature
 											robust_hyperparameters robust_hyperparameters
 											weight_feature weight_feature
 										))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -205,7 +205,7 @@
 				)
 			)
 			(conclude
-				(call !Return (assoc errors (list "Must specify action_feature when computing feature_mda_permutatio, feature_mda, or feature_contributions.")))
+				(call !Return (assoc errors (list "Must specify action_feature when computing feature_mda_permutation, feature_mda, or feature_contributions.")))
 			)
 		)
 

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -744,7 +744,14 @@
 				"D" 0.2
 				"E" 1.2
 		)
-		thresh 1.1
+		thresh
+			(assoc
+				"A" 2
+				"B" 0.5
+				"C" 0.5
+				"D" 0.5
+				"E" 2
+			)
 	))
 
 	(print "Robust case residuals and residual convictions for a prediction: ")

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -669,14 +669,6 @@
 	)
 	(call_entity "howso" "set_feature_attributes" (assoc features feat_attr))
 
-	(call_entity "howso" "react_aggregate" (assoc
-		details (assoc
-			prediction_stats (true)
-			feature_residuals_full (true)
-		)
-		sample_model_fraction 1.0)
-	)
-
 	(assign (assoc
 		result
 			(call_entity "howso" "react" (assoc
@@ -719,11 +711,11 @@
 	(call assert_approximate (assoc
 		obs (get result (list 1 "payload" "global_case_feature_residual_convictions_full"))
 		exp (assoc
-				"A" 4.6
-				"B" 0.14
+				"A" 5.1
+				"B" 0.15
 				"C" 0.27
-				"D" 0.22
-				"E" 0.34
+				"D" 0.23
+				"E" 0.51
 		)
 		percent 0.1
 	))
@@ -740,6 +732,19 @@
 					"global_case_feature_residual_convictions_robust" (true)
 				)
 			))
+	))
+
+	(print "Global case feature residual convictions robust for a case: ")
+	(call assert_approximate (assoc
+		obs (get result (list 1 "payload" "global_case_feature_residual_convictions_robust"))
+		exp (assoc
+				"A" 1.3
+				"B" 0.2
+				"C" 0.4
+				"D" 0.2
+				"E" 1.2
+		)
+		thresh 1.1
 	))
 
 	(print "Robust case residuals and residual convictions for a prediction: ")
@@ -773,11 +778,6 @@
 				"D" 3
 				"E" 2
 			)
-	))
-	(print "robust global is null: ")
-	(call assert_null (assoc
-		;should be null because we haven't computed robust global residuals yet
-		obs (get result (list 1 "payload" "global_case_feature_residual_convictions_robust"))
 	))
 
 	(call exit_if_failures (assoc msg "Full feature residual conviction."))

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -738,7 +738,7 @@
 	(call assert_approximate (assoc
 		obs (get result (list 1 "payload" "global_case_feature_residual_convictions_robust"))
 		exp (assoc
-				"A" 1.3
+				"A" 1.8
 				"B" 0.2
 				"C" 0.4
 				"D" 0.2

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -84,30 +84,7 @@
 	))
 	(call keep_result_warnings)
 
-	(print "Warning about calling react_aggregate() with residuals: ")
-	(call assert_true (assoc
-		obs (= 1 (size result))
-	))
-
-	(call_entity "howso" "react_aggregate" (assoc
-		details (assoc feature_residuals_full (true))
-	))
-
-	(assign (assoc
-		result
-			(call_entity "howso" "react" (assoc
-				case_indices (list "default" 10)
-				preserve_feature_values features
-				leave_case_out (true)
-				details
-					(assoc
-						global_case_feature_residual_convictions_full (true)
-						local_case_feature_residual_convictions_full (true)
-					)
-			))
-	))
-	(call keep_result_warnings)
-	(print "No warning after storing matching residuals: ")
+	(print "No warnings for case feature residuals even before react_aggregate has been called ")
 	(call assert_null (assoc
 		obs result
 	))


### PR DESCRIPTION
some of the test numbers slightly change because we no longer use sample_model_fraction in the test,

also includes a small bug fix for misnamed action feature parameter