### PR TITLE
21239: Reduces references in Trainee attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ performance_tests/*.csv
 # scratch and temporary trial files
 scratch*
 research.amlg
+
+# trace files
+**/**.trace

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ test.amlg
 local/
 
 # Test output
-performance_tests/bank_gen.csv
+performance_tests/*.csv
 
 # Ignore MacOS Hidden File
 .DS_Store

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -383,7 +383,7 @@
 								(assign (assoc derived_features_list (list)))
 							)
 							(accum (assoc
-								source_to_derived_feature_map (associate source_feature_name (append derived_features_list feature))
+								source_to_derived_feature_map (associate source_feature_name (replace (append derived_features_list feature)))
 							))
 						)
 
@@ -410,7 +410,7 @@
 											(assign (assoc derived_features_list (list)))
 										)
 										(accum (assoc
-											source_to_derived_feature_map (associate source_feature_name (append derived_features_list feature))
+											source_to_derived_feature_map (associate source_feature_name (replace (append derived_features_list feature)))
 										))
 									)
 								)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -620,7 +620,7 @@
 										;ensure to zip a list of classes by prepending an empty list
 										(append (list) (current_value))
 										;zip all classes with a value of 1 so that all clases in the predicted list are assigned a value of 1
-										1
+										(range (lambda (replace 1)) 1 (size (current_value)) 1)
 									)
 								)
 								(map

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -620,7 +620,14 @@
 										;ensure to zip a list of classes by prepending an empty list
 										(append (list) (current_value))
 										;zip all classes with a value of 1 so that all clases in the predicted list are assigned a value of 1
-										(range (lambda (replace 1)) 1 (size (current_value)) 1)
+										(range
+											(lambda 1)
+											1
+											;if there is only one entry for a value, then it's predicted values: (current_value)
+											;will be singular (not a list, size=0), so we bound the list of 1's to be at least size=1
+											(max 1 (size (current_value)))
+											1
+										)
 									)
 								)
 								(map

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -649,9 +649,9 @@
 			ts_derived_features
 				(append
 					(list ".series_progress" ".series_progress_delta")
-					lag_features
-					train_delta_features
-					train_rate_features
+					(replace lag_features)
+					(replace train_delta_features)
+					(replace train_rate_features)
 				)
 			series_has_terminators (false)
 			stop_on_terminator (false)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -150,7 +150,7 @@
 						(assoc
 							"featureDeviations"
 								;prepend a null to represent the undefined feature deviation
-								(map (lambda (append (list (null)) (current_value))) null_deviations)
+								(map (lambda (append (list (null)) (replace (current_value)))) null_deviations)
 						)
 
 						(assoc)


### PR DESCRIPTION
Using (replace) to reduce the amount of references that are stored into the Trainee's attributes.