### PR TITLE
21189: Adds endpoint to enable to memory validation on !Return

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -865,6 +865,7 @@
 	#debug_label
 	(retrieve_from_entity label)
 
+	;adds calls to validate the nodes in memory in #!Return
 	#enable_memory_validation
 	(assign_to_entities (assoc
 		!validatePoint (replace (lambda (system "validate")))

--- a/howso.amlg
+++ b/howso.amlg
@@ -865,8 +865,8 @@
 	#debug_label
 	(retrieve_from_entity label)
 
-	;adds calls to validate the nodes in memory in #!Return
-	#enable_memory_validation
+	;enables debugging instrumentation
+	#enable_debugging_instrumentation
 	(assign_to_entities (assoc
 		!validatePoint (replace (lambda (system "validate")))
 	))

--- a/howso.amlg
+++ b/howso.amlg
@@ -865,6 +865,11 @@
 	#debug_label
 	(retrieve_from_entity label)
 
+	#enable_memory_validation
+	(assign_to_entities (assoc
+		!validatePoint (replace (lambda (system "validate")))
+	))
+
 	;create a return response object in the format of:
 	; success:
 	; [ 1, { 'payload' : payload, 'warnings' : warnings } ]
@@ -880,7 +885,9 @@
 	; payload: any value or object
 	#!Return
 	(seq
-		(system "validate")
+		#!validatePoint
+		(null)
+
 		(if errors
 			(list 0
 				(append

--- a/howso.amlg
+++ b/howso.amlg
@@ -879,19 +879,22 @@
 	; warnings: optional, list of warning strings to output
 	; payload: any value or object
 	#!Return
-	(if errors
-		(list 0
-			(append
-				(assoc "detail" (if (> (size errors) 1) errors (first errors)) )
-				(if error_code (assoc "code" error_code) (assoc))
-				(if error_details (assoc "errors" error_details) (assoc))
+	(seq
+		(system "validate")
+		(if errors
+			(list 0
+				(append
+					(assoc "detail" (if (> (size errors) 1) errors (first errors)) )
+					(if error_code (assoc "code" error_code) (assoc))
+					(if error_details (assoc "errors" error_details) (assoc))
+				)
 			)
+
+			warnings
+			(list 1 (assoc "payload" payload "warnings" warnings ) )
+
+			(list 1 (assoc "payload" payload) )
 		)
-
-		warnings
-		(list 1 (assoc "payload" payload "warnings" warnings ) )
-
-		(list 1 (assoc "payload" payload) )
 	)
 
 )


### PR DESCRIPTION
users can now call the `#enable_memory_validation` label to add a call to `(system "validate")` into `#!Return` which should help debug memory problems within the Engine.