### PR TITLE
21517: Updates `#edit_cases` to re-derive non-time-series features that auto-derive on train, also fixes some bugs related to derivation

### DIFF
--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -31,7 +31,7 @@
 			;append series_ordered_by_features with sourced features and ensure no duplicates
 			necessary_features
 				(append
-					series_ordered_by_features
+					(or series_ordered_by_features [])
 
 					;filter out features in sourced_features that already exist in series_ordered_by_features
 					;leaving only the ones that are unique to sourced_features

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -174,7 +174,7 @@
 
 		;if series_id_features isn't specified, return the entire dataset
 		(if (= 0 (size series_id_features))
-			(list (query_exists !internalLabelSession))
+			[ [(query_exists !internalLabelSession)] ]
 
 			(= 1 (size series_id_features))
 			(let

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -218,17 +218,103 @@
 		))
 
 		(if case_ids
-			(map
-				(lambda
-					(call !UpdateCaseWithHistory (assoc
-						case_id (current_value 1)
-						features features
-						feature_values feature_values
-						unencoded_feature_values unencoded_feature_values
-						session session
-					))
+			(seq
+				(map
+					(lambda
+						(call !UpdateCaseWithHistory (assoc
+							case_id (current_value 1)
+							features features
+							feature_values feature_values
+							unencoded_feature_values unencoded_feature_values
+							session session
+						))
+					)
+					case_ids
 				)
-				case_ids
+
+				;update derived features if necessary
+				(let
+					(assoc
+						affected_derived_features
+							;any features edited that are the source feature of a non-TS derived feature
+							(filter
+								(lambda
+									(and
+										;its not a time-series feature (lag, rate, etc.)
+										(not (contains_index (get !featureAttributes (current_value)) "ts_type"))
+										;this derived feature is generated upon training, others are not saved into cases
+										(size (get !featureAttributes [(current_value 1) "auto_derive_on_train"]) )
+										;at least one source feature that affects this derived feature was edited
+										(size (filter
+											(lambda
+												;"list of derived features contains this specific derived feature?""
+												(contains_value (current_value) (current_value 1))
+											)
+											;only iterate over sources features that were edited
+											(keep !sourceToDerivedFeatureMap features)
+										))
+									)
+								)
+								(indices !derivedFeaturesMap)
+							)
+					)
+
+					;most likely a no-op (when affected_derived_features is empty)
+					(map
+						(lambda
+							(let
+								(assoc
+									derived_feature (current_value 1)
+									necessary_features_offset_map
+										(get_all_labels (parse (get !featureAttributes (list (current_value 2) "auto_derive_on_train" "code"))))
+								)
+
+								;only re-derive features that only use features within their own case/row
+								;offsets other than zero indicate deriving from values of another row within a series
+								;tackling this problem for TS data is TODO: 21518
+								(if (=
+										[0]
+										(values necessary_features_offset_map (true))
+									)
+									(let
+										(assoc necessary_features (indices necessary_features_offset_map) )
+
+										(declare (assoc
+											necessary_values
+												(map
+													(lambda (retrieve_from_entity (current_value) necessary_features))
+													case_ids
+												)
+										))
+
+										(declare (assoc
+											updated_values
+												(call !AddDerivedCodeFeature (assoc
+													feature derived_feature
+													features necessary_features
+													series_data necessary_values
+												))
+										))
+
+										(call !StoreCaseValues (assoc
+											;map of case id -> value
+											case_values_map (zip case_ids updated_values)
+											label_name derived_feature
+											overwrite (true)
+										))
+									)
+								)
+
+							)
+						)
+						affected_derived_features
+					)
+
+					;update features if necessary so that data mass change is correct
+					(if (size affected_derived_features)
+						(assign (assoc features (append features affected_derived_features) ))
+					)
+				)
 			)
 		)
 

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -266,7 +266,7 @@
 										)
 									)
 								)
-								(indices !derivedFeaturesMap)
+								(or (indices !derivedFeaturesMap) [])
 							)
 					)
 
@@ -309,10 +309,8 @@
 						affected_derived_features
 					)
 
