### PR TITLE
21928: Updates applicable labels to automatically use populated case weights

### DIFF
--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -105,6 +105,14 @@
 		;react calls made during the analyze flow
 		(declare (assoc analyze_warnings (assoc) ))
 
+		(if (and
+				(= (null) use_case_weights)
+				!hasPopulatedCaseWeight
+				(= weight_feature ".case_weight")
+			)
+			(assign (assoc use_case_weights (true) ))
+		)
+
 		(if use_case_weights
 			;CreateCaseWeights will find all cases missing weight_feature, then initialize
 			;weight_feature with a value of 1.0 for each

--- a/howso/feature_conviction.amlg
+++ b/howso/feature_conviction.amlg
@@ -109,7 +109,7 @@
 				(call !GetHyperparameters (assoc
 					feature (null)
 					context_features features
-					weight_feature ".none"
+					weight_feature weight_feature
 				))
 			valid_weight_feature (false)
 		))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -223,7 +223,7 @@
 			(assign (assoc sample_model_fraction (null)))
 		)
 
-		;if not using case weights, change weight_feature to '.none'
+		;update case weight related parameters based on use_case_weights
 		(if (= (false) use_case_weights)
 			(assign (assoc
 				weight_feature ".none"

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -225,7 +225,14 @@
 
 		;if not using case weights, change weight_feature to '.none'
 		(if (= (false) use_case_weights)
-			(assign (assoc weight_feature ".none"))
+			(assign (assoc
+				weight_feature ".none"
+			))
+
+			(= (true) use_case_weights)
+			(assign (assoc
+				valid_weight_feature (or !hasPopulatedCaseWeight (= weight_feature ".case_weight"))
+			))
 
 			;set up case weight parameters appropriately since unspecified
 			(let
@@ -254,6 +261,8 @@
 							".none"
 						)
 				))
+
+				(assign (assoc valid_weight_feature (and use_case_weights (!= ".none" weight_feature)) ))
 			)
 		)
 

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -230,9 +230,7 @@
 			))
 
 			(= (false) use_case_weights)
-			(assign (assoc
-				weight_feature ".none"
-			))
+			(assign (assoc weight_feature ".none" ))
 
 			;set up case weight parameters appropriately since unspecified
 			(let

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -246,8 +246,12 @@
 						(if (and !hasPopulatedCaseWeight (contains_value analyzed_weight_features ".case_weight"))
 							".case_weight"
 
-							;else fall back on the first weight feature
+							;use first weight feature,
+							(size analyzed_weight_features)
 							(first analyzed_weight_features)
+
+							;else use none
+							".none"
 						)
 				))
 			)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -224,10 +224,33 @@
 		)
 
 		;if not using case weights, change weight_feature to '.none'
-		(if (not use_case_weights)
+		(if (= (false) use_case_weights)
 			(assign (assoc weight_feature ".none"))
 
-			(assign (assoc valid_weight_feature (or !hasPopulatedCaseWeight (!= weight_feature ".case_weight")) ))
+			;set up case weight parameters appropriately since unspecified
+			(let
+				(assoc
+					analyzed_weight_features
+						(filter
+							(lambda (!= (current_value) ".none"))
+							(map
+								(lambda (last (current_value)))
+								!hyperparameterParamPaths
+							)
+						)
+				)
+
+				(assign (assoc
+					use_case_weights (or !hasPopulatedCaseWeight (size analyzed_weight_features))
+					weight_feature
+						(if (and !hasPopulatedCaseWeight (contains_value analyzed_weight_features ".case_weight"))
+							".case_weight"
+
+							;else fall back on the first weight feature
+							(first analyzed_weight_features)
+						)
+				))
+			)
 		)
 
 

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -231,7 +231,7 @@
 
 			(= (true) use_case_weights)
 			(assign (assoc
-				valid_weight_feature (or !hasPopulatedCaseWeight (= weight_feature ".case_weight"))
+				valid_weight_feature (or !hasPopulatedCaseWeight (!= weight_feature ".case_weight"))
 			))
 
 			;set up case weight parameters appropriately since unspecified

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -224,14 +224,14 @@
 		)
 
 		;update case weight related parameters based on use_case_weights
-		(if (= (false) use_case_weights)
-			(assign (assoc
-				weight_feature ".none"
-			))
-
-			(= (true) use_case_weights)
+		(if use_case_weights
 			(assign (assoc
 				valid_weight_feature (or !hasPopulatedCaseWeight (!= weight_feature ".case_weight"))
+			))
+
+			(= (false) use_case_weights)
+			(assign (assoc
+				weight_feature ".none"
 			))
 
 			;set up case weight parameters appropriately since unspecified


### PR DESCRIPTION
react_aggregate and analyze could be triggered in ways that left case-weight usage unspecified, but would not automatically use populated case weights from ablation/reduction. This fixes that