### PR TITLE
22117: Enables Dynamic Deviations for generative reacts and details, and fixes an issue when using ordinal features with Dynamic Deviations

### DIFF
--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -622,7 +622,12 @@
 
 			;not parameters, variables for Residuals code
 			case_ids (null)
-			features (null)
+			features
+				;filter the context features to get just continuous
+				(filter
+					(lambda (= "continuous" (get !featureAttributes [(current_value 1) "type"])))
+					context_features
+				)
 			k_parameter (null)
 			p_parameter (null)
 			dt_parameter (null)
@@ -699,7 +704,7 @@
 			features
 				;a list of feature names and feature residual names
 				(append
-					features
+					context_features
 					(map
 						(lambda
 							(concat "." (current_value) "_residual")
@@ -713,7 +718,7 @@
 					(lambda
 						(append
 							;case values
-							(retrieve_from_entity (current_value) features)
+							(retrieve_from_entity (current_value) context_features)
 							;residuals
 							(map
 								(lambda

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -660,6 +660,20 @@
 		)
 
 		(declare (assoc
+			feature_weights (get hyperparam_map "featureWeights")
+			feature_deviations (get hyperparam_map "featureDeviations")
+		))
+
+		;use dynamic deviations subtrainee if present
+		(if (get hyperparam_map "subtraineeName")
+			(call !UseDynamicDeviationsAndWeights (assoc
+				context_features features
+				context_values feature_values
+				hyperparam_map hyperparam_map
+			))
+		)
+
+		(declare (assoc
 			new_case_dc
 				(call !ComputeCandidateCaseDistanceContribution (assoc
 					features features
@@ -677,10 +691,10 @@
 						(max k_parameter !regionalModelMinSize)
 						features
 						feature_values
-						(get hyperparam_map "featureWeights")
+						feature_weights
 						!queryDistanceTypeMap
 						(get hyperparam_map "featureDomainAttributes")
-						(get hyperparam_map "featureDeviations")
+						feature_deviations
 						(get hyperparam_map "p")
 						(get hyperparam_map "dt")
 						(if use_case_weights weight_feature (null))
@@ -703,10 +717,10 @@
 							(get hyperparam_map "k")
 							features
 							local_model_cases
-							(get hyperparam_map "featureWeights")
+							feature_weights
 							!queryDistanceTypeMap
 							(get hyperparam_map "featureDomainAttributes")
-							(get hyperparam_map "featureDeviations")
+							feature_deviations
 							(get hyperparam_map "p")
 							(get hyperparam_map "dt")
 							(if use_case_weights weight_feature (null))
@@ -788,6 +802,14 @@
 					query_closest_k (get hyperparam_map "k")
 					query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
 				))
+
+				(if (get hyperparam_map "subtraineeName")
+					(call !UseDynamicDeviationsAndWeights (assoc
+						context_features features
+						context_values feature_values
+						hyperparam_map hyperparam_map
+					))
+				)
 			)
 		)
 

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -157,13 +157,21 @@
 					)
 				)
 
-			context_deviations (get hyperparam_map "featureDeviations")
+			feature_deviations (get hyperparam_map "featureDeviations")
 			feature_weights (get hyperparam_map "featureWeights")
 			k_parameter (get hyperparam_map "k")
 			p_parameter (get hyperparam_map "p")
 			dt_parameter (get hyperparam_map "dt")
 			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
 		))
+
+		(if (get hyperparam_map "subtraineeName")
+			(call !UseDynamicDeviationsAndWeights (assoc
+				context_features features
+				context_values (unzip case_values_map features)
+				hyperparam_map hyperparam_map
+			))
+		)
 
 		(if (get details "derivation_parameters")
 			(accum (assoc
@@ -178,7 +186,7 @@
 									)
 								"feature_deviations"
 									(or
-										context_deviations
+										feature_deviations
 										(zip (append context_features action_features) 0)
 									)
 								"use_irw" (= "targetless" (get hyperparam_map (list "paramPath" 0)))
@@ -646,7 +654,7 @@
 							feature_weights
 							!queryDistanceTypeMap
 							query_feature_attributes_map
-							context_deviations
+							feature_deviations
 							p_parameter
 							dt_parameter
 							(if valid_weight_feature weight_feature (null))

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -25,7 +25,7 @@
 								feature_weights
 								!queryDistanceTypeMap
 								query_feature_attributes_map
-								context_deviations
+								feature_deviations
 								p_parameter
 								dt_parameter
 								(if valid_weight_feature weight_feature (null))
@@ -231,7 +231,7 @@
 						feature_weights
 						!queryDistanceTypeMap
 						query_feature_attributes_map
-						context_deviations
+						feature_deviations
 						p_parameter
 						1 ;dt of 1 queries distance in ascending order
 						(if valid_weight_feature weight_feature (null))
@@ -368,7 +368,7 @@
 								feature_weights
 								!queryDistanceTypeMap
 								query_feature_attributes_map
-								context_deviations
+								feature_deviations
 								p_parameter
 								dt_parameter
 								(if valid_weight_feature weight_feature (null))
@@ -522,6 +522,14 @@
 			feature_deviations  (get hyperparam_map "featureDeviations")
 			feature_weights (get hyperparam_map "featureWeights")
 		))
+
+		(if (get hyperparam_map "subtraineeName")
+			(call !UseDynamicDeviationsAndWeights (assoc
+				context_features context_features
+				context_values context_values
+				hyperparam_map hyperparam_map
+			))
+		)
 
 		;--- calculate boundary cases ---
 		; if one nominal, call !function to get nominal case ids, return boundary cases

--- a/howso/details_influences.amlg
+++ b/howso/details_influences.amlg
@@ -18,7 +18,7 @@
 							feature_weights
 							!queryDistanceTypeMap
 							query_feature_attributes_map
-							context_deviations
+							feature_deviations
 							p_parameter
 							dt_parameter
 							(if valid_weight_feature weight_feature (null))
@@ -152,7 +152,7 @@
 						feature_weights
 						!queryDistanceTypeMap
 						query_feature_attributes_map
-						context_deviations
+						feature_deviations
 						p_parameter
 						1 ; dt_parameter return actual distance
 						(if valid_weight_feature weight_feature (null))
@@ -342,7 +342,7 @@
 						feature_weights
 						!queryDistanceTypeMap
 						query_feature_attributes_map
-						context_deviations
+						feature_deviations
 						p_parameter
 						1 ; dt_parameter return actual distance
 						(if valid_weight_feature weight_feature (null))
@@ -469,7 +469,7 @@
 						feature_weights
 						!queryDistanceTypeMap
 						query_feature_attributes_map
-						context_deviations
+						feature_deviations
 						p_parameter
 						1 ; dt_parameter return actual distance
 						(if valid_weight_feature weight_feature (null))
@@ -625,7 +625,7 @@
 							feature_weights
 							!queryDistanceTypeMap
 							query_feature_attributes_map
-							context_deviations
+							feature_deviations
 							p_parameter
 							dt_parameter
 							(if valid_weight_feature weight_feature (null))

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -16,7 +16,7 @@
 						feature_weights
 						!queryDistanceTypeMap
 						query_feature_attributes_map
-						context_deviations
+						feature_deviations
 						p_parameter
 						dt_parameter
 						(if valid_weight_feature weight_feature (null))
@@ -318,7 +318,7 @@
 								feature_weights
 								!queryDistanceTypeMap
 								query_feature_attributes_map
-								context_deviations
+								feature_deviations
 								p_parameter
 								dt_parameter
 								(if valid_weight_feature weight_feature (null))
@@ -465,7 +465,7 @@
 										(replace feature_weights)
 										(replace !queryDistanceTypeMap)
 										(replace query_feature_attributes_map)
-										(replace context_deviations)
+										(replace feature_deviations)
 										(replace p_parameter)
 										(replace dt_parameter)
 										(if valid_weight_feature (replace weight_feature) (null))

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -315,7 +315,7 @@
 
 		(if (!= (null) result)
 			(seq
-				(call_entity trainee_path "initialize" (assoc trainee_id trainee_id)))
+				(call_entity trainee_path "initialize" (assoc trainee_id trainee_id))
 
 				(call !AddChildTraineeReferences (assoc
 					child_id trainee_id

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -315,7 +315,7 @@
 
 		(if (!= (null) result)
 			(seq
-				(call_entity trainee_path "initialize" (assoc trainee_id trainee_id))
+				(call_entity trainee_path "initialize" (assoc trainee_id trainee_id filepath (retrieve_from_entity "filepath")))
 
 				(call !AddChildTraineeReferences (assoc
 					child_id trainee_id

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -315,7 +315,7 @@
 
 		(if (!= (null) result)
 			(seq
-				(call_entity trainee_path "initialize" (assoc trainee_id trainee_id filepath (retrieve_from_entity "filepath")))
+				(call_entity trainee_path "initialize" (assoc trainee_id trainee_id)))
 
 				(call !AddChildTraineeReferences (assoc
 					child_id trainee_id

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -721,7 +721,12 @@
 		)
 
 		(declare (assoc
-			continuous_context_features (filter (lambda (not (contains_index !nominalsMap (current_value)))) context_features)
+			continuous_context_features
+				;filter the context features to get just continuous
+				(filter
+					(lambda (= "continuous" (get !featureAttributes [(current_value 1) "type"])))
+					context_features
+				)
 		))
 
 		(assign (assoc

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -642,6 +642,20 @@
 				)
 		)
 
+		(declare (assoc
+			feature_weights (get feature_hyperparam_map "featureWeights")
+			feature_deviations (get feature_hyperparam_map "featureDeviations")
+		))
+
+		;use dynamic deviations subtrainee if present
+		(if (get feature_hyperparam_map "subtraineeName")
+			(call !UseDynamicDeviationsAndWeights (assoc
+				context_features context_features
+				context_values context_values
+				hyperparam_map feature_hyperparam_map
+			))
+		)
+
 		(call !CreateAndCacheTimeSeriesFilterQuery)
 
 		(assign (assoc
@@ -658,10 +672,10 @@
 						(max (get feature_hyperparam_map "k") 30)
 						regional_model_context_features
 						regional_model_context_values
-						(get feature_hyperparam_map "featureWeights")
+						feature_weights
 						!queryDistanceTypeMap
 						(get feature_hyperparam_map "featureDomainAttributes")
-						(get feature_hyperparam_map "featureDeviations")
+						feature_deviations
 						(get feature_hyperparam_map "p")
 						(get feature_hyperparam_map "dt")
 						(if valid_weight_feature weight_feature (null))
@@ -742,10 +756,10 @@
 								(get feature_hyperparam_map "k")
 								regional_model_context_features
 								regional_model_context_values
-								(get feature_hyperparam_map "featureWeights")
+								feature_weights
 								!queryDistanceTypeMap
 								(get feature_hyperparam_map "featureDomainAttributes")
-								(get feature_hyperparam_map "featureDeviations")
+								feature_deviations
 								(get feature_hyperparam_map "p")
 								(get feature_hyperparam_map "dt")
 								(if valid_weight_feature weight_feature (null))

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -563,7 +563,19 @@
 				)
 			local_model_cases_map (assoc)
 			local_model_case_values_map (assoc)
+
+			feature_weights (get hyperparam_map "featureWeights")
+			feature_deviations (get hyperparam_map "featureDeviations")
 		))
+
+		;use dynamic deviations subtrainee if present
+		(if (get hyperparam_map "subtraineeName")
+			(call !UseDynamicDeviationsAndWeights (assoc
+				context_features context_features
+				context_values context_values
+				hyperparam_map hyperparam_map
+			))
+		)
 
 		(declare (assoc
 			local_model_cases_tuple
@@ -590,10 +602,10 @@
 							)
 							context_features
 							context_values
-							(get hyperparam_map "featureWeights")
+							feature_weights
 							!queryDistanceTypeMap
 							(get hyperparam_map "featureDomainAttributes")
-							(get hyperparam_map "featureDeviations")
+							feature_deviations
 							(get hyperparam_map "p")
 							(get hyperparam_map "dt")
 							(if valid_weight_feature weight_feature (null))

--- a/performance_tests/adult_test.amlg
+++ b/performance_tests/adult_test.amlg
@@ -7,7 +7,8 @@
 		(false)
 		{escape_resource_name (false) escape_contained_resource_names (false)}
 	)
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(set_entity_root_permission "howso" (true))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	(declare (assoc test_start (system_time)))
 

--- a/performance_tests/asteroid_test.amlg
+++ b/performance_tests/asteroid_test.amlg
@@ -6,7 +6,8 @@
 		(false)
 		{escape_resource_name (false) escape_contained_resource_names (false)}
 	)
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(set_entity_root_permission "howso" (true))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	(declare (assoc test_start (system_time)))
 

--- a/performance_tests/bank_test.amlg
+++ b/performance_tests/bank_test.amlg
@@ -19,7 +19,7 @@
 		;set to true to see full output
 		verbose (false)
 		;set to null to do full model
-		submodel_size 1000 ;10000
+		submodel_size (null) ;10000
 		;set to true to also run analyze
 		do_analyze (true)
 		;set to true to force deviations in analyze
@@ -81,7 +81,6 @@
 				targeted_model "targetless"
 				use_case_weights use_case_weights
 				use_deviations use_deviations
-				use_dynamic_deviations (false)
 			))
 			(declare (assoc analyze_time (- (system_time) start) ))
 			(print "Analyze time: " analyze_time "\n" )

--- a/performance_tests/bank_test.amlg
+++ b/performance_tests/bank_test.amlg
@@ -6,7 +6,8 @@
 		(false)
 		{escape_resource_name (false) escape_contained_resource_names (false)}
 	)
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(set_entity_root_permission "howso" (true))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	(declare (assoc test_start (system_time)))
 
@@ -18,7 +19,7 @@
 		;set to true to see full output
 		verbose (false)
 		;set to null to do full model
-		submodel_size (null) ;10000
+		submodel_size 1000 ;10000
 		;set to true to also run analyze
 		do_analyze (true)
 		;set to true to force deviations in analyze
@@ -80,6 +81,7 @@
 				targeted_model "targetless"
 				use_case_weights use_case_weights
 				use_deviations use_deviations
+				use_dynamic_deviations (false)
 			))
 			(declare (assoc analyze_time (- (system_time) start) ))
 			(print "Analyze time: " analyze_time "\n" )

--- a/performance_tests/e_shop_test.amlg
+++ b/performance_tests/e_shop_test.amlg
@@ -6,7 +6,8 @@
 		(false)
 		{escape_resource_name (false) escape_contained_resource_names (false)}
 	)
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(set_entity_root_permission "howso" (true))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	(declare (assoc test_start (system_time)))
 

--- a/performance_tests/mnist_10k_test.amlg
+++ b/performance_tests/mnist_10k_test.amlg
@@ -6,7 +6,8 @@
 		(false)
 		{escape_resource_name (false) escape_contained_resource_names (false)}
 	)
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(set_entity_root_permission "howso" (true))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	(declare (assoc test_start (system_time)))
 

--- a/performance_tests/online_retail_test.amlg
+++ b/performance_tests/online_retail_test.amlg
@@ -6,7 +6,8 @@
 		(false)
 		{escape_resource_name (false) escape_contained_resource_names (false)}
 	)
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(set_entity_root_permission "howso" (true))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	(declare (assoc test_start (system_time)))
 

--- a/performance_tests/range_queries_test.amlg
+++ b/performance_tests/range_queries_test.amlg
@@ -6,7 +6,8 @@
 		(false)
 		{escape_resource_name (false) escape_contained_resource_names (false)}
 	)
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(set_entity_root_permission "howso" (true))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	(declare (assoc test_start (system_time)))
 

--- a/performance_tests/religious_texts_test.amlg
+++ b/performance_tests/religious_texts_test.amlg
@@ -6,7 +6,8 @@
 		(false)
 		{escape_resource_name (false) escape_contained_resource_names (false)}
 	)
-	(call_entity "howso" "initialize" (assoc trainee_id "model"))
+	(set_entity_root_permission "howso" (true))
+	(call_entity "howso" "initialize" (assoc trainee_id "model" filepath "../"))
 
 	(declare (assoc test_start (system_time)))
 


### PR DESCRIPTION
Adds the necessary logic to utilize Dynamic Deviations for generative reacts and other react details where it previously would not be used. 

Additionally fixes an issue in Dynamic Deviations where ordinal feature values would be counted as continuous, which would consequently break the trained values and analyzed hyperparameters of the subtrainee.

Lastly, I also fix the performance tests to specify the filepaths correctly. Without the correct filepath, the Trainee could not properly create subtrainees.