### PR TITLE
21567: Updates !ValidateParameters to use new (opcode_stack) parameters for decreased memory allocation

### DIFF
--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -369,7 +369,7 @@
 	(declare
 		(assoc
 			;this automatically determines the label/method that this method is being called within
-			label_name (first (get_labels (get (opcode_stack) -8)))
+			label_name (first (get_labels (opcode_stack 6 (true))))
 			;the args passed to the method above
 			given_parameters (args 1)
 		)

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
   "dependencies": {
-    "amalgam": "54.4.0"
+    "amalgam": "54.5.0"
   }
 }


### PR DESCRIPTION
This will require Amalgam version: 54.5.0