### PR TITLE
21502: Ignores early lag-dependent features for residuals computation for time series datasets

### DIFF
--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -84,7 +84,7 @@
 						series_ordered_by_features (get feature_attribute_map "ordered_by_features")
 					))
 
-					;create .series_progress and .series_progress_delta features
+					;create .series_progress, .series_progress_delta and .series_index features
 					(= "progress" (get feature_attribute_map "derive_type"))
 					(call !CreateSeriesProgressFeatures (assoc
 						feature feature

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -296,6 +296,10 @@
 			unique_features_for_populating_output (null)
 
 			provided_case_id_flag (true)
+
+			;store an assoc of lag/rate/delta feature -> lag/order amount for time series flows
+			ts_feature_lag_amount_map (null)
+			max_lag_index_value (null)
 		))
 
 		(call !InitResiduals)

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -1,7 +1,7 @@
 ;Contains methods to generate features or feature values as defined by feature attributes.
 (null
 
-	;creates a nominal start or end time feature for a specified series_id using the specified series_time to determine start and end
+	;creates the built-in .series_progress, .series_progress_delta and .series_index features
 	;
 	;parameters:
 	; feature: name of feature to add and populate
@@ -90,7 +90,7 @@
 								fixed_delta (/ 1 (- (size sorted_time_values) 1))
 							))
 
-							;create an assoc of case_id -> [ progress%, delta_to_previous ]
+							;create an assoc of case_id -> [ progress%, index, delta_to_previous ]
 							;where progress is: 0-based value / range
 							(zip
 								sorted_case_ids
@@ -110,7 +110,8 @@
 											))
 										)
 										(assign (assoc previous_value (current_value 1)))
-										(list progress delta)
+										;output the tuple
+										[progress (current_index 1) delta]
 									))
 									sorted_time_values
 								)
@@ -122,7 +123,7 @@
 		))
 
 		;store the progress and delta value at the same time into each case
-		;by iterating over assoc of:case_id -> [ progress%, delta_to_previous ]
+		;by iterating over assoc of:case_id -> [ progress%, index, delta_to_previous ]
 		(map
 			(lambda
 				;see whether the entity has the label
@@ -131,6 +132,7 @@
 						(current_index)
 						(associate
 							feature (first (current_value 1))
+							".series_index" (get (current_value 1) 1)
 							(concat feature "_delta") (last (current_value 1))
 						)
 					)
@@ -140,6 +142,7 @@
 						(current_index)
 						(list
 							(set_labels (first (current_value 1)) (list feature))
+							(set_labels (get (current_value 1) 1) (list ".series_index"))
 							(set_labels (last (current_value 1)) (list (concat feature "_delta")) )
 						)
 					)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -323,7 +323,7 @@
 				(if !tsTimeFeature
 					(map
 						(lambda (or
-							;store value of 'max_row_la'g for lag features and 'ts_order' for delta or rate features
+							;store value of 'max_row_lag' for lag features and 'ts_order' for delta or rate features
 							(get (current_value) "max_row_lag")
 							(get (current_value) "ts_order")
 						))

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -439,7 +439,7 @@
 		;keep a copy of all originally specified features
 		(assign (assoc
 			case_features
-				(values (append context_features features) (true))
+				(values (append context_features features (if !tsTimeFeature [".series_index"] [])) (true))
 		))
 
 		;Ensure enough cases
@@ -473,7 +473,19 @@
 						)
 					)
 				)
+			lag_feature_amount_map (null)
+			original_context_features context_features
 		))
+
+		(if !tsTimeFeature
+			(assign (assoc
+				lag_feature_amount_map
+					(indices (filter
+						(lambda (get (current_value) "max_row_lag"))
+						!featureAttributes
+					))
+			))
+		)
 
 		;iterate over each case and accumulate residuals for all the feature(s)
 		#!AccumulateFeatureResiduals
@@ -494,6 +506,23 @@
 							;map of feature -> value for all the case values
 							case_values_map (zip case_features (retrieve_from_entity (current_value 1) case_features) )
 							time_series_filter_query (list)
+						)
+
+						(if !tsTimeFeature
+							(let
+								(assoc series_index (get case_values_map ".series_index"))
+
+								;modify context_features to not include any lag features whose lag amount is larger than this case's series_index
+								(assign (assoc
+									context_features
+										(filter
+											(lambda
+												(not (< series_index (get lag_feature_amount_map (current_value))) )
+											)
+											original_context_features
+										)
+								))
+							)
 						)
 
 						;for robust computation we randomly (50/50) decide whether to remove a feature from the context

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -476,10 +476,18 @@
 			;store an assoc of lag feature -> lag amount for time series flows
 			lag_feature_amount_map
 				(if !tsTimeFeature
-					(indices (filter
+					(map
 						(lambda (get (current_value) "max_row_lag"))
-						!featureAttributes
-					))
+						(filter
+							(lambda
+								(and
+									(get (current_value) "max_row_lag")
+									(= "lag" (get (current_value) "ts_type"))
+								)
+							)
+							!featureAttributes
+						)
+					)
 				)
 			;create a backup of context_features for time series flows
 			original_context_features (if !tsTimeFeature (replace context_features))
