### PR TITLE
21479: Adds a warning to analyze when users do targeted analysis on a time-series Trainee with no previous targetless hyperparameters

### DIFF
--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -182,6 +182,27 @@
 			(assign (assoc targeted_model "targetless"))
 		)
 
+		;if this is a time series Trainee, there are no targetless hyperparameters,
+		; and this analyze is targeted, emit a warning to the user that recommends
+		; a targeted analyze
+		(if (and
+				(!= (null) !tsTimeFeature)
+				(=
+					0
+					;the number of saved hyperparameter maps that are targetless
+					(size (filter (lambda (= ".targetless" (first (current_value))) ) !hyperparameterParamPaths))
+				)
+				(!= targeted_model "targetless")
+			)
+			(accum (assoc
+				analyze_warnings
+					(zip [(concat
+						"It is recomended to use a \"targetless\" analysis of the data for a time-series Trainee. "
+						"Please analyze the data once more with no action features specified and the value \"targetless\" "
+						"specified for the \"targeted_model\" parameter."
+					)])
+			))
+		)
 
 		;if the bypass hyperparameter analysis flag is null or is false, analyze hyper parameters
 		(if (not bypass_hyperparameter_analysis)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -196,11 +196,11 @@
 			)
 			(accum (assoc
 				analyze_warnings
-					(zip [(concat
+					(associate (concat
 						"It is recomended to use a \"targetless\" analysis of the data for a time-series Trainee. "
 						"Please analyze the data once more with no action features specified and the value \"targetless\" "
 						"specified for the \"targeted_model\" parameter."
-					)])
+					))
 			))
 		)
 


### PR DESCRIPTION
Adds a warning to analyze that triggers when users call a targeted analysis on a time-series Trainee that has no previously stored targetless hyperparameters.

The motivation here is that training time-series data used to trigger a targetless analysis internally. We strongly recommend targetless hyperparameters when using the howso-engine for time-series data, but with the removal of the internal analyze call in time-series flows, users may only do a targeted analyze before calling things like `#react_series`. 

Here we add a new warning to analyze to try and warn users when they go down this unrecommended path.