### PR TITLE
21701: Added supplemental type schemas to get_api

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -788,6 +788,9 @@
 					"description"
 					(get_entity_comments)
 
+					"version"
+					(call get_trainee_version)
+
 					"labels"
 					(map
 						(lambda

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -5,7 +5,7 @@
 	#set_feature_attributes
 	(declare
 		(assoc
-			;{type "assoc" additional_indices {ref "FeatureAttributes"}}
+			;{ref "FeatureAttributesIndex"}
 			;assoc of feature -> attributes, attributes defined below:
 			;
 			;	'type': string, one of 'continuous', 'ordinal' or 'nominal'. Default is 'continuous'.

--- a/howso/typing.amlg
+++ b/howso/typing.amlg
@@ -358,6 +358,12 @@
                             )
                     )
             )
+        FeatureAttributesIndex
+            (assoc
+                type "assoc"
+                additional_indices {ref "FeatureAttributes"}
+                description "A map of feature name to feature attributes."
+            )
         CaseIndices
             (assoc
                 type "list"
@@ -1140,6 +1146,45 @@
                         "Types of stats to output. When unspecified, returns all except the confusion_matrix. "
                         "If all, then returns all including the confusion_matrix."
                     )
+            )
+        EditHistoryRecord
+            (assoc
+                type "assoc"
+                indices
+                    (assoc
+                        type
+                            (assoc
+                                type "string"
+                                enum ["set" "remove" "impute" "edit"]
+                                description "The type of modification."
+                            )
+                        feature
+                            (assoc
+                                type "string"
+                                description "The feature that was modified."
+                            )
+                        value
+                            (assoc
+                                type "any"
+                                description "The new value."
+                            )
+                        previous_value
+                            (assoc
+                                type "any"
+                                description "The previous value."
+                            )
+                    )
+                description "A record of a single edit that was made to a feature of a case."
+            )
+        EditHistory
+            (assoc
+                type "assoc"
+                additional_indices
+                    (assoc
+                        type "list"
+                        values {ref "EditHistoryRecord"}
+                    )
+                description "The edit history of a given case. Keyed by the session id and in order of occurance."
             )
     )
 )

--- a/howso/typing.amlg
+++ b/howso/typing.amlg
@@ -1133,14 +1133,16 @@
                         "to be a new case (that is, a case not found in original dataset.)"
                     )
             )
+        PredictionStat
+            (assoc
+                type "string"
+                enum (get_value !supportedPredictionStats)
+                description "Types of prediction statistics."
+            )
         SelectedPredictionStats
             (assoc
                 type "list"
-                values
-                    (assoc
-                        type "string"
-                        enum (get_value !supportedPredictionStats)
-                    )
+                values {ref "PredictionStat"}
                 description
                     (concat
                         "Types of stats to output. When unspecified, returns all except the confusion_matrix. "


### PR DESCRIPTION
- Adds schema enum for PredictionStat
- Adds schema for FeatureAttributesIndex
- Adds version to get_api output
- Adds edit history schema