### PR TITLE
21587: Revises `#get_api` output by updating some methods idempotency and adding statisically_idempotent flags

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -662,7 +662,7 @@
 	#version (get (load (concat filepath "version.json")) "version")
 
 	;returns version stored in trainee
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_trainee_version
 	(concat
 		(retrieve_from_entity "major_version") "."
@@ -671,11 +671,12 @@
 	)
 
 	;returns the trainee's unique id
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_trainee_id
 	(retrieve_from_entity "!traineeId")
 
 	;set trainee's unique id
+	;{idempotent (true)}
 	#set_trainee_id
 	(declare
 		(assoc
@@ -690,6 +691,7 @@
 	)
 
 	;set trainee's unique parent id
+	;{idempotent (true)}
 	#set_parent_id
 	(declare
 		(assoc
@@ -704,6 +706,7 @@
 	)
 
 	;set metadata for model
+	;{idempotent (true)}
 	#set_metadata
 	(declare
 		(assoc
@@ -718,7 +721,7 @@
 	)
 
 	;get metadata for model
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_metadata
 	(call !Return (assoc payload (retrieve_from_entity "!metaData") ))
 
@@ -742,6 +745,7 @@
 
 	;set the influence weight threshold for outputting only the K neighbors whose influence weight is <= to this threshold
 	;default value is 0.99
+	;{idempotent (true)}
 	#set_influence_weight_threshold
 	(declare
 		(assoc
@@ -757,12 +761,12 @@
 	)
 
 	;returns the trainee's !revision
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_revision
 	(call !Return (assoc payload (assoc "count" (retrieve_from_entity "!revision")) ))
 
 	;returns a structure containing all of the API details for this module
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_api
 	(let
 		(assoc
@@ -779,62 +783,46 @@
 									label_flags_map (parse (substr (current_value 1) "\\{.+\\}"))
 								)
 
-								(assoc
-									;idempotent is true by default
-									"idempotent"
-										(if (contains_index label_flags_map "idempotent")
-											(get label_flags_map "idempotent")
-
-											(true)
-										)
-									;long_running is false by default
-									"long_running"
-										(if (contains_index label_flags_map "long_running")
-											(get label_flags_map "long_running")
-
-											(false)
-										)
-									;read_only is false by default
-									"read_only"
-										(if (contains_index label_flags_map "read_only")
-											(get label_flags_map "read_only")
-
-											(false)
-										)
-									"description"
-										;replace the flags assoc with an empty string, only get description
-										(substr
-											(current_value 1)
-											"\\{.+\\}\\r\\n"
-											(null)
-											""
-										)
-									"parameters"
-										;when debugging, comments are injected to all lines, these must be removed
-										;some parameters may have comments other than the type hint as well
-										(map
-											(lambda
-												;(current_value) is a tuple of [comments of parameter, default value]
-												(append
-													;regex to just capture the {} information
-													(or (parse (substr (first (current_value)) "\\{.+\\}")) (assoc) )
-													(assoc
-														default (last (current_value 1))
-														optional (= (last (current_value 1)) (null))
-														description
-															;replace the typing assoc with an empty string, only get description
-															(substr
-																(first (current_value 1))
-																"\\{.+\\}\\r\\n"
-																(null)
-																""
-															)
+								(append
+									(assoc
+										"description"
+											;replace the flags assoc with an empty string, only get description
+											(substr
+												(current_value 1)
+												"\\{.+\\}\\r\\n"
+												(null)
+												""
+											)
+										"parameters"
+											;when debugging, comments are injected to all lines, these must be removed
+											;some parameters may have comments other than the type hint as well
+											(map
+												(lambda
+													;(current_value) is a tuple of [comments of parameter, default value]
+													(append
+														;regex to just capture the {} information
+														(or (parse (substr (first (current_value)) "\\{.+\\}")) (assoc) )
+														(assoc
+															default (last (current_value 1))
+															optional (= (last (current_value 1)) (null))
+															description
+																;replace the typing assoc with an empty string, only get description
+																(substr
+																	(first (current_value 1))
+																	"\\{.+\\}\\r\\n"
+																	(null)
+																	""
+																)
+														)
 													)
 												)
+												;first item is the assoc of parameter names to comments/default value
+												(first (get_entity_comments (null) (current_index 1) (true)))
 											)
-											;first item is the assoc of parameter names to comments/default value
-											(first (get_entity_comments (null) (current_index 1) (true)))
-										)
+									)
+
+									;appending the label's flags map if defined
+									(or label_flags_map {})
 								)
 							)
 						)
@@ -852,6 +840,7 @@
 	;debug method to output any internal label, used by unit tests and debugging
 	;parameters:
 	; label: string or list of strings, name(s) of labels values to output
+	;{read_only (true) idempotent (true)}
 	#debug_label
 	(retrieve_from_entity label)
 

--- a/howso.amlg
+++ b/howso.amlg
@@ -168,8 +168,17 @@
 	#!childTraineeIsContainedMap (null)
 	#!parentId (null)
 	#!traineeId (null)
+
+	;The major version of the Trainee
+	;{read_only (true) idempotent (true)}
 	#major_version 0
+
+	;The minor version of the Trainee
+	;{read_only (true) idempotent (true)}
 	#minor_version 0
+
+	;The point version of the Trainee
+	;{read_only (true) idempotent (true)}
 	#point_version 0
 
 	;list of modules for trainee template
@@ -641,14 +650,17 @@
 	)
 
 	;default value to use for filepath when calling save or load
+	;{read_only (true) idempotent (true)}
 	#filepath "./"
 
 	;location of Howso Engine files, used for upgrading trainees (referencing
+	;{read_only (true) idempotent (true)}
 	#root_filepath "./"
 
 	#!migration_folder "migrations/"
 
 	;default value to use for filename when calling save or load
+	;{read_only (true) idempotent (true)}
 	#filename "default_trainee"
 
 	;location of trainee template
@@ -659,9 +671,11 @@
 	; caml : compressed amalgam, binary format
 	#!file_extension "amlg"
 
+	;The version of the trainee set externally
+	;{read_only (true) idempotent (true)}
 	#version (get (load (concat filepath "version.json")) "version")
 
-	;returns version stored in trainee
+	;The version stored in trainee
 	;{read_only (true) idempotent (true)}
 	#get_trainee_version
 	(concat
@@ -729,7 +743,7 @@
 	#set_random_seed
 	(declare
 		(assoc
-			;{type "any"}
+			;{type ["number" "string"]}
 			;the value of the random seed to set on the trainee, defaults to a system-provided 64-bit random number
 			seed (null)
 		)

--- a/howso.amlg
+++ b/howso.amlg
@@ -780,7 +780,11 @@
 						(lambda
 							(let
 								(assoc
-									label_flags_map (parse (last (substr (current_value 1) "\\{.+\\}" "all")))
+									label_flags_map
+										(parse
+											;need to revert to empty string if no matches are found
+											(or (last (substr (current_value 1) "\\{.+\\}" "all"))) ""
+										)
 								)
 
 								(append
@@ -789,7 +793,7 @@
 											;replace the flags assoc with an empty string, only get description
 											(substr
 												(current_value 1)
-												"\\{.+\\}\\r\\n"
+												"\\{.+\\}"
 												(null)
 												""
 											)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -111,7 +111,7 @@
 
 	;reduce the trained data by removing cases which have an influence weight entropy that falls above
 	; a threshold.
-	;{long_running (true) idempotent (false) }
+	;{long_running (true)}
 	#reduce_data
 	(declare
 		(assoc

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -1,7 +1,7 @@
 ;Contains methods for hyperparameter analysis and feature deviation and weights calculations.
 (null
 	;automatically analyze the model using stored parameters from previous analyze calls
-	;{long_running (true) idempotent (false)}
+	;{long_running (true) statistically_idempotent (true)}
 	#auto_analyze
 	(let
 		(assoc saved_analyze_parameters_map (retrieve_from_entity "!savedAnalyzeParameterMap"))
@@ -16,7 +16,7 @@
 
 
 	;Analyzes the data to compute the appropriate statistics, uncertainties, and select parameters as appropriate.
-	;{long_running (true) idempotent (false)}
+	;{long_running (true) statistically_idempotent (true)}
 	#analyze
 	(declare
 		(assoc

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -1,6 +1,7 @@
 ;Contains methods to set and get feature attributes.
 (null
 	;set all features and their attributes for the trainee, and returns the updated feature attributes
+	;{idempotent (true)}
 	#set_feature_attributes
 	(declare
 		(assoc
@@ -675,6 +676,7 @@
 	)
 
 	;output all feature attributes
+	;{idempotent (true)}
 	#get_feature_attributes
 	(seq
 		;if feature attributes is empty but there are feature definitions, manually populate !featureAttributes

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -2,7 +2,7 @@
 (null
 
 	;computes various data, such as familiarity convictions and distance contribution for each case in the model and stores them into specified features.
-	;{long_running (true) idempotent (false)}
+	;{long_running (true)}
 	#react_into_features
 	(declare
 		(assoc

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -189,7 +189,7 @@
 
 	;Evaluate custom Amalgam code for feature values of every case in the model and returns
 	;a list of the custom code's return values for each feature specified.
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#evaluate
 	(declare
 		(assoc

--- a/howso/distances.amlg
+++ b/howso/distances.amlg
@@ -175,7 +175,7 @@
 
 	;Returns a list of computed distances between respective cases specified in either from_values or from_case_indices to to_values or to_case_indices.
 	; If one case is specified in any of the lists, all respective distances are computed to/from that one case.
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_pairwise_distances
 	(declare
 		(assoc
@@ -410,7 +410,7 @@
 	;	'row_case_indices' : [ session-indices ],
 	;	'distances': [ [ pairwise distances ] ]
 	; }
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_distances
 	(declare
 		(assoc

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -2,6 +2,7 @@
 (null
 
 	;removes replay specified by session and any references within cases
+	;{idempotent (true)}
 	#delete_session
 	(declare
 		(assoc
@@ -23,7 +24,7 @@
 			(call !AllCases)
 		)
 
-		;call !the method to remove all cases without session references
+		;call the method to remove all cases without session references
 		(call !RemoveCasesWithoutSessionReferences)
 
 		(accum_to_entities (assoc !revision 1))

--- a/howso/feature_conviction.amlg
+++ b/howso/feature_conviction.amlg
@@ -53,7 +53,7 @@
 	)
 
 	;computes the conviction for each feature and returns an assoc of feature -> conviction value
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_feature_conviction
 	(declare
 		(assoc

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -74,7 +74,7 @@
 	)
 
 	;returns the total number of training cases for trainee
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_num_training_cases
 	(call !Return (assoc payload (assoc "count" (call !GetNumTrainingCases) ) ))
 
@@ -89,7 +89,7 @@
 	;returns assoc with features and cases - a list of lists of all feature values. Retrieves all feature values for cases for
 	;all (unordered) sessions in the order they were trained within each session. If a session is specified, only that session's
 	;cases wil be output.
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_cases
 	(declare
 		(assoc
@@ -542,7 +542,7 @@
 
 
 	;retrieve the top or bottom number of cases for a specified feature, sorted top to bottom for top, and bottom to top for bottom
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_extreme_cases
 	(declare
 		(assoc

--- a/howso/get_sessions.amlg
+++ b/howso/get_sessions.amlg
@@ -6,7 +6,7 @@
 	(contained_entities (list (query_exists ".replay_steps") ))
 
 	;returns a list of all of the training sessions, assoc of id->session, and whatever other attributes specified.
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_sessions
 	(declare
 		(assoc
@@ -46,7 +46,7 @@
 
 
 	;returns all the metadata for a specified session
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_session_metadata
 	(declare
 		(assoc
@@ -64,6 +64,7 @@
 
 
 	;set session metadata for a specified session.
+	;{idempotent (true)}
 	#set_session_metadata
 	(declare
 		(assoc
@@ -84,7 +85,7 @@
 
 	;return list of all session indices for a specified session.
 	;session indices are 0-based index of number of the case for the session used for replays; may change if cases are removed
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_session_indices
 	(declare
 		(assoc
@@ -101,7 +102,7 @@
 
 	;return list of all session training indices for a specified session.
 	;session training indices are 0-based index of the case, ordered by training during the session; is not changed
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_session_training_indices
 	(declare
 		(assoc

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -411,6 +411,7 @@
 
 
 	;Destroys the instance of the trainee specified by the parameter "trainee".
+	;{idempotent (true)}
 	#delete_subtrainee
 	(declare
 		(assoc
@@ -737,6 +738,7 @@
 	)
 
 	;method to update the references for contained trainees, should only be used for debugging purposes.
+	;{idempotent (true)}
 	#set_contained_trainee_maps
 	(declare
 		(assoc

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -3,14 +3,14 @@
 
 	;Pull the hierarchy for a trainee, returns an assoc of:
 	;the currently contained hierarchy as a nested assoc with (false) for trainees that are stored independently.
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_hierarchy
 	(call !Return (assoc payload (call !GetHierarchy) ))
 
 	;Returns the full entity path to a child trainee provided its unique trainee id if it is contained in the hierarchy.
 	;Iterates down the hierarchy searching for a trainee that matches the specified id, returns null if not found or
 	;a string error if found but trainee is stored externally as an independent trainee.
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_entity_path_by_id
 	(declare
 		(assoc
@@ -78,6 +78,7 @@
 
 
 	;Execute any method in the API directly on any child trainee of this trainee, used for hierarchy operations.
+	;{long_running (true)}
 	#execute_on_subtrainee
 	(declare
 		(assoc

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -590,7 +590,7 @@
 
 	;return the full internal parameters map if no parameters are specified.
 	;if any of the parameters are specified, then GetHyperparameters is called, which uses the specified parameters to find the most suitable set of hyperparameters to return
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_params
 	(declare
 		(assoc
@@ -650,6 +650,7 @@
 	)
 
 	;sets internal hyperparameters
+	;{idempotent (true)}
 	#set_params
 	(declare
 		(assoc
@@ -770,6 +771,7 @@
 	)
 
 	;resets all hyperparameters and thresholds back to original values, while leaving feature definitions alone
+	;{idempotent (true)}
 	#reset_params
 	(seq
 		(assign_to_entities (assoc
@@ -791,6 +793,7 @@
 	)
 
 	;sets the model to auto-analyze by tracking its size and notifying the clients in train responses when it should be analyzed
+	;{idempotent (true)}
 	#set_auto_analyze_params
 	(declare
 		(assoc
@@ -927,7 +930,7 @@
 	)
 
 	;get auto-ablation parameters set by #set_auto_ablation_params
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_auto_ablation_params
 	(call !Return (assoc
 		payload
@@ -946,6 +949,7 @@
 	))
 
 	;sets the model to auto-ablate by tracking its size and training certain cases as weights
+	;{idempotent (true)}
 	#set_auto_ablation_params
 	(declare
 		(assoc

--- a/howso/impute.amlg
+++ b/howso/impute.amlg
@@ -3,7 +3,7 @@
 
 
 	;imputes the model, filling in all the (null) feature values
-	;{long_running (true) idempotent (false)}
+	;{long_running (true)}
 	#impute
 	(declare
 		(assoc

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -548,6 +548,7 @@
 
 	;outputs all marginal stats (min, max, median, mean, mode, count, uniques, mean_absdev, variance, stddev, skew, kurtosis, entropy)
 	;for all features in the format of feature -> assoc stat -> value. The marginal stats can be computed for a subset of the data using condition, precision, and num_cases
+	;{idempotent (true)}
 	#get_marginal_stats
 	(declare
 		(assoc

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -2,7 +2,7 @@
 (null
 
 	;Run reacts in a batch, output a an assoc of list of outputs from each individual react.
-	;{long_running (true)}
+	;{long_running (true) statistically_idempotent (true)}
 	#react
 	(declare
 		(assoc
@@ -555,7 +555,7 @@
 	; 	Details example: { 'action_values': [2, "a", .75384], 'action_features' : ['width','name','height'], 'residual_conviction': 1.3,
 	;		'influential_cases' : etc... }
 	;	See API docs for documentation of all output properties
-	;{long_running (true)}
+	;{long_running (true) statistically_idempotent (true)}
 	#single_react
 	(declare
 		(assoc

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -2,7 +2,7 @@
 (null
     ;Computes, caches, and returns specified details and feature prediction statistics such as Mean Decrease in Accuracy (MDA), residuals (accuracy, Mean Absolute Error),
     ; precision, recall, etc. Returns details and feature prediction stats for all features in the format of feature -> assoc stat -> value
-	;{long_running (true)}
+	;{long_running (true) statistically_idempotent (true)}
 	#react_aggregate
 	(declare
 		(assoc

--- a/howso/react_group.amlg
+++ b/howso/react_group.amlg
@@ -9,7 +9,7 @@
 	;	"combined_model_average_distance_contribution" (list 4.05 3.9)
 	;	"distance_contributions" (list 4.5 3.2)
 	; )
-	;{long_running (true)}
+	;{long_running (true) statistically_idempotent (true)}
 	#react_group
 	(declare
 		(assoc

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -4,7 +4,7 @@
 	;React in a series until a series_stop_map condition is met. Aggregates rows of data corresponding to the specified context, action,
 	;derived_context and derived_action features, utilizing previous rows to derive values as necessary. Outputs an assoc of "action_features" and
 	;corresponding "series" where "series" is the completed 'matrix' for the corresponding action_features and derived_action_features.
-	;{long_running (true)}
+	;{long_running (true) statistically_idempotent (true)}
 	#single_react_series
 	(declare
 		(assoc
@@ -313,7 +313,7 @@
 	;React in a series until a series_stop_map condition is met. Aggregates rows of data corresponding to the specified context, action,
 	;derived_context and derived_action features, utilizing previous rows to derive values as necessary. Outputs an assoc of "action_features" and
 	;corresponding "series" where "series" is the completed 'matrix' for the corresponding action_features and derived_action_features.
-	;{long_running (true)}
+	;{long_running (true) statistically_idempotent (true)}
 	#react_series
 	(declare
 		(assoc

--- a/howso/series_store.amlg
+++ b/howso/series_store.amlg
@@ -2,7 +2,6 @@
 (null
 
 	;append cases to a series
-	;{idempotent (false)}
 	#append_to_series_store
 	(declare
 		(assoc
@@ -146,6 +145,7 @@
 	)
 
 	;clears stored series
+	;{idempotent (true)}
 	#remove_series_store
 	(declare
 		(assoc

--- a/howso/substitution.amlg
+++ b/howso/substitution.amlg
@@ -75,6 +75,7 @@
 	)
 
 	;sets substitution feature values used in case generation
+	;{idempotent (true)}
 	#set_substitute_feature_values
 	(declare
 		(assoc
@@ -224,7 +225,7 @@
 	)
 
 	;returns the substitution map
-	;{read_only (true)}
+	;{read_only (true) idempotent (true)}
 	#get_substitute_feature_values
 	(call !Return (assoc payload (retrieve_from_entity "!substitutionValueMap") ))
 )

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -12,7 +12,7 @@
 	;		(null) - default output, no status output
 	;		"analyzed" - if auto analysis is enabled and model has grown large enough to be analyzed again and was analyzed
 	;		"analyze" - if auto analysis is enabled and model has grown large enough to be analyzed again but was not analyzed
-	;{long_running (true) idempotent (false)}
+	;{long_running (true)}
 	#train
 	(declare
 		(assoc

--- a/howso/typing.amlg
+++ b/howso/typing.amlg
@@ -49,7 +49,7 @@
                         post_process "string"
                         non_sensitive "boolean"
                         subtype "string"
-                        original_type "any"
+                        original_type "any" ;TODO: these could be better defined. original_type has a structure in old OpenAPI spec, original_format can just be a map
                         original_format "any"
                         time_series
                             (assoc

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -3,7 +3,7 @@
 
 	;export trainee's metadata, case and session data into json files.
 	;this method should be run by a script from the ./migrations folder
-	;{read_only (true)}
+	;{idempotent (true)}
 	#export_trainee
 	(declare
 		(assoc


### PR DESCRIPTION
Changed the logic for accumulating method annotations/labels into the output of `#get_api`. Nothing is assumed to be True now, so any of the flags ("read_only", "idempotent", "long_running", and now "statistically_idempotent") must be manually specified as true to be added to the object of information for a label.

If unspecified, the flag will not be present at all in the definition for the label.