### PR TITLE
21450: Fixes issues in time series where value features without nulls could synth derived features with nulls

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -128,7 +128,7 @@
 	#!ablatedCasesDistributionBatchSize (null)
 	#!dataMassChangeSinceLastAnalyze (null)
 	#!savedAnalyzeParameterMap (null)
-	#!derivedFeaturesSet (null)
+	#!derivedFeaturesMap (null)
 	#!sourceToDerivedFeatureMap (null)
 	#!featureCustomDerivedMethods (null)
 	#!hasTimeSeriesAttrbutes (null)
@@ -473,8 +473,8 @@
 			;format of: { series: features }
 			!seriesFeatures (assoc)
 
-			;assoc of features for fast lookup of features that need to be derived
-			!derivedFeaturesSet (assoc)
+			;assoc of derived features -> their original value parent feature, e.g.,  ".value_delta_1" -> "value" where ".value_delta_1" is used to derive "value"
+			!derivedFeaturesMap (assoc)
 
 			;map of source feature to a list derived features that rely on it
 			;format of: { source_feature : [ list of derived features ] }

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -521,7 +521,7 @@
 			!hasPostProcessing has_post_processing
 			!encodingNeededFeaturesSet encoding_needed_features_set
 			!uniqueNominalsSet unique_nominals_set
-			!derivedFeaturesSet (map (null) derived_features_map)
+			!derivedFeaturesSet (map (lambda (get (current_value) "parent")) derived_features_map)
 			!sourceToDerivedFeatureMap source_to_derived_feature_map
 			!postProcessMap post_process_map
 

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -504,7 +504,13 @@
 		(declare (assoc query_distance_type_map (call !ComposeDistanceTypeMap) ))
 
 		(assign_to_entities (assoc
-			!featureAttributes feature_attributes
+			!featureAttributes
+				;drop the 'parent' key from any time series related feature that has it
+				(if time_series_feature
+					(map (lambda (remove (current_value) "parent")) feature_attributes)
+
+					feature_attributes
+				)
 
 			!trainedFeatures (sort (values (append !trainedFeatures (indices feature_attributes)) (true)) )
 			!trainedFeaturesContextKey
@@ -521,7 +527,7 @@
 			!hasPostProcessing has_post_processing
 			!encodingNeededFeaturesSet encoding_needed_features_set
 			!uniqueNominalsSet unique_nominals_set
-			!derivedFeaturesSet (map (lambda (get (current_value) "parent")) derived_features_map)
+			!derivedFeaturesMap (map (lambda (get (current_value) "parent")) derived_features_map)
 			!sourceToDerivedFeatureMap source_to_derived_feature_map
 			!postProcessMap post_process_map
 

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -196,7 +196,7 @@
 					!unSubstituteValueMap (remove !unSubstituteValueMap feature)
 					!featureAttributes (remove !featureAttributes feature)
 					!featureBoundsMap (remove !featureBoundsMap feature)
-					!derivedFeaturesSet (remove !derivedFeaturesSet feature)
+					!derivedFeaturesMap (remove !derivedFeaturesMap feature)
 					!sourceToDerivedFeatureMap (remove !sourceToDerivedFeatureMap feature)
 					!featureCustomDerivedMethods (remove !featureCustomDerivedMethods feature)
 					!featureNullRatiosMap (remove !featureNullRatiosMap feature)

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -728,6 +728,7 @@
 					"ts_type" "lag"
 					;internal sub-attributed used to identify time series type of parent feature
 					"parent_type" (get attributes (list "time_series" "type"))
+					"parent" feature
 				)
 				(if date_time_format
 					(assoc "date_time_format" date_time_format)
@@ -781,6 +782,7 @@
 						)
 					"ts_type" "delta"
 					"ts_order" (current_index 1)
+					"parent" feature
 				)
 
 				;if order <= derived_orders, set the derived_feature_code property
@@ -834,6 +836,7 @@
 						)
 					"ts_type" "rate"
 					"ts_order" (current_index 1)
