### PR TITLE
#21177 Fix performance-test.yml GitHub Action.

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -1,12 +1,21 @@
 name: Performance Test
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
-      version:
-        required: true
-        type: string
       payload:
+        description: |
+          JSON payload containing extra info used by workflow.
+
+          For builds that have dependencies, key values of 'repo' => 'build-id' may
+          be used to define version. If blank or not supplied, latest tagged release
+          build will be used. Build ID may also be a release tag version.
+
+          Example:
+          {
+            "amalgam": "6191984493",
+            "howso-engine": "68.1.0"
+          }
         required: false
         type: string
 
@@ -15,16 +24,24 @@ defaults:
     shell: bash
 
 jobs:
-  get-dependency-details:
+  amalgam-version:
     uses: "./.github/workflows/get-dependency-details.yml"
     secrets: inherit
     with:
       owner: "howsoai"
       repo: "amalgam"
       payload: "${{ inputs.payload }}"
+
+  howso-engine-version:
+    uses: "./.github/workflows/get-dependency-details.yml"
+    secrets: inherit
+    with:
+      owner: "howsoai"
+      repo: "howso-engine"
+      payload: "${{ inputs.payload }}"
         
   performance-test-linux-amd64:
-    needs: ['get-dependency-details']
+    needs: [amalgam-version, howso-engine-version]
     runs-on: ubuntu-latest
     steps:
 
@@ -41,11 +58,31 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh ${{ needs.get-dependency-details.outputs.run-type }} download -D target -R "howsoai/amalgam" -p "*linux-amd64*" "${{ needs.get-dependency-details.outputs.run-id }}"
+        gh ${{ needs.amalgam-version.outputs.run-type }} download -D target -R "howsoai/amalgam" -p "*linux-amd64*" "${{ needs.amalgam.outputs.run-id }}"
         # Needed because release/non-release downloads are different structure
-        cd target && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
+        cd target && if [ ! -f amalgam-*.tar.gz ]; then mv */amalgam-*.tar.gz ./; fi && tar -xvzf amalgam-*.tar.gz
+        ln -s . target
 
-    - name: Test
+    - name: Download Howso Engine
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh ${{ needs.howso-engine-version.outputs.run-type }} download -D target -R "howsoai/amalgam" -p "*linux-amd64*" "${{ needs.howso-engine-version.outputs.run-id }}"
+        # Needed because release/non-release downloads are different structure
+        cd target && if [ ! -f howso-engine-*.tar.gz ]; then mv */howso-engine-*.tar.gz ./; fi && tar -xvzf howso-engine-*.tar.gz
+
+    - name: Set up performance test environment
+      run: |
+        cp run_performance_tests.amlg build.sh target/
+        cp -a performance_tests target/
+        cd target && sed -i.bak -e s@howso.amlg@howso.caml@ performance_tests/*.amlg
+
+    - name: Run performance test
       run: |
         sudo locale-gen es_ES.UTF-8
-        ./build.sh performance_test ${{ inputs.version }}
+        cd target
+        ./bin/amalgam-mt --debug-internal-memory ./run_performance_tests.amlg | tee /tmp/pt_results
+        if ! grep -q 'PASSED : Total comprehensive test execution time' /tmp/pt_results; then
+          cat /tmp/pt_results
+          exit 81
+        fi


### PR DESCRIPTION
Since it's invoked from a separate workflow, it needs to be set up as `workflow_dispatch:`, and since it's not run as part of the core build, it needs to get the Howso Engine version and download it.