### PR TITLE
21548: Moves cache updates to the beginning of `#react` and `#react_series`

### DIFF
--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -405,14 +405,8 @@
 
 		(call !UpdateCaseWeightParameters (assoc set_valid_weight_feature (false) ))
 
-		;if expected values haven't been cached (i.e., analyze was skipped), do that here
-		(if (= 0 (size !expectedValuesMap))
-			(call !CacheExpectedValuesAndProbabilities (assoc
-				features !trainedFeatures
-				weight_feature (if (not use_case_weights) ".none" weight_feature)
-				use_case_weights use_case_weights
-			))
-		)
+		;check and update caches if necessary
+		(call !PreReactCacheChecks)
 
 		(declare (assoc
 			output_action_features
@@ -698,6 +692,31 @@
 				))
 			)
 		)
+
+		(declare (assoc
+			hyperparam_map
+				(if (= 1 (size action_features))
+					(call !GetHyperparameters (assoc
+						feature (first action_features)
+						context_features context_features
+						mode "full"
+						weight_feature weight_feature
+					))
+
+					(call !GetHyperparameters (assoc
+						feature ".targetless"
+						context_features context_features
+						mode "robust"
+						weight_feature weight_feature
+					))
+				)
+			constrained_features (null)
+		))
+
+		(call !UpdateCaseWeightParameters (assoc set_valid_weight_feature (false) ))
+
+		;check and update caches if necessary
+		(call !PreReactCacheChecks)
 
 		;assoc of feature -> unique value, pre-populated if there are unique features that need to be synthed
 		(declare (assoc
@@ -1290,6 +1309,68 @@
 				candidate_case_weights (get candidate_cases_lists 1)
 				candidate_case_values (last candidate_cases_lists)
 				allow_nulls allow_nulls
+			))
+		)
+	)
+
+	;helper method for React calls that checks marginal, expected value, and residuals caches
+	;requires the following vars on the stack:
+	; hyperparam_map, desired_conviction, weight_feature, use_case_weights
+	; These should be ready if !GetHyperparmeters and !UpdateCaseWeightParameters are called beforehand
+	#!PreReactCacheChecks
+	(seq
+		;if doing a generative react and global residuals have have not been calculated yet,
+		;recalculate them only if there are enough training cases
+		;they are needed regardless of which residual mode is being used
+		(if (and
+				(!= desired_conviction (null))
+				(= 0 (size (get hyperparam_map "featureResiduals")))
+				(>= (call !GetNumTrainingCases) 2)
+			)
+			(seq
+				(assign (assoc
+					hyperparam_map
+						(call !CalculateResidualsAndUpdateParameters (assoc
+							context_features !trainedFeatures
+							custom_hyperparam_map hyperparam_map
+							num_samples 1000
+							;robust with respect to the set of contexts used (across the power set of contexts), should match hyperparam map robust mode
+							robust_residuals (!= 1 (size action_features))
+							hyperparameter_feature
+								(if (= 1 (size action_features))
+									(first action_features)
+									".targetless"
+								)
+							weight_feature weight_feature
+							use_case_weights use_case_weights
+							compute_null_uncertainties (false)
+							compute_all_statistics (false)
+						))
+				))
+				(if (= (first (get hyperparam_map "paramPath")) ".default")
+					;updating default hyperparam set with featuredeviations
+					(assign_to_entities (assoc !defaultHyperparameters hyperparam_map) )
+
+					;update the appropriate hyperparameter set
+					(assign_to_entities (assoc !hyperparameterMetadataMap (set !hyperparameterMetadataMap (get hyperparam_map "paramPath") hyperparam_map)) )
+				)
+				(accum_to_entities (assoc !revision 1))
+			)
+		)
+
+		;compute and cache all min-max values for all features
+		(if (= 0 (size !featureMarginalStatsMap))
+			(call !CalculateMarginalStats (assoc
+				weight_feature (if use_case_weights weight_feature)
+			))
+		)
+
+		;if expected values haven't been cached (i.e., analyze was skipped), do that here
+		(if (= 0 (size !expectedValuesMap))
+			(call !CacheExpectedValuesAndProbabilities (assoc
+				features !trainedFeatures
+				weight_feature (if (not use_case_weights) ".none" weight_feature)
+				use_case_weights use_case_weights
 			))
 		)
 	)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -187,6 +187,21 @@
 			))
 		)
 
+		(declare (assoc
+			hyperparam_map
+				(call !GetHyperparameters (assoc
+					feature ".targetless"
+					context_features context_features
+					mode "robust"
+					weight_feature weight_feature
+				))
+		))
+
+		(call !UpdateCaseWeightParameters (assoc set_valid_weight_feature (false) ))
+
+		;check and update caches if necessary
+		(call !PreReactCacheChecks)
+
 		;if user passed in a series for continuing, create a temporary trainee to derive all the necessary values (lags, deltas, etc.)
 		;and then overwrite the passed continue_series_values with the additional derived feature values
 		(if (size continue_series_values)
@@ -538,6 +553,21 @@
 		(declare (assoc output_features action_features))
 
 		(call !ValidateDerivedActionFeaturesIsSubset)
+
+		(declare (assoc
+			hyperparam_map
+				(call !GetHyperparameters (assoc
+					feature ".targetless"
+					context_features context_features
+					mode "robust"
+					weight_feature weight_feature
+				))
+		))
+
+		(call !UpdateCaseWeightParameters (assoc set_valid_weight_feature (false) ))
+
+		;check and update caches if necessary
+		(call !PreReactCacheChecks)
 
 		;this can get appended to in later logic, but should not appear required in the API so it's default is (null)
 		(if (= (null) initial_values)

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -83,43 +83,6 @@
 
 		(call !UpdateCaseWeightParameters)
 
-		;if global residuals have have not been calculated yet, recalculate them only if there are enough training cases
-		;they are needed regardless of which residual mode is being used
-		(if (and
-				(= 0 (size (get hyperparam_map "featureResiduals")))
-				(>= (call !GetNumTrainingCases) 2)
-			)
-			(seq
-				(assign (assoc
-					hyperparam_map
-						(call !CalculateResidualsAndUpdateParameters (assoc
-							context_features !trainedFeatures
-							custom_hyperparam_map hyperparam_map
-							num_samples 1000
-							;robust with respect to the set of contexts used (across the power set of contexts), should match hyperparam map robust mode
-							robust_residuals (!= 1 (size action_features))
-							hyperparameter_feature
-								(if (= 1 (size action_features))
-									(first action_features)
-									".targetless"
-								)
-							weight_feature weight_feature
-							use_case_weights use_case_weights
-							compute_null_uncertainties (false)
-							compute_all_statistics (false)
-						))
-				))
-				(if (= (first (get hyperparam_map "paramPath")) ".default")
-					;updating default hyperparam set with featuredeviations
-					(assign_to_entities (assoc !defaultHyperparameters hyperparam_map) )
-
-					;update the appropriate hyperparameter set
-					(assign_to_entities (assoc !hyperparameterMetadataMap (set !hyperparameterMetadataMap (get hyperparam_map "paramPath") hyperparam_map)) )
-				)
-				(accum_to_entities (assoc !revision 1))
-			)
-		)
-
 		(declare (assoc cached_residuals_map (get hyperparam_map "featureResiduals") ))
 
 		;if for some reason expected values haven't been cached, do that here


### PR DESCRIPTION
These changes move the cache updates for residuals, expected values, and marginal stats to the beginning of all react labels so that the entity writes are not attempted between multiple threads.