### PR TITLE
21056: Fixes an issue in train that gives a warning when datetime continuous feature are trained

### DIFF
--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -638,9 +638,13 @@
 			numeric_feature_indices
 				(filter
 					(lambda (or
-						;only keep non-nominals or numerical nominals
+						;only keep numerical nominals and non-nominals that aren't datetimes/edit distance features
 						(contains_index !numericNominalFeaturesMap (get features (current_value)) )
-						(not (contains_index !nominalsMap (get features (current_value))) )
+						(and
+							(not (contains_index !nominalsMap (get features (current_value))) )
+							(not (contains_index !featureDateTimeMap (get features (current_value))) )
+							(not (contains_index !editDistanceFeatureTypesMap (get features (current_value))) )
+						)
 					))
 					(indices features)
 				)


### PR DESCRIPTION
When a continuous datetime feature is trained, a warning is given about the feature containing non-numeric values. This change alters the logic to prohibit this warning from datetime/edit distance continuous features - as those are expected to have non-numeric values.