### PR TITLE
21821: Fixes `missing_value_accuracy` as a requestable prediction stat in `#react_aggregate`

### DIFF
--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -281,6 +281,7 @@
 			nominal_performance_map (assoc)
 
 			null_uncertainties_map (assoc)
+			null_accuracies_map (assoc)
 			;list of unique features to populate output at the end
 			unique_features_for_populating_output (null)
 
@@ -351,44 +352,44 @@
 
 				;compute null deviations and update hyperparam_map with them
 				(if (size features_with_nulls)
-					(assign (assoc
-						null_uncertainties_map
-							(call !ComputeNullUncertainties (assoc
-								features_with_nulls features_with_nulls
-								context_features context_features
-								null_cases_map
-									(map
-										(if regional_model_only
-											;if regional model only, just filter which of the case ids have nulls for each feature
-											(lambda
-												(filter
-													(lambda (= (null) (retrieve_from_entity (current_value) (current_index 1))))
-													case_ids
-												)
-											)
-
-											;otherwise sample null feature value cases from the model using queries
-											(lambda
-												(contained_entities (append
-													(query_exists (current_index))
-													(query_equals (current_index) (null))
-
-													;time series derived features only consider cases outside the null triangle at the start of a series
-													;e.g., a lag of 2 feature, will only consider nulls from cases with index >= 2
-													(if (and !tsTimeFeature (contains_index ts_feature_lag_amount_map (current_index)))
-														(query_greater_or_equal_to ".series_index" (get ts_feature_lag_amount_map (current_index)) )
-
-														;else don't append anything
-														[]
-													)
-
-													(query_sample 200)
-												))
-											)
-										)
-										(zip features_with_nulls)
+					(call !ComputeNullUncertainties (assoc
+						features_with_nulls features_with_nulls
+						context_features context_features
+						null_cases_map
+							(map
+								(if (or
+										regional_model_only
+										(< (size case_ids) 200)
 									)
-							))
+									;if regional model only or small dataset/sample, just filter which of the case ids have nulls for each feature
+									(lambda
+										(filter
+											(lambda (= (null) (retrieve_from_entity (current_value) (current_index 1))))
+											case_ids
+										)
+									)
+
+									;otherwise sample null feature value cases from the model using queries
+									(lambda
+										(contained_entities (append
+											(query_exists (current_index))
+											(query_equals (current_index) (null))
+
+											;time series derived features only consider cases outside the null triangle at the start of a series
+											;e.g., a lag of 2 feature, will only consider nulls from cases with index >= 2
+											(if (and !tsTimeFeature (contains_index ts_feature_lag_amount_map (current_index)))
+												(query_greater_or_equal_to ".series_index" (get ts_feature_lag_amount_map (current_index)) )
+
+												;else don't append anything
+												[]
+											)
+
+											(query_sample 200)
+										))
+									)
+								)
+								(zip features_with_nulls)
+							)
 					))
 				)
 			)
@@ -407,6 +408,7 @@
 			"hyperparam_map" hyperparam_map
 			"prediction_stats" prediction_stats
 			"null_uncertainty_map" null_uncertainties_map
+			"null_accuracy_map" null_accuracies_map
 		)
 	)
 

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -572,6 +572,10 @@
 								(assoc "mae" (get prediction_stats_map "residual_map"))
 								{}
 							)
+							(if (contains_value selected_prediction_stats "missing_value_accuracy")
+								(assoc "missing_value_accuracy" (get prediction_stats_map "null_accuracy_map"))
+								{}
+							)
 							(if (get details "feature_residuals_full")
 								{"feature_residuals_full" (get prediction_stats_map "residual_map")}
 								{}

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -378,7 +378,10 @@
 									case_weight_feature (if valid_weight_feature weight_feature)
 								))
 								;else just use all the case ids because the model size is <= num_samples or the model is small
-								(call !AllCases)
+								(seq
+									(declare (assoc using_full_model (true) ))
+									(call !AllCases)
+								)
 							)
 						)
 					)
@@ -386,7 +389,11 @@
 		)
 
 		;ensure features with nulls have cases that have values for computation but only if the selected cases were not conditioned
-		(if (and (not robust_residuals) (= 0 (size action_condition_filter_query)))
+		(if (and
+				(not using_full_model)
+				(not robust_residuals)
+				(= 0 (size action_condition_filter_query))
+			)
 			(let
 				(assoc not_null_feature_output_map (call !SelectNonNullCases) )
 
@@ -1102,7 +1109,8 @@
 		)
 	)
 
-	;Helper method to compute null deviations
+	;Helper method to compute null uncertainties and accuracies
+	; assigns to null_uncertainties_map and null_accuracies_map
 	#!ComputeNullUncertainties
 	(declare
 		(assoc
@@ -1115,7 +1123,6 @@
 		(declare (assoc
 			context_map (zip context_features)
 			features_list (values (append context_features features_with_nulls) (true))
-			null_prediction_map (null)
 
 			;assoc of feature -> number of cases with nulls
 			null_cases_counts_map (map (lambda (size (current_value))) null_cases_map)
@@ -1257,7 +1264,7 @@
 
 		;create a map of feature -> null prediction probability by averaging out all the correctly predicted nulls for each feature
 		(assign (assoc
-			null_prediction_map
+			null_accuracies_map
 				(zip
 					features_with_nulls
 					(map
@@ -1276,7 +1283,7 @@
 
 		;assoc of feature -> null uncertainty pair of [known-null distance, null-null distance]
 		(assign (assoc
-			null_prediction_map
+			null_uncertainties_map
 				(map
 					(lambda (let
 						(assoc
@@ -1318,10 +1325,8 @@
 							)
 						)
 					))
-					null_prediction_map
+					null_accuracies_map
 				)
 		))
-
-		null_prediction_map
 	)
 )

--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -206,6 +206,28 @@
 		obs (~ (assoc) (first (first result)))
 	))
 
+	;missing_value_accuracy test
+	(assign (assoc
+		result
+			(call_entity "howso" "react_aggregate" (assoc
+				details
+					(assoc
+						"prediction_stats" (true)
+						"selected_prediction_stats" ["missing_value_accuracy"]
+					)
+			))
+	))
+	(call keep_result_payload)
+
+	(print "Missing value accuracy is as expected: ")
+	(call assert_same (assoc
+		obs result
+		exp
+			(assoc
+				B (assoc missing_value_accuracy 0.875)
+				C (assoc missing_value_accuracy 0.75)
+			)
+	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))
 )


### PR DESCRIPTION
Somewhere along the way 'missing_value_accuracy' was lost as a requestable metric via react_aggregate. This change makes it get-able again and fixes a few quirks with the sampling of cases in small models