### PR TITLE
21512: Fixes an issue where categorical action probabilities are not returned when there is no context

### DIFF
--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1027,7 +1027,27 @@
 				(= (list) context_features)
 				(= 0 (size (first candidate_cases_lists)))
 			)
-			(call !CalculateFeatureExpectedValue (assoc feature (first action_features) allow_nulls (false)))
+			(let
+				(assoc
+					;!CalculateFeatureExpectedValue may update the !expectedValuesMap so it should be called first
+					exp_value (call !CalculateFeatureExpectedValue (assoc feature (first action_features) allow_nulls (false)))
+				)
+
+				;use the global class counts for the feature as the categorical action probabilities
+				(if output_categorical_action_probabilities
+					(call !AccumulateCategoricalActionProbabilties (assoc
+						action_feature (first action_features)
+						categorical_value_weights_map
+							(get !expectedValuesMap [
+								(if valid_weight_feature weight_feature ".none")
+								(first action_features)
+								"class_counts"
+							])
+					))
+				)
+
+				exp_value
+			)
 
 			;else interpolate the result from the nearest neighbors
 			(call !InterpolateActionValues (assoc


### PR DESCRIPTION
When requesting categorical action probabilities from DiscriminativeReact, if no context features are provided the CAPs would not be returned previously. This fixes that.