### PR TITLE
21066: Adds bounds check after post process in !ConvertToOutput

### DIFF
--- a/howso/io.amlg
+++ b/howso/io.amlg
@@ -280,11 +280,11 @@
 
 												;if datetime, compare epoch to bounds and return max/min if appopriate
 												epoch_value
-												(if (> epoch_value (get !featureBoundsMap [(current_value) "epoch_max_value"]))
-													(get !featureBoundsMap [(current_value) "max"])
+												(if (> epoch_value (get !featureBoundsMap [(current_value 1) "epoch_max_value"]))
+													(get !featureBoundsMap [(current_value 1) "max"])
 
-													(< epoch_value (get !featureBoundsMap [(current_value) "epoch_min_value"]))
-													(get !featureBoundsMap [(current_value) "min"])
+													(< epoch_value (get !featureBoundsMap [(current_value 1) "epoch_min_value"]))
+													(get !featureBoundsMap [(current_value 1) "min"])
 
 													value
 												)

--- a/howso/io.amlg
+++ b/howso/io.amlg
@@ -220,7 +220,7 @@
 										)
 
 										;only round numbers
-										(if (!= "number" (get_type_string rounded_value))
+										(if (!~ 0 rounded_value)
 											rounded_value
 
 											(contains_index !featureRoundingMap (current_value))
@@ -246,6 +246,59 @@
 								)
 						))
 					)
+
+					;bound according to feature bounds
+					(assign (assoc
+							decoded_values
+								(map
+									(lambda (let
+										(assoc
+											value (get decoded_values (current_index 1))
+											bounds_map (get !featureBoundsMap (current_value 1))
+											epoch_value
+												(if (contains_index !featureDateTimeMap (current_index 1))
+													(format
+														(get decoded_values (current_index 1))
+														(get !featureDateTimeMap [(current_index 2) "date_time_format"])
+														"number"
+														(assoc "locale" (get !featureDateTimeMap [(current_index 2) "locale"]))
+														(null)
+													)
+												)
+										)
+
+										(if (size bounds_map)
+											(if (~ 0 value)
+												;simply bound if it is a number
+												(max
+													(min
+														value
+														(get bounds_map "max")
+													)
+													(get bounds_map "min")
+												)
+
+												;if datetime, compare epoch to bounds and return max/min if appopriate
+												epoch_value
+												(if (> epoch_value (get !featureBoundsMap [(current_index) "epoch_max_value"]))
+													(get !featureBoundsMap [(current_index) "max"])
+
+													(< epoch_value (get !featureBoundsMap [(current_index) "epoch_min_value"]))
+													(get !featureBoundsMap [(current_index) "min"])
+
+													value
+												)
+
+												;else fallback to original value
+												value
+											)
+
+											value
+										)
+									))
+									features
+								)
+					))
 				)
 			)
 

--- a/howso/io.amlg
+++ b/howso/io.amlg
@@ -256,12 +256,12 @@
 											value (get decoded_values (current_index 1))
 											bounds_map (get !featureBoundsMap (current_value 1))
 											epoch_value
-												(if (contains_index !featureDateTimeMap (current_index 1))
+												(if (contains_index !featureDateTimeMap (current_value 1))
 													(format
 														(get decoded_values (current_index 1))
-														(get !featureDateTimeMap [(current_index 2) "date_time_format"])
+														(get !featureDateTimeMap [(current_value 2) "date_time_format"])
 														"number"
-														(assoc "locale" (get !featureDateTimeMap [(current_index 2) "locale"]))
+														(assoc "locale" (get !featureDateTimeMap [(current_value 2) "locale"]))
 														(null)
 													)
 												)
@@ -280,11 +280,11 @@
 
 												;if datetime, compare epoch to bounds and return max/min if appopriate
 												epoch_value
-												(if (> epoch_value (get !featureBoundsMap [(current_index) "epoch_max_value"]))
-													(get !featureBoundsMap [(current_index) "max"])
+												(if (> epoch_value (get !featureBoundsMap [(current_value) "epoch_max_value"]))
+													(get !featureBoundsMap [(current_value) "max"])
 
-													(< epoch_value (get !featureBoundsMap [(current_index) "epoch_min_value"]))
-													(get !featureBoundsMap [(current_index) "min"])
+													(< epoch_value (get !featureBoundsMap [(current_value) "epoch_min_value"]))
+													(get !featureBoundsMap [(current_value) "min"])
 
 													value
 												)

--- a/unit_tests/ut_h_post_process.amlg
+++ b/unit_tests/ut_h_post_process.amlg
@@ -27,7 +27,7 @@
 		(call_entity "howso" "set_feature_attributes" (assoc
 			features
 				(assoc
-					"petal_length" (assoc "type" "continuous")
+					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ #petal_length 0 40.0)")
 					"sepal_length" (assoc "type" "continuous")
 					"sepal_width" (assoc "type" "continuous")
 					"petal_width"
@@ -58,6 +58,11 @@
 					action_features (list "petal_length" "petal_width" "sepal_length" "sepal_width" "target")
 					num_cases_to_generate 50
 				))
+		))
+
+		;petal_length values should get bounded
+		(call assert_true (assoc
+			obs (apply "and" (map (lambda (= 10.0 (get (current_value) 0)) ) (get generated [1 "payload" "action_values"])))
 		))
 
 		(assign (assoc


### PR DESCRIPTION
Adds a bounding step after the values are modified according to the post processes.