### PR TITLE
21398: Updates the Amalgam unit test framework for ease of use

### DIFF
--- a/howso/typing.amlg
+++ b/howso/typing.amlg
@@ -157,7 +157,6 @@
                         influential_cases_familiarity_convictions "boolean"
                         influential_cases_raw_weights "boolean"
                         influence_weights "boolean"
-                        familiarity_conviction "boolean"
                         hypothetical_values "assoc"
                         most_similar_cases "boolean"
                         num_most_similar_cases "number"

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -18,7 +18,10 @@
 	#num_failed_asserts 0
 
 	;if set to true will auto-output verbose on any fail
-	#verbose_on_fail (true)
+	#verbose_on_fail (false)
+
+	;if set to true, exp and obs values will be printed when assertions fail
+	#print_values_on_fail (true)
 
 	;name of unit test
 	#unit_test_name (null)
@@ -68,7 +71,7 @@
 	;helper function that gives failure output when a non-null value is not given for exp, skips check if called within a recursive assertion
 	#verify_exp
 	(if (and (= (null) exp) (not inner))
-		(call failed_assert_output (assoc msg "FAILED: A non-null value was not given for exp. If the expected value is (null), use #assert_null.\n"))
+		(call failed_assert_output (assoc msg "FAILED: A non-null value was not given for exp. If the expected value is (null), use #assert_null."))
 	)
 
 	; returns true (1) if the passed in numbers are within the specified percent of each other, otherwise returns false (0)
@@ -194,6 +197,8 @@
 		)
 		(call verify_exp)
 
+		(declare (assoc failed_assert (false) ))
+
 		;for approximate comparison, order isn't important so we sort both inputs just in case
 		(assign (assoc
 			obs (sort obs)
@@ -213,21 +218,26 @@
 			(call failed_assert_output (assoc msg "FAILED: assert_approximate"))
 		)
 
-		(if (call verbose_output) (let
-			(assoc
-				threshold_type
-					(if (!= (null) thresh)
-						"Threshhold: "
-						"Percent: "
-					)
-				threshold
-					(if (!= (null) thresh)
-						thresh
-						percent
-					)
+		(if (or
+				(call verbose_output)
+				(and print_values_on_fail failed_assert)
 			)
-			(print ", Expected: " exp "  Observed: " obs "  " threshold_type threshold)
-		))
+			(let
+				(assoc
+					threshold_type
+						(if (!= (null) thresh)
+							"Threshhold: "
+							"Percent: "
+						)
+					threshold
+						(if (!= (null) thresh)
+							thresh
+							percent
+						)
+				)
+				(print ", Expected: " exp "  Observed: " obs "  " threshold_type threshold)
+			)
+		)
 		(print "\n")
 	)
 
@@ -242,6 +252,7 @@
 			obs (null)
 		)
 		(call verify_exp)
+		(declare (assoc failed_assert (false) ))
 
 		;when testing an unordered assoc, means its values can be unordered
 		(if (and unordered (= (get_type_string obs) "assoc"))
@@ -276,7 +287,12 @@
 			(call failed_assert_output (assoc msg "FAILED: assert_same"))
 		)
 
-		(if (call verbose_output) (print ", Expected: " exp "  Observed: " obs))
+		(if (or
+				(call verbose_output)
+				(and print_values_on_fail failed_assert)
+			)
+			(print ", Expected: " exp "  Observed: " obs)
+		)
 		(print "\n")
 	)
 
@@ -288,12 +304,18 @@
 		(assoc
 			obs (null)
 		)
+		(declare (assoc failed_assert (false) ))
 		(if (= (true) obs)
 			(print "PASSED (true)")
 
 			(call failed_assert_output (assoc msg "FAILED: assert_true"))
 		)
-		(if (call verbose_output) (print ", Expected: true  Observed: " obs))
+		(if (or
+				(and print_values_on_fail failed_assert)
+				(call verbose_output)
+			)
+			(print ", Expected: true  Observed: " obs)
+		)
 		(print "\n")
 	)
 
@@ -305,12 +327,18 @@
 		(assoc
 			obs (null)
 		)
+		(declare (assoc failed_assert (false) ))
 		(if (= (false) obs)
 			(print "PASSED (false)")
 
 			(call failed_assert_output (assoc msg "FAILED: assert_false"))
 		)
-		(if (call verbose_output) (print ", Expected: false  Observed: " obs))
+		(if (or
+				(and print_values_on_fail failed_assert)
+				(call verbose_output)
+			)
+			(print ", Expected: false  Observed: " obs)
+		)
 		(print "\n")
 	)
 
