### PR TITLE
21659: Updates typing validation code and logic to support required properties, MAJOR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,14 +76,14 @@ Return types of methods should be specified by comments on the assoc with the pa
 | Key                 | Values |
 | ------------------- | ------ |
 | type                | If single type, the type as a string. If multiple types, a list of types as strings. The available types are "list", "assoc", "number", "string", "boolean", "any".
-| values              | Only used when `type` is "list" or "assoc". Values should be similar to the values of `type` and should define the possible types of the values. This value can be an assoc if the type is a data structure/
+| values              | Only used when `type` is "list". Values should be similar to the values of `type` and should define the possible types of the values. This value can be an assoc if the type is a data structure/
 | min_size            | Only applicable when `type` is "list" or "assoc". Value should be an integer.
 | max_size            | Only applicable when `type` is "list" or "assoc". Value should be an integer.
 | enum                | Only applicable when `type` is "string". A list of possible values for the string
 | min                 | Only applicable when `type` is "number". The minimum value.
 | max                 | Only applicable when `type` is "number". The maximum value.
 | indices             | Only applicable when `type` is "assoc". Value is an assoc of named indices to their expected types.
-| additional_indices  | Only applicable when `type` is "assoc". Value should be  similar to `type` values but is specified for indices that were not named in `indices`. This should only be used if `indices` is used as well.
+| additional_indices  | Only applicable when `type` is "assoc". Value should be  similar to `type` values but is defined for all unspecified indices.
 | optional            | The value of this should be a boolean, and this should only be specified for sub-types. This will be automatically added to the top level of type hints based on the default value of the parameter.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,6 @@ Return types of methods should be specified by comments on the assoc with the pa
 | max                 | Only applicable when `type` is "number". The maximum value.
 | indices             | Only applicable when `type` is "assoc". Value is an assoc of named indices to their expected types.
 | additional_indices  | Only applicable when `type` is "assoc". Value should be  similar to `type` values but is defined for all unspecified indices.
-| optional            | The value of this should be a boolean, and this should only be specified for sub-types. This will be automatically added to the top level of type hints based on the default value of the parameter.
 | required            | The value of this should be a boolean. If used under the type within an 'indices' (assoc), then that index must be present in the parent (assoc). If used in a top-level type, that parameter must be specified as a non-null value.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Return types of methods should be specified by comments on the assoc with the pa
 | Key                 | Values |
 | ------------------- | ------ |
 | type                | If single type, the type as a string. If multiple types, a list of types as strings. The available types are "list", "assoc", "number", "string", "boolean", "any".
-| values              | Only used when `type` is "list". Values should be similar to the values of `type` and should define the possible types of the values. This value can be an assoc if the type is a data structure/
+| values              | Only used when `type` is "list". Values should be similar to the values of `type` and should define the possible types of the values. This value can be an assoc if the type is a data structure.
 | min_size            | Only applicable when `type` is "list" or "assoc". Value should be an integer.
 | max_size            | Only applicable when `type` is "list" or "assoc". Value should be an integer.
 | enum                | Only applicable when `type` is "string". A list of possible values for the string
@@ -85,6 +85,7 @@ Return types of methods should be specified by comments on the assoc with the pa
 | indices             | Only applicable when `type` is "assoc". Value is an assoc of named indices to their expected types.
 | additional_indices  | Only applicable when `type` is "assoc". Value should be  similar to `type` values but is defined for all unspecified indices.
 | optional            | The value of this should be a boolean, and this should only be specified for sub-types. This will be automatically added to the top level of type hints based on the default value of the parameter.
+| required            | The value of this should be a boolean. If used under the type within an 'indices' (assoc), then that index must be present in the parent (assoc). If used in a top-level type, that parameter must be specified as a non-null value.
 
 
 ### Typing Examples