-					;update features if necessary so that data mass change is correct
-					(if (size affected_derived_features)
-						(assign (assoc features (append features affected_derived_features) ))
-					)
+					;update features so that data mass change is correct
+					(accum (assoc features affected_derived_features ))
 				)
 			)
 		)

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -240,9 +240,9 @@
 							(filter
 								(lambda
 									(and
-										;its not a time-series feature (lag, rate, etc.)
+										;not a time-series feature (lag, rate, etc.)
 										(not (contains_index (get !featureAttributes (current_value)) "ts_type"))
-										;this derived feature is generated upon training, others are not saved into cases
+										;generated upon training, otherwise not saved into cases
 										(size (get !featureAttributes [(current_value 1) "auto_derive_on_train"]) )
 										;at least one source feature that affects this derived feature was edited
 										(size (filter
@@ -253,6 +253,17 @@
 											;only iterate over sources features that were edited
 											(keep !sourceToDerivedFeatureMap features)
 										))
+										;the derivation code only uses values from within the same case (not other cases in the series)
+										;(get_all_labels) returns a map of all labels to their values from the code, in this case all feature names to their  offsets,
+										;offsets other than zero indicate deriving from values of another row within a series
+										;tackling this problem for TS data is TODO: 21518
+										(=
+											[0]
+											(values
+												(get_all_labels (parse (get !featureAttributes (list (current_value 1) "auto_derive_on_train" "code"))))
+												(true)
+											)
+										)
 									)
 								)
 								(indices !derivedFeaturesMap)
@@ -265,46 +276,33 @@
 							(let
 								(assoc
 									derived_feature (current_value 1)
-									necessary_features_offset_map
-										(get_all_labels (parse (get !featureAttributes (list (current_value 2) "auto_derive_on_train" "code"))))
+									necessary_features
+										(indices (get_all_labels (parse (get !featureAttributes (list (current_value 2) "auto_derive_on_train" "code")))))
 								)
 
-								;only re-derive features that only use features within their own case/row
-								;offsets other than zero indicate deriving from values of another row within a series
-								;tackling this problem for TS data is TODO: 21518
-								(if (=
-										[0]
-										(values necessary_features_offset_map (true))
-									)
-									(let
-										(assoc necessary_features (indices necessary_features_offset_map) )
+								(declare (assoc
+									necessary_values
+										(map
+											(lambda (retrieve_from_entity (current_value) necessary_features))
+											case_ids
+										)
+								))
 
-										(declare (assoc
-											necessary_values
-												(map
-													(lambda (retrieve_from_entity (current_value) necessary_features))
-													case_ids
-												)
+								(declare (assoc
+									updated_values
+										(call !AddDerivedCodeFeature (assoc
+											feature derived_feature
+											features necessary_features
+											series_data necessary_values
 										))
+								))
 
-										(declare (assoc
-											updated_values
-												(call !AddDerivedCodeFeature (assoc
-													feature derived_feature
-													features necessary_features
-													series_data necessary_values
-												))
-										))
-
-										(call !StoreCaseValues (assoc
-											;map of case id -> value
-											case_values_map (zip case_ids updated_values)
-											label_name derived_feature
-											overwrite (true)
-										))
-									)
-								)
-
+								(call !StoreCaseValues (assoc
+									;map of case id -> value
+									case_values_map (zip case_ids updated_values)
+									label_name derived_feature
+									overwrite (true)
+								))
 							)
 						)
 						affected_derived_features

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -270,13 +270,14 @@
 							)
 					)
 
-					;most likely a no-op (when affected_derived_features is empty)
+					;this will be a no-op if affected_derived_features is empty
 					(map
 						(lambda
 							(let
 								(assoc
 									derived_feature (current_value 1)
 									necessary_features
+										;the labels (feature names) used in the derivation code
 										(indices (get_all_labels (parse (get !featureAttributes (list (current_value 2) "auto_derive_on_train" "code")))))
 								)
 
@@ -290,6 +291,7 @@
 
 								(declare (assoc
 									updated_values
+										;derive new values for each case
 										(call !AddDerivedCodeFeature (assoc
 											feature derived_feature
 											features necessary_features
@@ -298,7 +300,6 @@
 								))
 
 								(call !StoreCaseValues (assoc
-									;map of case id -> value
 									case_values_map (zip case_ids updated_values)
 									label_name derived_feature
 									overwrite (true)

--- a/unit_tests/ut_h_derive_custom.amlg
+++ b/unit_tests/ut_h_derive_custom.amlg
@@ -228,5 +228,29 @@
 	(print "Derived action features included in react action_features: ")
 	(call assert_same (assoc obs (get result "action_features") exp (list "reciever" "mult") ))
 
+	;editing the "sender" feature of cases should update the .custom4 feature
+	(call_entity "howso" "edit_cases" (assoc
+		condition (assoc ".custom4" ["C"])
+		features ["sender"]
+		feature_values ["mike"]
+	))
+
+	(assign (assoc
+		result
+			(get
+				(call_entity "howso" "get_cases" (assoc
+					features (list ".custom4")
+				))
+				(list 1 "payload" "cases")
+			)
+	))
+
+	; all .custom4 should be M now that all with C had sender changed to "mike"
+	(print "Derived complex nominal with literals: ")
+	(call assert_same (assoc
+		obs (apply "append" result)
+		exp (list "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M" "M")
+	))
+
 	(call exit_if_failures (assoc msg unit_test_name ))
 )


### PR DESCRIPTION
Adds logic to `#edit_cases` that will check if any non-time-series derived features within the Trainee are derived from features that were edited. If there are any, they are re-derived with the updated values and the cases are updated with the new values.