@@ -777,10 +785,18 @@
 			;store an assoc of lag feature -> lag amount for time series flows
 			lag_feature_amount_map
 				(if !tsTimeFeature
-					(indices (filter
+					(map
 						(lambda (get (current_value) "max_row_lag"))
-						!featureAttributes
-					))
+						(filter
+							(lambda
+								(and
+									(get (current_value) "max_row_lag")
+									(= "lag" (get (current_value) "ts_type"))
+								)
+							)
+							!featureAttributes
+						)
+					)
 				)
 		))
 

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -317,7 +317,28 @@
 			p_parameter (get hyperparam_map "p")
 			dt_parameter (get hyperparam_map "dt")
 			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
+
+			;store an assoc of lag/rate/delta feature -> lag/order amount for time series flows
+			ts_feature_lag_amount_map
+				(if !tsTimeFeature
+					(map
+						(lambda (or
+							;store value of 'max_row_la'g for lag features and 'ts_order' for delta or rate features
+							(get (current_value) "max_row_lag")
+							(get (current_value) "ts_order")
+						))
+						;only lag, delta and rate features have a ts_type defined
+						(filter
+							(lambda (get (current_value) "ts_type") )
+							!featureAttributes
+						)
+					)
+				)
 		))
+
+		(if !tsTimeFeature
+			(assign (assoc max_lag_index_value (apply "max" (values ts_feature_lag_amount_map)) ))
+		)
 
 		;flag that 'case_ids' were not provided so 'action_condition_filter_query' is used.
 		(if (and (= (size case_ids) 0) (size action_condition_filter_query))
@@ -473,30 +494,9 @@
 						)
 					)
 				)
-			;store an assoc of lag feature -> lag amount for time series flows
-			lag_feature_amount_map
-				(if !tsTimeFeature
-					(map
-						(lambda (get (current_value) "max_row_lag"))
-						(filter
-							(lambda
-								(and
-									(get (current_value) "max_row_lag")
-									(= "lag" (get (current_value) "ts_type"))
-								)
-							)
-							!featureAttributes
-						)
-					)
-				)
 			;create a backup of context_features for time series flows
 			original_context_features (if !tsTimeFeature (replace context_features))
-			max_lag_index_value (null)
 		))
-
-		(if !tsTimeFeature
-			(assign (assoc max_lag_index_value (apply "max" (values lag_feature_amount_map)) ))
-		)
 
 		;iterate over each case and accumulate residuals for all the feature(s)
 		#!AccumulateFeatureResiduals
@@ -529,7 +529,7 @@
 										(if (< series_index max_lag_index_value)
 											(filter
 												(lambda
-													(not (< series_index (get lag_feature_amount_map (current_value))) )
+													(not (< series_index (get ts_feature_lag_amount_map (current_value))) )
 												)
 												original_context_features
 											)
@@ -787,32 +787,7 @@
 	;helper method for CalculateFeatureResiduals to calculate full residuals
 	#!RunFullResiduals
 	(seq
-
-		(declare (assoc
-			context_features_map (zip context_features)
-
-			;store an assoc of lag feature -> lag amount for time series flows
-			lag_feature_amount_map
-				(if !tsTimeFeature
-					(map
-						(lambda (get (current_value) "max_row_lag"))
-						(filter
-							(lambda
-								(and
-									(get (current_value) "max_row_lag")
-									(= "lag" (get (current_value) "ts_type"))
-								)
-							)
-							!featureAttributes
-						)
-					)
-				)
-			max_lag_index_value (null)
-		))
-
-		(if !tsTimeFeature
-			(assign (assoc max_lag_index_value (apply "max" (values lag_feature_amount_map)) ))
-		)
+		(declare (assoc context_features_map (zip context_features) ))
 
 		(assign (assoc
 			feature_residuals_lists
@@ -872,7 +847,7 @@
 													(if (< series_index max_lag_index_value)
 														(filter
 															(lambda
-																(not (< series_index (get lag_feature_amount_map (current_value))) )
+																(not (< series_index (get ts_feature_lag_amount_map (current_value))) )
 															)
 															original_react_context_features
 														)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -473,20 +473,18 @@
 						)
 					)
 				)
-			lag_feature_amount_map (null)
-			original_context_features context_features
-		))
-
-		;store an assoc of lag feature -> lag amount
-		(if !tsTimeFeature
-			(assign (assoc
-				lag_feature_amount_map
+			;store an assoc of lag feature -> lag amount for time series flows
+			lag_feature_amount_map
+				(if !tsTimeFeature
 					(indices (filter
 						(lambda (get (current_value) "max_row_lag"))
 						!featureAttributes
 					))
-			))
-		)
+				)
+			;create a backup of context_features for time series flows
+			original_context_features (if !tsTimeFeature (replace context_features))
+		))
+
 
 		;iterate over each case and accumulate residuals for all the feature(s)
 		#!AccumulateFeatureResiduals
