### PR TITLE
21559: Removes `allFeatureResidualsCached` flag removed from Trainee hyperparameter maps

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -625,7 +625,6 @@
 					"dt" -1
 					"featureWeights" (null)
 					"featureDeviations" (null)
-					"allFeatureResidualsCached" (false)
 					"paramPath" (list ".default")
 				)
 

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -64,12 +64,6 @@
 			))
 
 			(accum (assoc iteration 1))
-
-			(if (= 1 iteration)
-				(if (= (sort !trainedFeatures) (sort features))
-					(accum (assoc baseline_hyperparameter_map (assoc "allFeatureResidualsCached" (true))))
-				)
-			)
 		)
 	)
 
@@ -384,10 +378,6 @@
 					))
 			))
 			(accum (assoc iteration 1))
-		)
-
-		(if (= (sort !trainedFeatures) (sort features))
-			(accum (assoc analyzed_hp_map (assoc "allFeatureResidualsCached" (true))))
 		)
 	)
 

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -119,7 +119,7 @@
 
 		;output a warning when trainee has not been analyzed (using default hyperparameters w/o residuals)
 		(if (and
-				(= (false) (get hyperparam_map "allFeatureResidualsCached"))
+				(!= (zip !trainedFeatures) (zip (indices (get hyperparam_map "featureResiduals"))) )
 				(= (list ".default") (get hyperparam_map "paramPath"))
 			)
 			(accum (assoc

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -89,11 +89,6 @@
 			(assign (assoc hyperparam_map (set hyperparam_map "featureDeviations" (assoc))))
 		)
 
-		;if calculating and storing or all features, set the allFeatureResidualsCached flag to true
-		(if (= (sort !trainedFeatures) (sort features))
-			(accum (assoc hyperparam_map (assoc "allFeatureResidualsCached" (true))))
-		)
-
 		(declare (assoc
 			output_map
 				(call !CalculateFeatureResiduals (assoc
@@ -114,14 +109,6 @@
 		))
 
 		(assign (assoc hyperparam_map (get output_map "hyperparam_map") ))
-
-		;reset the flag if there are no residuals
-		(if (and
-				(= (sort !trainedFeatures) (sort features))
-				(= 0 (size (get output_map "residual_map")))
-			)
-			(accum (assoc hyperparam_map (assoc "allFeatureResidualsCached" (false))))
-		)
 
 		;update hyperparam_map with null uncertainties if present
 		(if (size (get output_map "nullUncertainties"))

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -426,7 +426,6 @@
 						)
 
 						(append (current_value) (assoc
-							"allFeatureResidualsCached" (false)
 							"featureWeights" feature_weights_map
 							"featureDeviations" feature_deviations_map
 						))
@@ -782,7 +781,6 @@
 					"dt" -1
 					"featureWeights" (null)
 					"featureDeviations" (null)
-					"allFeatureResidualsCached" (false)
 				)
 		))
 		(accum_to_entities (assoc !revision 1))

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -83,7 +83,6 @@
 				"dt" -1
 				"k" 8
 				"featureDeviations" (null)
-				"allFeatureResidualsCached" (false)
 			)
 
 	))
@@ -192,11 +191,6 @@
 	(call assert_true (assoc
 		obs
 			(and
-				(= (false) (get result (list "weight" "height.length.size.sweet.tart.width." "robust" ".none" "allFeatureResidualsCached")) )
-				(= (false) (get result (list "width" "fruit.height.length.size.sweet.tart.weight." "full" ".none" "allFeatureResidualsCached")) )
-				(= (false) (get result (list ".targetless" "fruit.height.length.size.sweet.tart.weight.width." "robust" ".none" "allFeatureResidualsCached")) )
-				(= (false) (get result (list "fruit" "height.length.size.sweet.tart.weight.width." "full" ".none" "allFeatureResidualsCached")) )
-				(= (false) (get result (list "height" "fruit.length.size.sweet.tart.weight.width." "full" ".none" "allFeatureResidualsCached")) )
 				; TEST is in the weights map
 				(= 1 (get result (list ".targetless" "fruit.height.length.size.sweet.tart.weight.width." "robust" ".none" "featureWeights" "TEST")) )
 			)

--- a/unit_tests/ut_h_distance_contributions.amlg
+++ b/unit_tests/ut_h_distance_contributions.amlg
@@ -27,7 +27,6 @@
 	(call_entity "howso" "set_params" (assoc
 		default_hyperparameter_map
 			(assoc
-				allFeatureResidualsCached (true)
 				dt -1
 				k 5
 				p 1
@@ -106,7 +105,6 @@
 	(call_entity "howso" "set_params" (assoc
 		default_hyperparameter_map
 			(assoc
-				allFeatureResidualsCached (true)
 				dt -1
 				k 2
 				p 1

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -449,7 +449,6 @@
 											".date_start" 2.063250907075116
 										)
 									"dt" -1
-									"allFeatureResidualsCached" (true)
 									"gridSearchError" 95624160.73285918
 									"paramPath" (list ".targetless" ".date_delta_1..date_lag_1..f1_lag_1..f1_rate_1..f2_lag_1..f2_rate_1..f2_rate_2..f3_lag_1..f3_rate_1..series_progress..series_progress_delta.ID.date.f1.f2.f3." "robust" ".none")
 								)


### PR DESCRIPTION
Removing the `allFeatureResidualsCached` flag from hyperparameter maps within the Trainee. 

Keeping it in the type definition though in case any users are trying to bring older hyperparameters into their new Trainees.