--- a/howso.amlg
+++ b/howso.amlg
@@ -726,7 +726,7 @@
 	#set_random_seed
 	(declare
 		(assoc
-			;{type "any"}
+			;{type ["string" "number"]}
 			;the value of the random seed to set on the trainee, defaults to a system-provided 64-bit random number
 			seed (null)
 		)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -4,7 +4,7 @@
 	#set_feature_attributes
 	(declare
 		(assoc
-			;{type "assoc" values {ref "FeatureAttributes"}}
+			;{type "assoc" additional_indices {ref "FeatureAttributes"}}
 			;assoc of feature -> attributes, attributes defined below:
 			;
 			;	'type': string, one of 'continuous', 'ordinal' or 'nominal'. Default is 'continuous'.

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -193,7 +193,7 @@
 	#evaluate
 	(declare
 		(assoc
-			;{type "assoc" values "string"}
+			;{type "assoc" additional_indices "string"}
 			;a assoc of feature names to custom code
 			features_to_code_map (null)
 			;{type "string"}

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -739,13 +739,13 @@
 	#set_contained_trainee_maps
 	(declare
 		(assoc
-			;{type "assoc" values "string"}
+			;{type "assoc" additional_indices "string"}
 			;map of contained trainee name to its unique id
 			contained_trainee_name_to_id_map (null)
-			;{type "assoc" values "string"}
+			;{type "assoc" additional_indices "string"}
 			;map of contained trainee unique id to its name
 			contained_trainee_id_to_name_map (null)
-			;{type "assoc" values "boolean"}
+			;{type "assoc" additional_indices "boolean"}
 			;map of trainee name to boolean if it's contained internally
 			child_trainee_is_contained_map (null)
 		)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -967,11 +967,11 @@
 			;list of features. for each of the features specified, will ablate a case if the prediction
 			;	matches exactly.
 			exact_prediction_features (null)
-			;{type "assoc" values {type "list" min_size 2 max_size 2}}
+			;{type "assoc" additional_indices {type "list" min_size 2 max_size 2}}
 			;assoc of feature -> [MIN, MAX]. for each of the features specified, will
 			;	ablate a case if the prediction >= (case value - MIN) and the prediction <= (case value + MAX)
 			tolerance_prediction_threshold_map (null)
-			;{type "assoc" values "number"}
+			;{type "assoc" additional_indices "number"}
 			;assoc of feature -> PERCENT. for each of the features specified, will
 			;	ablate a case if abs(prediction - case value) / prediction <= PERCENT
 			relative_prediction_threshold_map (null)

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -329,7 +329,6 @@
 										typing_map
 										(assoc
 											default default_value
-											optional (= default_value (null))
 										)
 									)
 								)

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -513,34 +513,7 @@
 										(= exp_type "assoc")
 										(and
 											(~ (assoc) given_value)
-											(if (and (contains_index specification "values") (size given_value))
-												(apply "and"
-													(map
-														(lambda
-															(call !SingleTypeCheck (append
-																(assoc given_value (current_value 1))
-																(if (~ (assoc) (get specification "values"))
-																	(assoc
-																		specification (get specification "values")
-																		exp_type (get specification (list "values" "type"))
-																	)
-
-																	;otherwise, "values" should just be a string
-																	(assoc
-																		specification (assoc)
-																		exp_type (get specification "values")
-																	)
-																)
-															))
-														)
-														(values given_value)
-													)
-												)
-
-												;else
-												(true)
-											)
-											(if (and (contains_index specification "indices") (size given_value))
+											(if (contains_index specification "indices")
 												(apply "and"
 													(values (map
 														(lambda
@@ -560,6 +533,13 @@
 																		)
 																	)
 																))
+
+																;if the index is not present but it is required, then return false
+																(and
+																	(~ (assoc) (current_value))
+																	(get (current_value) "required")
+																)
+																(false)
 
 																(true)
 															)
@@ -636,7 +616,7 @@
 		))
 
 		(declare (assoc
-			invalid_params (filter (lambda (not (get parameter_validity_map (current_value)))) (indices parameter_validity_map))
+			invalid_params (indices (filter (lambda (not (current_value))) parameter_validity_map))
 		))
 
 		(if (size invalid_params)

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -259,7 +259,7 @@
 			;{type "boolean"}
 			;flag, if false uses model feature residuals, if true recalculates regional model residuals. Only used when desired_conviction is specified
 			use_regional_model_residuals (true)
-			;{ref "FeatureBoundsMap"}
+			;{type "assoc" additional_indices {ref "FeatureBoundsMap"}}
 			;assoc of :
 			;	{ feature : { "min": a, "max": b, "allow_null": false/true } }
 			;	to ensure that specified features' generated values stay in bounds
@@ -641,7 +641,7 @@
 			;{type "boolean"}
 			;flag, if false uses model feature residuals, if true recalculates regional model residuals. Only used when desired_conviction is specified
 			use_regional_model_residuals (true)
-			;{type "assoc" values {ref "FeatureBoundsMap"}}
+			;{type "assoc" additional_indices {ref "FeatureBoundsMap"}}
 			;assoc of :
 			;	{ feature : { "min": a, "max": b, "allow_null": false/true } }
 			;	to ensure that specified features' generated values stay in bounds

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -96,7 +96,7 @@
 			;{type "boolean"}
 			;flag, if false uses model feature residuals, if true recalculates regional model residuals.
 			use_regional_model_residuals (true)
-			;{type "assoc" values {type "assoc" indices {min "number" max "number" allow_null "boolean"} } }
+			;{type "assoc" additional_indices {type "assoc" indices {min "number" max "number" allow_null "boolean"} } }
 			;assoc of :
 			;	{ feature : { "min": a, "max": b, "allow_null": false/true } }
 			;	to ensure that specified features' generated values stay in bounds
@@ -440,7 +440,7 @@
 			;{type "boolean"}
 			;flag, if false uses model feature residuals, if true recalculates regional model residuals.
 			use_regional_model_residuals (true)
-			;{type "assoc" values {type "assoc" indices {min ["number" "string"] max ["number" "string"] allow_null "boolean"} } }
+			;{type "assoc" additional_indices {type "assoc" indices {min ["number" "string"] max ["number" "string"] allow_null "boolean"} } }
 			;assoc of :
 			;	{ feature : { "min": a, "max": b, "allow_null": false/true } }
 			;	to ensure that specified features' generated values stay in bounds

--- a/howso/typing.amlg
+++ b/howso/typing.amlg
@@ -391,7 +391,7 @@
         FeatureBoundsMap
             (assoc
                 type "assoc"
-                additional_indices
+                indices
                     (assoc
                         min
                             (assoc

--- a/howso/typing.amlg
+++ b/howso/typing.amlg
@@ -10,7 +10,7 @@
                 additional_indices "any"
                 indices
                     (assoc
-                        type (assoc type "string" enum ["continuous" "ordinal" "nominal"])
+                        type (assoc type "string" enum ["continuous" "ordinal" "nominal"] required (true))
                         bounds
                             (assoc
                                 type "assoc"
@@ -56,7 +56,7 @@
                                 type "assoc"
                                 indices
                                     (assoc
-                                        type {type "string" enum ["rate" "delta"]}
+                                        type {type "string" enum ["rate" "delta"] required (true)}
                                         time_feature "boolean"
                                         order "number"
                                         derived_orders "number"
@@ -92,7 +92,7 @@
         FeatureBoundsMap
             (assoc
                 type "assoc"
-                values
+                additional_indices
                     (assoc
                         type "assoc"
                         indices
@@ -115,33 +115,33 @@
                         derivedAutoAnalyzed (assoc type "boolean" optional (true))
                         featureDeviations (assoc type "assoc"  optional (true))
                         featureDomainAttributes (assoc type "assoc" optional (true))
-                        featureWeights (assoc type "assoc" values "number" optional (true))
+                        featureWeights (assoc type "assoc" additional_indices "number" optional (true))
                         paramPath (assoc type "list" values "string")
                         useDeviations "boolean"
                         allFeatureResidualsCached "boolean"
                         featureOrdinalDeviations (assoc type "assoc" optional (true))
                         gridSearchError "number"
-                        nullUncertainties (assoc type "assoc" values "list" optional (true))
-                        featureResiduals (assoc type "assoc" values "number" optional (true))
+                        nullUncertainties (assoc type "assoc" additional_indices "list" optional (true))
+                        featureResiduals (assoc type "assoc" additional_indices "number" optional (true))
                     )
             )
         FullHyperparameterMap
             (assoc
                 ;action_feature
                 type "assoc"
-                values
+                additional_indices
                     (assoc
                         ;context_features key
                         type "assoc"
-                        values
+                        additional_indices
                             (assoc
                                 ;robust/full
                                 type "assoc"
-                                values
+                                additional_indices
                                     (assoc
                                         ;weight feature
                                         type "assoc"
-                                        values
+                                        additional_indices
                                             (assoc ref "HyperparameterMap")
                                     )
                             )

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -60,7 +60,7 @@
 					(assoc
 						"type" "nominal"
 						"id_feature" (true)
-						"time_series"
+						"time_series" (assoc "type" "delta")
 					)
 
 				"time"
@@ -403,6 +403,7 @@
 						"id_feature" (true)
 						"time_series"
 							(assoc
+								"type" "delta"
 								"series_has_terminators" (true)
 								"stop_on_terminator" (true)
 							)
@@ -607,6 +608,7 @@
 						"id_feature" (true)
 						"time_series"
 							(assoc
+								"type" "delta"
 								"series_has_terminators" (true)
 								"stop_on_terminator" (true)
 							)


### PR DESCRIPTION
'required' is now a supported attribute of an index within a type definition of an assoc.

Additionally, `values` is no longer an appopriate typing property for (assoc)'s, 'additional_indices' should be used to declare the type of any unspecified indices. 