@@ -322,12 +350,18 @@
 		(assoc
 			obs "You did not pass in a value for obs" ;intentionally not null
 		)
+		(declare (assoc failed_assert (false) ))
 		(if (= (null) obs)
 			(print "PASSED (null)")
 
 			(call failed_assert_output (assoc msg "FAILED: assert_null"))
 		)
-		(if (call verbose_output) (print ", Expected: null  Observed: " obs))
+		(if (or
+				(and print_values_on_fail failed_assert)
+				(call verbose_output)
+			)
+			(print ", Expected: null  Observed: " obs)
+		)
 		(print "\n")
 	)
 
@@ -338,12 +372,18 @@
 		(assoc
 			obs (null)
 		)
+		(declare (assoc failed_assert (false) ))
 		(if (!= (null) obs)
 			(print "PASSED (not null)")
 
 			(call failed_assert_output (assoc msg "FAILED: assert_not_null"))
 		)
-		(if (call verbose_output) (print ", Expected: not null  Observed: " obs))
+		(if (or
+				(and print_values_on_fail failed_assert)
+				(call verbose_output)
+			)
+			(print ", Expected: not null  Observed: " obs)
+		)
 		(print "\n")
 	)
 
@@ -418,6 +458,7 @@
 	#failed_assert_output
 	(seq
 		(assign_to_entities (assoc num_failed_asserts (+ 1 num_failed_asserts)))
+		(assign (assoc failed_assert (true) ))
 		(print msg)
 		(if (= 2 verbose_mode)
 			(print " at\n" (stack)) ;TODO: figure out a less verbose/more concise way to give feedback as to where exactly the failure occured

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -186,6 +186,7 @@
 	; percent : the allowed relative error  (eg, 0.056 = must be within 5.6% of exp)
 	; thresh : the allowed absolute error (eg, 0.56 = obs must be +/- 0.56 of exp, if specified, percent is ignored. may be an assoc with same keys as obs.
 	; infinity_threshold : when we can approximately consider numbers higher than this threshold to be infinity
+	; unordered : if true, order doesn't matter
 	#assert_approximate
 	(declare
 		(assoc
@@ -194,9 +195,17 @@
 			percent .05
 			thresh (null)
 			infinity_threshold 1e200
+			unordered (false)
 		)
 		(call verify_exp)
 		(declare (assoc failed_assert (false) ))
+
+		(if unordered
+			(assign (assoc
+				obs (sort obs)
+				exp (sort exp)
+			))
+		)
 
 		(if
 			(call is_approximate (assoc

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -17,7 +17,7 @@
 	;counter of the number of failed asserts
 	#num_failed_asserts 0
 
-	;if set to true will auto-output verbose on any fail
+	;if set to true will auto-output verbose on any fail, causing all assertion values to print after a failure
 	#verbose_on_fail (false)
 
 	;if set to true, exp and obs values will be printed when assertions fail

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -196,14 +196,7 @@
 			infinity_threshold 1e200
 		)
 		(call verify_exp)
-
 		(declare (assoc failed_assert (false) ))
-
-		;for approximate comparison, order isn't important so we sort both inputs just in case
-		(assign (assoc
-			obs (sort obs)
-			exp (sort exp)
-		))
 
 		(if
 			(call is_approximate (assoc
@@ -250,6 +243,7 @@
 		(assoc
 			exp (null)
 			obs (null)
+			unordered (false)
 		)
 		(call verify_exp)
 		(declare (assoc failed_assert (false) ))

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -3,7 +3,7 @@
 ; (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
 ; (call assert_same (assoc obs assoc1 exp assoc2))
 ; (call assert_approximate (assoc obs (list 100 92) exp (list 95 94) percent 6))
-; (print "should be 1: " (call is_approximate (assoc obs (list 102 92) exp (list 94 92) percent 8)) "\n")
+; (print "should be 1: " (call !is_approximate (assoc obs (list 102 92) exp (list 94 92) percent 8)) "\n")
 
 (null
 
@@ -68,10 +68,10 @@
 		(print "=====================================\n")
 	)
 
-	;helper function that gives failure output when a non-null value is not given for exp, skips check if called within a recursive assertion
-	#verify_exp
+	;helper function that prints failure output when a non-null value is not given for exp, skips check if called within a recursive assertion
+	#!verify_exp
 	(if (and (= (null) exp) (not inner))
-		(call failed_assert_output (assoc msg "FAILED: A non-null value was not given for exp. If the expected value is (null), use #assert_null."))
+		(call !failed_assert_output (assoc msg "FAILED: A non-null value was not given for exp. If the expected value is (null), use #assert_null."))
 	)
 
 	; returns true (1) if the passed in numbers are within the specified percent of each other, otherwise returns false (0)
@@ -81,7 +81,7 @@
 	; percent : the allowed relative error (eg, 0.056 = obs  must be within 5.6% of exp)
 	; thresh : the allowed absolute error (eg, 0.56 = obs must be +/- 0.56 of exp, if specified, percent is ignored. may be an assoc with same keys as obs.
 	; infinity_threshold : when we can approximately consider numbers higher than this threshold to be infinity
-	#is_approximate
+	#!is_approximate
 	(declare
 		(assoc
 			exp (null)
@@ -90,7 +90,7 @@
 			thresh (null)
 			infinity_threshold 1e200
 		)
-		(call verify_exp)
+		(call !verify_exp)
 
 		(assign (assoc threshhold (abs percent)))
 
@@ -149,7 +149,7 @@
 
 							)
 							(!= (true)
-								(call is_approximate (assoc
+								(call !is_approximate (assoc
 									obs (current_value 1)
 									exp (get exp (current_index 1))
 									percent percent
@@ -197,7 +197,7 @@
 			infinity_threshold 1e200
 			unordered (false)
 		)
-		(call verify_exp)
+		(call !verify_exp)
 		(declare (assoc failed_assert (false) ))
 
 		(if unordered
@@ -208,7 +208,7 @@
 		)
 
 		(if
-			(call is_approximate (assoc
+			(call !is_approximate (assoc
 				obs obs
 				exp exp
 				percent percent
@@ -217,7 +217,7 @@
 			))
 			(print "PASSED (approximate)")
 
-			(call failed_assert_output (assoc msg "FAILED: assert_approximate"))
+			(call !failed_assert_output (assoc msg "FAILED: assert_approximate"))
 		)
 
 		(if (or
@@ -254,7 +254,7 @@
 			obs (null)
 			unordered (false)
 		)
-		(call verify_exp)
+		(call !verify_exp)
 		(declare (assoc failed_assert (false) ))
 
 		;when testing an unordered assoc, means its values can be unordered
@@ -287,7 +287,7 @@
 		(if (= obs exp)
 			(print "PASSED (same)")
 
-			(call failed_assert_output (assoc msg "FAILED: assert_same"))
+			(call !failed_assert_output (assoc msg "FAILED: assert_same"))
 		)
 
 		(if (or
@@ -311,7 +311,7 @@
 		(if (= (true) obs)
 			(print "PASSED (true)")
 
-			(call failed_assert_output (assoc msg "FAILED: assert_true"))
+			(call !failed_assert_output (assoc msg "FAILED: assert_true"))
 		)
 		(if (or
 				(and print_values_on_fail failed_assert)
@@ -334,7 +334,7 @@
 		(if (= (false) obs)
 			(print "PASSED (false)")
 
-			(call failed_assert_output (assoc msg "FAILED: assert_false"))
+			(call !failed_assert_output (assoc msg "FAILED: assert_false"))
 		)
 		(if (or
 				(and print_values_on_fail failed_assert)
@@ -351,13 +351,14 @@
 	#assert_null
 	(declare
 		(assoc
-			obs "You did not pass in a value for obs" ;intentionally not null
+			;intentionally not null
+			obs "You did not pass in a value for obs"
 		)
 		(declare (assoc failed_assert (false) ))
 		(if (= (null) obs)
 			(print "PASSED (null)")
 
-			(call failed_assert_output (assoc msg "FAILED: assert_null"))
+			(call !failed_assert_output (assoc msg "FAILED: assert_null"))
 		)
 		(if (or
 				(and print_values_on_fail failed_assert)
@@ -379,7 +380,7 @@
 		(if (!= (null) obs)
 			(print "PASSED (not null)")
 
-			(call failed_assert_output (assoc msg "FAILED: assert_not_null"))
+			(call !failed_assert_output (assoc msg "FAILED: assert_not_null"))
 		)
 		(if (or
 				(and print_values_on_fail failed_assert)
@@ -458,13 +459,13 @@
 
 	;method used by others to display failure message and increase the number of failed asserts
 	; msg : the message to display
-	#failed_assert_output
+	#!failed_assert_output
 	(seq
 		(assign_to_entities (assoc num_failed_asserts (+ 1 num_failed_asserts)))
 		(assign (assoc failed_assert (true) ))
 		(print msg)
 		(if (= 2 verbose_mode)
-			(print " at\n" (stack)) ;TODO: figure out a less verbose/more concise way to give feedback as to where exactly the failure occured
+			(print " at\n" (stack))
 		)
 	)
 

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -37,33 +37,39 @@
 	;parameters
 	; name : string, optional name of unit test. If unspecified defaults to name of file.
 	#init_unit_test
-		(declare
-			(assoc name (null) )
+	(declare
+		(assoc name (null) )
 
-			;parse out filename being run to use as name if name isn't specified
-			(if (= (null) name)
-				(let
-					(assoc script_path (first argv) )
-					(assign (assoc
-						;split script path by backslash and slash since Windows allows both
-            			name (last (split (last (split script_path "/")) "\\\\"))
-					))
-				)
+		;parse out filename being run to use as name if name isn't specified
+		(if (= (null) name)
+			(let
+				(assoc script_path (first argv) )
+				(assign (assoc
+					;split script path by backslash and slash since Windows allows both
+					name (last (split (last (split script_path "/")) "\\\\"))
+				))
 			)
-
-			(assign_to_entities (assoc
-				unit_test_name name
-				unit_test_start_time (system_time)
-			))
-			(print ">> " unit_test_name " >> unit test loaded:\n")
-
-			;self-check
-			(call assert_true (assoc obs (!= (null) unit_test_name)))
-			(call assert_false (assoc obs (= (null) unit_test_name)))
-			(call exit_if_failures (assoc quiet_pass (true) msg "Unit test framework Failed to load!"))
-
-			(print "=====================================\n")
 		)
+
+		(assign_to_entities (assoc
+			unit_test_name name
+			unit_test_start_time (system_time)
+		))
+		(print ">> " unit_test_name " >> unit test loaded:\n")
+
+		;self-check
+		(call assert_true (assoc obs (!= (null) unit_test_name)))
+		(call assert_false (assoc obs (= (null) unit_test_name)))
+		(call exit_if_failures (assoc quiet_pass (true) msg "Unit test framework Failed to load!"))
+
+		(print "=====================================\n")
+	)
+
+	;helper function that gives failure output when a non-null value is not given for exp
+	#verify_exp
+	(if (= (null) exp)
+		(call failed_assert_output (assoc msg "FAILED: A non-null value was not given for exp. If the expected value is (null), use #assert_null."))
+	)
 
 	; returns true (1) if the passed in numbers are within the specified percent of each other, otherwise returns false (0)
 	; note: when comparing lists, compares each number at each index as an individual pair of numbers, not the two lists as a whole
@@ -73,96 +79,99 @@
 	; thresh : the allowed absolute error (eg, 0.56 = obs must be +/- 0.56 of exp, if specified, percent is ignored. may be an assoc with same keys as obs.
 	; infinity_threshold : when we can approximately consider numbers higher than this threshold to be infinity
 	#is_approximate
-		(declare
-			(assoc
-				percent .05
-				thresh (null)
-				infinity_threshold 1e200
-			)
-
-			(assign (assoc threshhold (abs percent)))
-
-			;if it's a string, convert it to number
-			(if (= (get_type_string obs) "string")
-				(assign (assoc obs (+ obs)))
-			)
-			(if (= (get_type_string exp) "string")
-				(assign (assoc exp (+ exp)))
-			)
-
-			(if (= (get_type_string obs) "number")
-				(if (!= thresh (null)) ;if absolute threshhold is specified, the difference in the numbers must be less than that
-					(<= (abs (- exp obs)) (abs thresh))
-
-					(and (= obs .infinity) (= exp .infinity))
-					(true)
-
-					(and (= obs -.infinity) (= exp -.infinity))
-					(true)
-
-					;treat numbers that should be infinity but instead are really large due to floating point errors as infinity
-					(and (= obs .infinity) (>= exp infinity_threshold))
-					(true)
-
-					;treat numbers that should be infinity but instead are really large due to floating point errors as infinity
-					(and (= exp .infinity) (>= obs infinity_threshold))
-					(true)
-
-					(= 0 exp obs)
-					(true)
-
-					(let
-						(assign (assoc diff (/ (abs (- exp obs)) exp)))
-						(>= threshhold diff)
-					)
-				)
-
-				;else if list, iterate over the list and remove all values from obs that approximately match those in exp
-				;if resulting list has no items, both lists are approximately same
-				(or (= (get_type_string obs) "list") (= (get_type_string obs) "assoc"))
-				(and
-					;size must match
-					(= (size obs) (size exp))
-					;contents must match
-					(= 0
-						(size (filter
-							(lambda (let
-								(assoc
-									threshold_amount
-										(if (= "number" (get_type_string thresh))
-											thresh
-											;else it's a list or assoc, use corresponding threshold for index
-											(get thresh (current_index 1))
-										)
-
-								)
-								(!= (true)
-									(call is_approximate (assoc
-										obs (current_value 1)
-										exp (get exp (current_index 1))
-										percent percent
-										thresh threshold_amount
-										infinity_threshold infinity_threshold
-									))
-								)
-							))
-							obs
-						))
-					)
-				)
-
-				;all are null
-				(= (null) obs exp)
-				(true)
-
-				;else booleans, check if same
-				(= obs exp)
-				(true)
-
-				;else not valid
-				(false)
-			)
+	(declare
+		(assoc
+			exp (null)
+			obs (null)
+			percent .05
+			thresh (null)
+			infinity_threshold 1e200
 		)
+		(call verify_exp)
+
+		(assign (assoc threshhold (abs percent)))
+
+		;if it's a string, convert it to number
+		(if (= (get_type_string obs) "string")
+			(assign (assoc obs (+ obs)))
+		)
+		(if (= (get_type_string exp) "string")
+			(assign (assoc exp (+ exp)))
+		)
+
+		(if (= (get_type_string obs) "number")
+			(if (!= thresh (null)) ;if absolute threshhold is specified, the difference in the numbers must be less than that
+				(<= (abs (- exp obs)) (abs thresh))
+
+				(and (= obs .infinity) (= exp .infinity))
+				(true)
+
+				(and (= obs -.infinity) (= exp -.infinity))
+				(true)
+
+				;treat numbers that should be infinity but instead are really large due to floating point errors as infinity
+				(and (= obs .infinity) (>= exp infinity_threshold))
+				(true)
+
+				;treat numbers that should be infinity but instead are really large due to floating point errors as infinity
+				(and (= exp .infinity) (>= obs infinity_threshold))
+				(true)
+
+				(= 0 exp obs)
+				(true)
+
+				(let
+					(assign (assoc diff (/ (abs (- exp obs)) exp)))
+					(>= threshhold diff)
+				)
+			)
+
+			;else if list, iterate over the list and remove all values from obs that approximately match those in exp
+			;if resulting list has no items, both lists are approximately same
+			(or (= (get_type_string obs) "list") (= (get_type_string obs) "assoc"))
+			(and
+				;size must match
+				(= (size obs) (size exp))
+				;contents must match
+				(= 0
+					(size (filter
+						(lambda (let
+							(assoc
+								threshold_amount
+									(if (= "number" (get_type_string thresh))
+										thresh
+										;else it's a list or assoc, use corresponding threshold for index
+										(get thresh (current_index 1))
+									)
+
+							)
+							(!= (true)
+								(call is_approximate (assoc
+									obs (current_value 1)
+									exp (get exp (current_index 1))
+									percent percent
+									thresh threshold_amount
+									infinity_threshold infinity_threshold
+								))
+							)
+						))
+						obs
+					))
+				)
+			)
+
+			;all are null
+			(= (null) obs exp)
+			(true)
+
+			;else booleans, check if same
+			(= obs exp)
+			(true)
+
+			;else not valid
+			(false)
+		)
+	)
 
 	;return true if either verbose_mode is set or a text failed with verbose_on_fail to auto-print the last failed assertion
 	#verbose_output (or verbose_mode (and verbose_on_fail (> num_failed_asserts 0)))
@@ -174,228 +183,244 @@
 	; thresh : the allowed absolute error (eg, 0.56 = obs must be +/- 0.56 of exp, if specified, percent is ignored. may be an assoc with same keys as obs.
 	; infinity_threshold : when we can approximately consider numbers higher than this threshold to be infinity
 	#assert_approximate
-		(declare
-			(assoc
-				percent .05
-				thresh (null)
-				infinity_threshold 1e200
-			)
-
-			;for approximate comparison, order isn't important so we sort both inputs just in case
-			(assign (assoc
-				obs (sort obs)
-				exp (sort exp)
-			))
-
-			(if
-				(call is_approximate (assoc
-					obs obs
-					exp exp
-					percent percent
-					thresh thresh
-					infinity_threshold infinity_threshold
-				))
-				(print "PASSED (approximate)")
-
-				(call failed_assert_output (assoc msg "FAILED: assert_approximate"))
-			)
-
-			(if (call verbose_output) (let
-				(assoc
-					threshold_type
-						(if (!= (null) thresh)
-							"Threshhold: "
-							"Percent: "
-						)
-					threshold
-						(if (!= (null) thresh)
-							thresh
-							percent
-						)
-				)
-				(print ", Expected: " exp "  Observed: " obs "  " threshold_type threshold)
-			))
-			(print "\n")
-
+	(declare
+		(assoc
+			obs (null)
+			exp (null)
+			percent .05
+			thresh (null)
+			infinity_threshold 1e200
 		)
+		(call verify_exp)
+
+		;for approximate comparison, order isn't important so we sort both inputs just in case
+		(assign (assoc
+			obs (sort obs)
+			exp (sort exp)
+		))
+
+		(if
+			(call is_approximate (assoc
+				obs obs
+				exp exp
+				percent percent
+				thresh thresh
+				infinity_threshold infinity_threshold
+			))
+			(print "PASSED (approximate)")
+
+			(call failed_assert_output (assoc msg "FAILED: assert_approximate"))
+		)
+
+		(if (call verbose_output) (let
+			(assoc
+				threshold_type
+					(if (!= (null) thresh)
+						"Threshhold: "
+						"Percent: "
+					)
+				threshold
+					(if (!= (null) thresh)
+						thresh
+						percent
+					)
+			)
+			(print ", Expected: " exp "  Observed: " obs "  " threshold_type threshold)
+		))
+		(print "\n")
+	)
 
 	;asserts if two items are equal
 	; obs : item 1
 	; exp : item 2
 	; unordered : if true, order doesn't matter
 	#assert_same
-		(seq
-			;Check that exp was passed
-			(if (= exp (null))
-				(call failed_assert_output (assoc msg "FAILED: assert_same was not given a non-null value for exp. If the expected value is (null), use #assert_null."))
-			)
+	(declare
+		(assoc
+			exp (null)
+			obs (null)
+		)
+		(call verify_exp)
 
-			;when testing an unordered assoc, means its values can be unordered
-			(if (and unordered (= (get_type_string obs) "assoc"))
-				(let
-					(assoc
-						same_keys (= (sort (indices obs)) (sort (indices exp)) )
-					    differents
-							(filter
-								(lambda
-									;leave any values that don't match
-									(!= (sort (current_value)) (sort (get obs (current_index))) )
-								)
-								obs
+		;when testing an unordered assoc, means its values can be unordered
+		(if (and unordered (= (get_type_string obs) "assoc"))
+			(let
+				(assoc
+					same_keys (= (sort (indices obs)) (sort (indices exp)) )
+					differents
+						(filter
+							(lambda
+								;leave any values that don't match
+								(!= (sort (current_value)) (sort (get obs (current_index))) )
 							)
-					)
+							obs
+						)
+				)
 
-					;expect keys to be same and no differences
-					(if (and same_keys (= 0 (size differents)) )
-						(assign (assoc obs exp))
-					)
+				;expect keys to be same and no differences
+				(if (and same_keys (= 0 (size differents)) )
+					(assign (assoc obs exp))
 				)
 			)
-
-			(if unordered
-				;sort both lists so they can be compared using =
-				(assign (assoc obs (sort obs) exp (sort exp)))
-			)
-
-			(if (= obs exp)
-				(print "PASSED (same)")
-
-				(call failed_assert_output (assoc msg "FAILED: assert_same"))
-			)
-
-			(if (call verbose_output) (print ", Expected: " exp "  Observed: " obs))
-			(print "\n")
 		)
+
+		(if unordered
+			;sort both lists so they can be compared using =
+			(assign (assoc obs (sort obs) exp (sort exp)))
+		)
+
+		(if (= obs exp)
+			(print "PASSED (same)")
+
+			(call failed_assert_output (assoc msg "FAILED: assert_same"))
+		)
+
+		(if (call verbose_output) (print ", Expected: " exp "  Observed: " obs))
+		(print "\n")
+	)
 
 
 	;asserts that the obs parameter is true
 	; obs : item to check if true
 	#assert_true
-		(seq
-			(if obs
-				(print "PASSED (true)")
-
-				(call failed_assert_output (assoc msg "FAILED: assert_true"))
-			)
-			(if (call verbose_output) (print ", Expected: true  Observed: " obs))
-			(print "\n")
+	(declare
+		(assoc
+			obs (null)
 		)
+		(if (= (true) obs)
+			(print "PASSED (true)")
+
+			(call failed_assert_output (assoc msg "FAILED: assert_true"))
+		)
+		(if (call verbose_output) (print ", Expected: true  Observed: " obs))
+		(print "\n")
+	)
 
 
 	;asserts that the obs parameter is false
 	; obs : item to check if false
 	#assert_false
-		(seq
-			(if (not obs)
-				(print "PASSED (false)")
-
-				(call failed_assert_output (assoc msg "FAILED: assert_false"))
-			)
-			(if (call verbose_output) (print ", Expected: false  Observed: " obs))
-			(print "\n")
+	(declare
+		(assoc
+			obs (null)
 		)
+		(if (= (false) obs)
+			(print "PASSED (false)")
+
+			(call failed_assert_output (assoc msg "FAILED: assert_false"))
+		)
+		(if (call verbose_output) (print ", Expected: false  Observed: " obs))
+		(print "\n")
+	)
 
 
 	;asserts that the obs parameter is null
 	; obs : item to check if null
 	#assert_null
-		(seq
-			(if (= (null) obs)
-				(print "PASSED (null)")
-
-				(call failed_assert_output (assoc msg "FAILED: assert_null"))
-			)
-			(if (call verbose_output) (print ", Expected: null  Observed: " obs))
-			(print "\n")
+	(declare
+		(assoc
+			obs "You did not pass in a value for obs" ;intentionally not null
 		)
+		(if (= (null) obs)
+			(print "PASSED (null)")
+
+			(call failed_assert_output (assoc msg "FAILED: assert_null"))
+		)
+		(if (call verbose_output) (print ", Expected: null  Observed: " obs))
+		(print "\n")
+	)
+
 	;asserts that the obs parameter is not null
 	; obs : item to check if not null
 	#assert_not_null
-		(seq
-			(if (!= (null) obs)
-				(print "PASSED (not null)")
-
-				(call failed_assert_output (assoc msg "FAILED: assert_not_null"))
-			)
-			(if (call verbose_output) (print ", Expected: not null  Observed: " obs))
-			(print "\n")
+	(declare
+		(assoc
+			obs (null)
 		)
+		(if (!= (null) obs)
+			(print "PASSED (not null)")
+
+			(call failed_assert_output (assoc msg "FAILED: assert_not_null"))
+		)
+		(if (call verbose_output) (print ", Expected: not null  Observed: " obs))
+		(print "\n")
+	)
 
 
 	;exit run if there are any assert failures ( requires entity to run with root priveledge)
 	; msg : optional message to display, defaults to name of unit test
 	; quiet_pass : flag, optional. if true and there's no failure, will not print out passed.
 	#exit_if_failures
-		(if (> num_failed_asserts 0)
-			(seq
-				(print "Number of failed asserts: " num_failed_asserts " \n")
-				(if (!= (null) msg)
-					(print "[FAILED: " msg "]\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n")
-				)
-				(if unit_test_name
-					(print "\nFAILED >> " unit_test_name " <<\n\n")
-				)
-
-				(if unit_test_retries
-					(print "Retried test: " unit_test_retries "\n")
-				)
-
-				(if (and (!= allowed_retries unit_test_retries) (not (contains_value argv "no-retries")) )
-					(seq
-						(assign_to_entities (assoc num_failed_asserts 0))
-						(accum_to_entities (assoc unit_test_retries 1))
-						(print "RETRYING " unit_test_name " from the start...\nvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n")
-						(call retry_unit_test)
-					)
-
-					(system "exit")
-				)
+	(if (> num_failed_asserts 0)
+		(seq
+			(print "Number of failed asserts: " num_failed_asserts " \n")
+			(if (!= (null) msg)
+				(print "[FAILED: " msg "]\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n")
+			)
+			(if unit_test_name
+				(print "\nFAILED >> " unit_test_name " <<\n\n")
 			)
 
-			(if (and (!= (null) msg) (!= (true) quiet_pass))
+			(if unit_test_retries
+				(print "Retried test: " unit_test_retries "\n")
+			)
+
+			(if (and (> allowed_retries unit_test_retries) (not (contains_value argv "no-retries")) )
 				(seq
-					(print "[PASSED: " msg "]\n")
-					(if (= msg unit_test_name)
-						(print
-							"Total execution time: " (- (system_time) unit_test_start_time) " s\n"
-							(if unit_test_retries
-								(concat "Number of times this test was retried: " unit_test_retries "\n")
-								""
-							)
-						)
-					)
-					(print "\n")
+					(assign_to_entities (assoc num_failed_asserts 0))
+					(accum_to_entities (assoc unit_test_retries 1))
+					(print "RETRYING " unit_test_name " from the start...\nvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n")
+					(call retry_unit_test)
 				)
+
+				(system "exit")
 			)
 		)
+
+		(if (and (!= (null) msg) (!= (true) quiet_pass))
+			(seq
+				(print "[PASSED: " msg "]\n")
+				(if (= msg unit_test_name)
+					(print
+						"Total execution time: " (- (system_time) unit_test_start_time) " s\n"
+						(if unit_test_retries
+							(concat "Number of times this test was retried: " unit_test_retries "\n")
+							""
+						)
+					)
+				)
+				(print "\n")
+			)
+		)
+	)
 
 	;method to automatically reload and re-run the unit test
 	;will load the unit test file by the unit_test_name
 	;and remove the code labeled with #unit_test from the loaded test to prevent infinite loops of retries
 	#retry_unit_test
-		(seq
-			(call (rewrite
-				(lambda
-					(if (!= (get_labels (current_value 1)) (list "unit_test"))
-						(current_value)
-					)
+	(seq
+		(call (rewrite
+			(lambda
+				(if (!= (get_labels (current_value 1)) (list "unit_test"))
+					(current_value)
 				)
-				(load unit_test_name)
-			))
-			;return a conclude to prevent execution of the rest of the original failed script if retrying
-			(conclude)
-		)
+			)
+			(load unit_test_name)
+		))
+		;return a conclude to prevent execution of the rest of the original failed script if retrying
+		(conclude)
+	)
 
 
 	;method used by others to display failure message and increase the number of failed asserts
 	; msg : the message to display
 	#failed_assert_output
-		(seq
-			(assign_to_entities (assoc num_failed_asserts (+ 1 num_failed_asserts)))
-			(print msg)
-			(if (= 2 verbose_mode)
-				(print " at\n" (stack)) ;TODO: figure out a less verbose/more concise way to give feedback as to where exactly the failure occured
-			)
+	(seq
+		(assign_to_entities (assoc num_failed_asserts (+ 1 num_failed_asserts)))
+		(print msg)
+		(if (= 2 verbose_mode)
+			(print " at\n" (stack)) ;TODO: figure out a less verbose/more concise way to give feedback as to where exactly the failure occured
 		)
+	)
 
 )

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -65,10 +65,10 @@
 		(print "=====================================\n")
 	)
 
-	;helper function that gives failure output when a non-null value is not given for exp
+	;helper function that gives failure output when a non-null value is not given for exp, skips check if called within a recursive assertion
 	#verify_exp
-	(if (= (null) exp)
-		(call failed_assert_output (assoc msg "FAILED: A non-null value was not given for exp. If the expected value is (null), use #assert_null."))
+	(if (and (= (null) exp) (not inner))
+		(call failed_assert_output (assoc msg "FAILED: A non-null value was not given for exp. If the expected value is (null), use #assert_null.\n"))
 	)
 
 	; returns true (1) if the passed in numbers are within the specified percent of each other, otherwise returns false (0)
@@ -152,6 +152,7 @@
 									percent percent
 									thresh threshold_amount
 									infinity_threshold infinity_threshold
+									inner (true)
 								))
 							)
 						))

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -345,7 +345,6 @@
 						"influential_cases" (true)
 						"influential_cases_familiarity_convictions" (true)
 						"boundary_cases" (true)
-						"familiarity_conviction" (true)
 						"similarity_conviction" (true)
 						"outlying_feature_values" (true)
 					)
@@ -366,7 +365,6 @@
 							"influential_cases" (true)
 							"influential_cases_familiarity_convictions" (true)
 							"boundary_cases" (true)
-							"familiarity_conviction" (true)
 							"similarity_conviction" (true)
 							"outlying_feature_values" (true)
 						)
@@ -376,7 +374,6 @@
 	))
 
 	(print "Details of case with and w/o action values provided: ")
-	(call assert_approximate (assoc obs (get result2 "familiarity_conviction"  ) exp (get result "familiarity_conviction" )))
 	(call assert_approximate (assoc obs (get result2 "similarity_conviction"  ) exp (get result "similarity_conviction"  )))
 	; sort the influential cases by session training index since the order may not always be exact when influence weights are the same
 	(declare (assoc


### PR DESCRIPTION
Changes the unit test framework in the following ways:

- Adds strict checks for the `exp` variable for assert methods that use it. Calling these methods without setting the a non-null value for `exp` will now trigger a failure
- Updated the value printing logic to always print values from a failed assert if `#print_values_on_fail` is `(true)` which is on by default and switches the previous `#verbose_on_fail` which caused all assert values to be printed after a single failure to now be `(false)` by default.
- Parametrizes the sorting logic in `#assert_approximate`
- Some minor style/comment changes

Also updates the type schema and a unit test as "familiarity_conviction" is not actually a functional react detail.