@@ -773,7 +771,18 @@
 	#!RunFullResiduals
 	(seq
 
-		(declare (assoc context_features_map (zip context_features) ))
+		(declare (assoc
+			context_features_map (zip context_features)
+
+			;store an assoc of lag feature -> lag amount for time series flows
+			lag_feature_amount_map
+				(if !tsTimeFeature
+					(indices (filter
+						(lambda (get (current_value) "max_row_lag"))
+						!featureAttributes
+					))
+				)
+		))
 
 		(assign (assoc
 			feature_residuals_lists
@@ -786,7 +795,7 @@
 							react_context_features (indices (remove context_features_map (current_value 1)))
 							feature_is_edit_distance (contains_index !editDistanceFeatureTypesMap (current_value 1))
 							feature_is_non_string_edit_distance (false)
-							needed_features (append context_features (get_value (current_value 1)))
+							needed_features (append context_features (get_value (current_value 1)) (if !tsTimeFeature [".series_index"] []) )
 						)
 
 						(if (and feature_is_edit_distance (!= "string_mixable" (get !editDistanceFeatureTypesMap feature)) )
@@ -802,6 +811,8 @@
 								)
 							has_time_series_filter_query (and !tsTimeFeature (contains_value react_context_features !tsTimeFeature) )
 							time_series_filter_query (list)
+							;create a backup of react_context_features for time series flows
+							original_react_context_features (if !tsTimeFeature (replace react_context_features))
 						))
 
 						(if (contains_index skip_features_map feature)
@@ -819,6 +830,23 @@
 										diff 0
 										output_categorical_action_probabilities (true)
 										categorical_action_probabilities_map (assoc)
+									)
+
+									(if !tsTimeFeature
+										(let
+											(assoc series_index (get case_values_map ".series_index"))
+
+											;modify context_features to not include any lag features whose lag amount is larger than this case's series_index
+											(assign (assoc
+												react_context_features
+													(filter
+														(lambda
+															(not (< series_index (get lag_feature_amount_map (current_value))) )
+														)
+														original_react_context_features
+													)
+											))
+										)
 									)
 
 									;set the filter query if has_time_series_filter already checked that time feature is in context features

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -523,7 +523,8 @@
 							(let
 								(assoc series_index (get case_values_map ".series_index"))
 
-								;modify context_features to not include any lag features whose lag amount is larger than this case's series_index
+								;modify context features to not include any lag-dependent features whose lag
+								;amount is larger than this case's series_index
 								(assign (assoc
 									context_features
 										(if (< series_index max_lag_index_value)
@@ -841,7 +842,8 @@
 										(let
 											(assoc series_index (get case_values_map ".series_index"))
 
-											;modify context_features to not include any lag features whose lag amount is larger than this case's series_index
+											;modify context features to not include any lag-dependent features whose lag
+											;amount is larger than this case's series_index
 											(assign (assoc
 												react_context_features
 													(if (< series_index max_lag_index_value)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -477,6 +477,7 @@
 			original_context_features context_features
 		))
 
+		;store an assoc of lag feature -> lag amount
 		(if !tsTimeFeature
 			(assign (assoc
 				lag_feature_amount_map

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -491,8 +491,12 @@
 				)
 			;create a backup of context_features for time series flows
 			original_context_features (if !tsTimeFeature (replace context_features))
+			max_lag_index_value (null)
 		))
 
+		(if !tsTimeFeature
+			(assign (assoc max_lag_index_value (apply "max" (values lag_feature_amount_map)) ))
+		)
 
 		;iterate over each case and accumulate residuals for all the feature(s)
 		#!AccumulateFeatureResiduals
@@ -522,10 +526,15 @@
 								;modify context_features to not include any lag features whose lag amount is larger than this case's series_index
 								(assign (assoc
 									context_features
-										(filter
-											(lambda
-												(not (< series_index (get lag_feature_amount_map (current_value))) )
+										(if (< series_index max_lag_index_value)
+											(filter
+												(lambda
+													(not (< series_index (get lag_feature_amount_map (current_value))) )
+												)
+												original_context_features
 											)
+
+											;else leave context features as-is
 											original_context_features
 										)
 								))
@@ -798,7 +807,12 @@
 						)
 					)
 				)
+			max_lag_index_value (null)
 		))
+
+		(if !tsTimeFeature
+			(assign (assoc max_lag_index_value (apply "max" (values lag_feature_amount_map)) ))
+		)
 
 		(assign (assoc
 			feature_residuals_lists
@@ -855,10 +869,15 @@
 											;modify context_features to not include any lag features whose lag amount is larger than this case's series_index
 											(assign (assoc
 												react_context_features
-													(filter
-														(lambda
-															(not (< series_index (get lag_feature_amount_map (current_value))) )
+													(if (< series_index max_lag_index_value)
+														(filter
+															(lambda
+																(not (< series_index (get lag_feature_amount_map (current_value))) )
+															)
+															original_react_context_features
 														)
+
+														;else leave context features as-is
 														original_react_context_features
 													)
 											))


### PR DESCRIPTION
TS flow creates a new internal-only feature called ".series_index" stores each cases's index with respect to its series.
During residual computation, lag features whose offset is larger than the series index of their case are not included, e.g, a lag feature of lag 5 will not be included when computing residuals for case with .case_index=3.