+					"parent" feature
 				)
 
 				;if order <= derived_orders, set the derived_feature_code property

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -53,7 +53,10 @@
 				(let
 					(assoc
 						cached_values
-							(if output_nominal_class_counts
+							(if (and output_instead_of_store output_nominal_class_counts)
+								(get !expectedValuesMap (list weight_feature_key feature))
+
+								output_nominal_class_counts
 								(get !expectedValuesMap (list weight_feature_key feature "class_counts"))
 
 								(contains_index !nominalsMap feature)
@@ -233,6 +236,7 @@
 								feature feature
 								output_nominal_class_counts (true)
 								case_ids case_ids
+								output_instead_of_store (true)
 							))
 					)
 

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -309,38 +309,19 @@
 				use_case_weights (false)
 			)
 
+			(declare (assoc num_cases (call !GetNumTrainingCases)))
+
 			(accum_to_entities (assoc
 				!expectedValuesMap
-					(assoc
-						".none"
-							||(map
-								(lambda (let
-									(assoc feature (current_index 1))
-									(call !CalculateFeatureExpectedValue (assoc
-										feature feature
-										weight_feature ".none"
-										output_instead_of_store (true)
-										;force all categoricals to compute counts
-										output_nominal_class_counts (contains_index !categoricalFeaturesSet feature)
-									))
-								))
-								;iterate over all unique provided context and action features
-								(zip features)
-							)
-					)
-			))
-
-			(if use_case_weights
-				(accum_to_entities (assoc
-					!expectedValuesMap
-						(associate
-							weight_feature
+					(append
+						(assoc
+							".none"
 								||(map
 									(lambda (let
 										(assoc feature (current_index 1))
 										(call !CalculateFeatureExpectedValue (assoc
 											feature feature
-											weight_feature weight_feature
+											weight_feature ".none"
 											output_instead_of_store (true)
 											;force all categoricals to compute counts
 											output_nominal_class_counts (contains_index !categoricalFeaturesSet feature)
@@ -350,48 +331,39 @@
 									(zip features)
 								)
 						)
-				))
-			)
-
-			(accum_to_entities (assoc
-				!nominalClassProbabilitiesMap
-					(assoc
-						".none"
-							||(map
-								(lambda (let
-									(assoc feature (current_index 1))
-									(call !ComputeModelNominalClassProbabilities (assoc
-										feature feature
-										weight_feature ".none"
-										store_global_probabilities (false)
-									))
-								))
-
-								;iterate over all unique provided context and action features that are categorical
-								(zip
-									(filter
-										(lambda (contains_index !categoricalFeaturesSet (current_value)))
-										features
+						(if use_case_weights
+							(associate
+								weight_feature
+									||(map
+										(lambda (let
+											(assoc feature (current_index 1))
+											(call !CalculateFeatureExpectedValue (assoc
+												feature feature
+												weight_feature weight_feature
+												output_instead_of_store (true)
+												;force all categoricals to compute counts
+												output_nominal_class_counts (contains_index !categoricalFeaturesSet feature)
+											))
+										))
+										;iterate over all unique provided context and action features
+										(zip features)
 									)
-								)
 							)
+							{}
+						)
 					)
-			))
-
-			(if use_case_weights
-				(accum_to_entities (assoc
-					!nominalClassProbabilitiesMap
-						(associate
-							weight_feature
+				!nominalClassProbabilitiesMap
+					(append
+						(assoc
+							".none"
 								||(map
 									(lambda (let
 										(assoc feature (current_index 1))
 										(call !ComputeModelNominalClassProbabilities (assoc
 											feature feature
-											weight_feature weight_feature
+											weight_feature ".none"
 											store_global_probabilities (false)
 										))
-
 									))
 
 									;iterate over all unique provided context and action features that are categorical
@@ -403,16 +375,33 @@
 									)
 								)
 						)
-				))
-			)
+						(if use_case_weights
+							(associate
+								weight_feature
+									||(map
+										(lambda (let
+											(assoc feature (current_index 1))
+											(call !ComputeModelNominalClassProbabilities (assoc
+												feature feature
+												weight_feature weight_feature
+												store_global_probabilities (false)
+											))
 
-			(declare (assoc num_cases (call !GetNumTrainingCases)))
-			(if (= (assoc) !featureMarginalStatsMap)
-				(call !CalculateMarginalStats)
-			)
+										))
 
-			;process all features, caching their min, max values as well as how many nulls there are and the ratio of cases / non-nulls
-			(accum_to_entities (assoc
+										;iterate over all unique provided context and action features that are categorical
+										(zip
+											(filter
+												(lambda (contains_index !categoricalFeaturesSet (current_value)))
+												features
+											)
+										)
+									)
+							)
+							{}
+						)
+					)
+				;process all features, caching their min, max values as well as how many nulls there are and the ratio of cases / non-nulls
 				!featureNullRatiosMap
 					(map
 						(lambda (let
@@ -477,6 +466,16 @@
 							)
 						))
 						(zip features)
+					)
+				!featureMarginalStatsMap
+					(if (= (assoc) !featureMarginalStatsMap)
+						(associate
+							(if weight_feature weight_feature ".none")
+							(call !CalculateMarginalStats (assoc store_stats (false)) )
+						)
+
+						;else don't accumulate anything because marginal stats are already stored
+						{}
 					)
 			))
 
@@ -618,11 +617,13 @@
 	;
 	;parameters:
 	; weight_feature: optional, name of case weight feature
+	; store_stats: optional, flag, default to true. when false will output stats without caching them
 	#!CalculateMarginalStats
 		(declare
 			(assoc
 				weight_feature (null)
 				filtering_queries (list)
+				store_stats (true)
 			)
 
 			(declare (assoc
@@ -797,7 +798,7 @@
 				(assign (assoc weight_feature ".none"))
 			)
 
-			(if (= (list) filtering_queries)
+			(if (and store_stats (= (list) filtering_queries))
 				(accum_to_entities (assoc
 					!featureMarginalStatsMap (associate weight_feature stats)
 				))

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -236,7 +236,6 @@
 								feature feature
 								output_nominal_class_counts (true)
 								case_ids case_ids
-								output_instead_of_store (true)
 							))
 					)
 

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1419,7 +1419,7 @@
 									(lambda (or
 										(= (false) (get !featureNullRatiosMap [(current_value 1) "has_nulls"]))
 										;rate or delta feature whose 'parent' feature has no nulls
-										(= (false) (get !featureNullRatiosMap [(get !derivedFeaturesSet (current_value 1)) "has_nulls"]))
+										(= (false) (get !featureNullRatiosMap [(get !derivedFeaturesMap (current_value 1)) "has_nulls"]))
 									))
 									action_features
 								)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -62,6 +62,14 @@
         )
 
 		(if !inactiveFeaturesNeedCaching (call !UpdateInactiveFeatures))
+		;if for some reason expected values haven't been cached, do that here
+		(if (= 0 (size !expectedValuesMap))
+			(call !CacheExpectedValuesAndProbabilities (assoc
+				features !trainedFeatures
+				weight_feature weight_feature
+				use_case_weights use_case_weights
+			))
+		)
 
 		(declare (assoc
 			warnings (assoc)
@@ -1370,6 +1378,7 @@
 						(append
 							feature_bounds_map
 							(zip
+								action_features
 								(map
 									(lambda (let
 										(assoc action_feature (get action_features (current_index 1)) )
@@ -1380,7 +1389,7 @@
 												(set (current_value) "allow_null" (false))
 
 												;else pull the bounds from !featureBoundsMap and overwrite those
-												(set (get !featureBoundsMap action_feature) "allow_null" (false) )
+												(set (or (get !featureBoundsMap action_feature) {}) "allow_null" (false) )
 											)
 
 											;else leave it as-is
@@ -1389,18 +1398,61 @@
 									)
 									(unzip feature_bounds_map action_features)
 								))
-								action_features
 							)
 						)
 
 						(filter (map
 							(lambda
 								(if (> (get !featureAttributes [(current_index 1) "ts_order"]) last_series_index)
-									(set (get !featureBoundsMap (current_index)) "allow_null" (false) )
+									(set (or (get !featureBoundsMap (current_index)) {}) "allow_null" (false) )
 								)
 							)
 							(zip action_features)
 						))
+					)
+
+					;else synthing data for the rest of the cases in a series, don't allow nulls for features that have no nulls
+					(let
+						(assoc
+							explicit_no_null_features
+								(filter
+									(lambda (or
+										(= (false) (get !featureNullRatiosMap [(current_value 1) "has_nulls"]))
+										;rate or delta feature whose 'parent' feature has no nulls
+										(= (false) (get !featureNullRatiosMap [(get !derivedFeaturesSet (current_value 1)) "has_nulls"]))
+									))
+									action_features
+								)
+						)
+						(if (size feature_bounds_map)
+							(append
+								feature_bounds_map
+								(zip
+									explicit_no_null_features
+									(map
+										(lambda
+											(set
+												(or (get feature_bounds_map (current_value)) {})
+												"allow_null"
+												(false)
+											)
+										)
+										explicit_no_null_features
+									)
+								)
+							)
+
+							(map
+								(lambda
+									(set
+										(or (get !featureBoundsMap (current_index)) {})
+										"allow_null"
+										(false)
+									)
+								)
+								(zip explicit_no_null_features)
+							)
+						)
 					)
 				)
 		))

--- a/howso/remove_cases.amlg
+++ b/howso/remove_cases.amlg
@@ -226,7 +226,7 @@
 
 		;check if time series dataset, if so, need to pull all cases from affected series so that their
 		;derived features can be-rederived below after cases are removed
-		(if (and (!= (null) !tsTimeFeature) (size !derivedFeaturesSet))
+		(if (and (!= (null) !tsTimeFeature) (size !derivedFeaturesMap))
 			(let
 				(assoc series_id_features (get !tsModelFeaturesMap "series_id_features") )
 

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -414,7 +414,7 @@
 		)
 
 		;if derived features wasn't specified, auto-detect them
-		(if (and (= (null) derived_features) (> (size !derivedFeaturesSet) 0))
+		(if (and (= (null) derived_features) (> (size !derivedFeaturesMap) 0))
 			(seq
 				(assign (assoc derived_features (list)))
 

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -341,5 +341,45 @@
 			!defaultHyperparameters default_hyperparameter_map
 		))
 	)
+"86.0.7"
+	(let
+		(assoc
+			parent_feature_to_derived_map
+				;keep only the original (non-derived built-in features that start with a '.')
+				(filter
+					(lambda (!= "." (first (current_index))))
+					!sourceToDerivedFeatureMap
+				)
+		)
+
+		(declare (assoc
+			derived_features_map
+				(append
+					(or !derivedFeaturesSet {})
+					;convert into one flat assoc
+					(apply "append"
+						;convert to a list of assocs
+						(apply "append"
+							(values
+								;convert assoc of {parent -> [ derived1 , derived2, etc ]} into:
+								; assoc of { parent -> [{derived1: parent}, {derived2: parent}, etc..] }
+								(map
+									(lambda (let
+										(assoc parent_feature (current_index 1))
+										(map
+											(lambda (associate (current_value 1) parent_feature))
+											(current_value)
+										)
+									))
+									parent_feature_to_derived_map
+								)
+							)
+						)
+					)
+				)
+		))
+
+		(assign_to_entities (assoc !derivedFeaturesMap derived_features_map ))
+	)
 
 ))


### PR DESCRIPTION
Changed the set of derived features (e.g., .value_delta_1) to be a map of the derived feature -> its parent feature, (e.g., { .value_delta_1 -> value }, for fast lookup, such that when derived features (e.g., '.value_delta_1') are derived, if their parent features (e.g., value) don't have nulls, it won't allow nulls for the derived feature either.