### PR TITLE
21589: Fixes an issue where the wrong section of a label's comments are parsed for flags

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -776,7 +776,7 @@
 						(lambda
 							(let
 								(assoc
-									label_flags_map (parse (substr (current_value 1) "\\{.+\\}"))
+									label_flags_map (parse (last (substr (current_value 1) "\\{.+\\}" "all")))
 								)
 
 								(assoc


### PR DESCRIPTION
In instances where a comment on a public label contains a pair of { }'s beside the annotation flags used for get_api output, those would be parsed instead.

Fixed by adding a parameter to the (substr) that requests all pattern matches and instead parses the last one as the annotation flags are placed as the last line of comments before the label.