### PR TITLE
21444: Fixes `#get_api` output by changing the default value for `#set_random_seed`

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Test
       run: |
         sudo locale-gen es_ES.UTF-8
-        ./build/test_debug.sh test ${{ inputs.version }}
+        ./build/build.sh test ${{ inputs.version }}
 
   test-linux-arm64:
     if: inputs.build-type != 'PR'

--- a/howso.amlg
+++ b/howso.amlg
@@ -740,7 +740,7 @@
 		(if (= seed (null))
 			(assign (assoc seed (system "rand" 16) ))
 		)
-		(set_entity_rand_seed trainee seed)
+		(set_entity_rand_seed seed)
 		(accum_to_entities (assoc !revision 1))
 
 		(call !Return)

--- a/howso.amlg
+++ b/howso.amlg
@@ -734,9 +734,12 @@
 	(declare
 		(assoc
 			;{type "any"}
-			seed (system "rand" 16)
+			seed (null)
 		)
 		(call !ValidateParameters)
+		(if (= seed (null))
+			(assign (assoc seed (system "rand" 16) ))
+		)
 		(set_entity_rand_seed trainee seed)
 		(accum_to_entities (assoc !revision 1))
 


### PR DESCRIPTION
Also fixes a bug within #set_random_seed, this was likely not working before.