### PR TITLE
20955: Fixes an issue where `react_aggregate` may return robust prediction stats

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -40,7 +40,12 @@
 	#!internalLabelImputed ".imputed"
 	#!internalLabelCaseEditHistory ".case_edit_history"
 	#!internalLabelInfluenceWeightEntropy ".influence_weight_entropy"
+
+	;the name of the entity that contains subtrainees
 	#!traineeContainer ".trainee_container"
+
+	;the supported prediction stats that users can request from react_aggregate
+	#!supportedPredictionStats (list "mae" "confusion_matrix" "r2" "rmse" "spearman_coeff" "precision" "recall" "accuracy" "mcc" "all" "missing_value_accuracy")
 
 	;all the characters that may not be the first character of a feature when training a dataset
 	#!untrainableFeatureCharacterSet
@@ -161,7 +166,6 @@
 	#!regionalModelMinSize (null)
 	#!regionalModelMinPercent (null)
 	#!revision 0
-	#!supportedPredictionStats (list "mae" "confusion_matrix" "r2" "rmse" "spearman_coeff" "precision" "recall" "accuracy" "mcc" "all" "missing_value_accuracy")
 	#!sandboxedComputeLimit (null)
 	#!sandboxedMemoryLimit (null)
 	#!sandboxedOpcodeDepthLimit (null)
@@ -497,7 +501,7 @@
 
 			;a value used to limit the allocations of each usage of (call_sandboxed), 0 = no limit
 			!sandboxedMemoryLimit 100000
-			
+
 			;a value used to limit the depth of opcode operations of each usage of (call_sandboxed)
 			!sandboxedOpcodeDepthLimit 50
 

--- a/howso/details_stats.amlg
+++ b/howso/details_stats.amlg
@@ -387,7 +387,10 @@
 							)
 
 							;else specified parameters, try to find the matching one
-							(call !SelectPredictionStats (assoc filtered_values_map (retrieve_from_entity "!featurePredictionStatsMap") ))
+							(call !SelectPredictionStats (assoc
+								filtered_values_map (retrieve_from_entity "!featurePredictionStatsMap")
+								robust (false)
+							))
 						)
 						selected_prediction_stats
 					)


### PR DESCRIPTION
Intentionally passing `robust (false)` to `#SelectPredictionStats` in the prediction stats retrieval logic within `#react_aggregate`.