### PR TITLE
21575: Fixes computed null uncertainties for time series with respect to their referenced lags and the series index

### DIFF
--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -342,7 +342,24 @@
 								(keep (remove !featureNullRatiosMap (indices !inactiveFeaturesMap)) features)
 							)
 						))
+					;store an assoc of lag/rate/delta feature -> lag/order amount for time series flows
+					ts_feature_lag_amount_map
+						(if !tsTimeFeature
+							(map
+								(lambda (or
+									;store value of 'max_row_lag' for lag features and 'ts_order' for delta or rate features
+									(get (current_value) "max_row_lag")
+									(get (current_value) "ts_order")
+								))
+								;only lag, delta and rate features have a ts_type defined
+								(filter
+									(lambda (get (current_value) "ts_type") )
+									!featureAttributes
+								)
+							)
+						)
 				)
+
 				;compute null deviations and update hyperparam_map with them
 				(if (size features_with_nulls)
 					(assign (assoc
@@ -366,6 +383,16 @@
 												(contained_entities (append
 													(query_exists (current_index))
 													(query_equals (current_index) (null))
+
+													;time series derived features only consider cases outside the null triangle at the start of a series
+													;e.g., a lag of 2 feature, will only consider nulls from cases with index >= 2
+													(if (and !tsTimeFeature (contains_index ts_feature_lag_amount_map (current_index)))
+														(query_greater_or_equal_to ".series_index" (get ts_feature_lag_amount_map (current_index)) )
+
+														;else don't append anything
+														[]
+													)
+
 													(query_sample 200)
 												))
 											)


### PR DESCRIPTION
When computing null uncertainties, ignore cases with nulls at the start of each time series where the series index is less than the referenced lag