### PR TITLE
21510: Updates expected values for tests that relied too heavily on consistent tie breaks for nearest cases

### DIFF
--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -54,7 +54,6 @@
 	))
 
 	(assign (assoc result (get opt_hp_map (list ".targetless" "A.B.C.D." "robust" ".none" "featureDeviations")) ))
-	(print result)
 	(print "Analyzed with null deviations: ")
 
 	(call assert_approximate (assoc
@@ -139,8 +138,8 @@
 	))
 	(call assert_approximate (assoc
 		obs (get result (list 1 "payload" "influential_cases" 2 ".influence_weight"))
-		exp 0.23
-		thresh 0.069
+		exp 0.24
+		thresh 0.08
 	))
 
 	(call exit_if_failures (assoc msg "Null-null uncertainty react." ))

--- a/unit_tests/ut_h_null_react.amlg
+++ b/unit_tests/ut_h_null_react.amlg
@@ -189,9 +189,9 @@
 	))
 	(print "Robust Feature contributions for nominal: ")
 	(call assert_approximate (assoc
-		exp (assoc "X" 0.64 "Y" .48)
+		exp (assoc "X" 0.64 "Y" .4)
 		obs (get result (list 1 "payload" "feature_contributions_robust"))
-		thresh 0.1
+		thresh 0.15
 	))
 
 	(call exit_if_failures (assoc msg "Nominal Feature contributions." ))
@@ -320,7 +320,7 @@
 	))
 	(print "Feature contributions: ")
 	(call assert_approximate (assoc
-		exp (assoc "X" .26 "Y" .07)
+		exp (assoc "X" .2 "Y" .07)
 		obs (get result (list 1 "payload" "feature_contributions_full"))
 		thresh 0.1
 	))
@@ -337,9 +337,9 @@
 	))
 	(print "Robust Feature contributions: ")
 	(call assert_approximate (assoc
-		exp (assoc "X" 0.46 "Y" .4)
+		exp (assoc "X" 0.46 "Y" .35)
 		obs (get result (list 1 "payload" "feature_contributions_robust"))
-		thresh 0.1
+		thresh 0.15
 	))
 
 	(call exit_if_failures (assoc msg "Feature contributions." ))


### PR DESCRIPTION
With incoming changes to the random number generator used within Amalgam, tests that relied on consistent tie-breaking between nearest cases needed to be adjusted.