### PR TITLE
21891: Adds errors to `#analyze` and `#set_auto_analyze_params` when action features are specified without specified context features

### DIFF
--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -26,7 +26,7 @@
 			;{type "list" values "string"}
 			;list of action features to analyze for. applicable only to 'single_targeted' mode
 			action_features (list)
-			;{type "number"}
+			;{type "number" min 1}
 			;number of cross validation folds to do. value of 1 does hold-one-out instead of k-fold
 			k_folds 1
 			;{type "boolean"}
@@ -43,13 +43,13 @@
 			;whether to use deviations for LK metric in queries. When true forces the use
 			;	of deviations, when false will not use deviations. If unspecified, the better performing option will be selected.
 			use_deviations (null)
-			;{type "number"}
+			;{type "number" min 2}
 			;number of cases to use to approximate residuals
 			num_samples (null)
-			;{type "number"}
+			;{type "number" min 2}
 			;number of cases to sample during analysis. only applies for k_folds = 1
 			num_analysis_samples (null)
-			;{type "number"}
+			;{type "number" min 2}
 			;number of samples to use for analysis. the rest will be randomly held-out and not included in calculations
 			analysis_sub_model_size (null)
 			;{type "list" values "number"}
@@ -58,7 +58,7 @@
 			;{type "list" values "number"}
 			;list of values for p (the parameter of the Lebesgue space) to grid search during analysis
 			p_values (null)
-			;{type "list" values "number"}
+			;{type "list" values ["number" "string"]}
 			;list of values for dt (the distance transform) to grid search during analysis
 			dt_values (null)
 			;{type "string" enum ["single_targeted" "omni_targeted" "targetless"]}
@@ -82,6 +82,17 @@
 
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
+
+		(if (and
+				(size action_features)
+				(= (size context_features) 0)
+			)
+			(conclude
+				(call !Return (assoc
+					errors ["Context features must be specified when action features are specified."]
+				))
+			)
+		)
 
 		;analyze uses its own explicit warnings since it should not output warnings from all the
 		;react calls made during the analyze flow

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -89,7 +89,7 @@
 			)
 			(conclude
 				(call !Return (assoc
-					errors ["Context features must be specified when action features are specified."]
+					errors ["`context_features` must be specified when `action_features` is specified."]
 				))
 			)
 		)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -882,7 +882,7 @@
 			)
 			(conclude
 				(call !Return (assoc
-					errors ["Context features must be specified when action features are specified."]
+					errors ["`context_features` must be specified when `action_features` is specified."]
 				))
 			)
 		)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -812,7 +812,7 @@
 			;{type "number"}
 			;stores the threshold for the number of cases at which the model should be re-analyzed. default of 100.
 			analyze_threshold 100
-			;{type "number"}
+			;{type "number" exclusive_min 1.0}
 			;the factor by which to increase the analyze threshold everytime the model grows to the current threshold size
 			;	default of two orders of magnitude using the universal scaling factor e
 			analyze_growth_factor 7.389056
@@ -821,7 +821,7 @@
 			context_features (null)
 			;{type "list" values "string"}
 			action_features (null)
-			;{type "number"}
+			;{type "number" min 1}
 			;number of cross validation folds to do. value of 1 does hold-one-out instead of k-fold
 			k_folds 1
 			;{type "boolean"}
@@ -838,13 +838,13 @@
 			;whether to use deviations for LK metric in queries. When true forces the use
 			;	of deviations, when false will not use deviations. If unspecified, the better performing option will be selected.
 			use_deviations (null)
-			;{type "number"}
+			;{type "number" min 2}
 			;number of cases to use to approximate residuals
 			num_samples (null)
-			;{type "number"}
+			;{type "number" min 2}
 			;number of cases to sample during analysis. only applies for k_folds = 1
 			num_analysis_samples (null)
-			;{type "number"}
+			;{type "number" min 2}
 			;number of samples to use for analysis. the rest will be randomly held-out and not included in calculations
 			analysis_sub_model_size (null)
 			;{type "list" values "number"}
@@ -853,7 +853,7 @@
 			;{type "list" values "number"}
 			;list of values for p (the parameter of the Lebesgue space) to grid search during analysis
 			p_values (null)
-			;{type "list" values "number"}
+			;{type "list" values ["number" "string"]}
 			;list of values for dt (the distance transform) to grid search during analysis
 			dt_values (null)
 			;{type "string" enum ["single_targeted" "omni_targeted" "targetless"]}
@@ -876,9 +876,15 @@
 		)
 		(call !ValidateParameters)
 
-		;growth factor must be more than 1
-		(if (<= analyze_growth_factor 1)
-			(assign (assoc analyze_growth_factor 2))
+		(if (and
+				(size action_features)
+				(= (size context_features) 0)
+			)
+			(conclude
+				(call !Return (assoc
+					errors ["Context features must be specified when action features are specified."]
+				))
+			)
 		)
 
 		(declare (assoc num_cases (call !GetNumTrainingCases) ))


### PR DESCRIPTION
Also takes the opportunities to do some modest type improvements for other params on these labels.