### PR TITLE
22143: Rename `session` parameter of `#delete_session` to `target_session`, MAJOR

### DIFF
--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -7,16 +7,16 @@
 	(declare
 		(assoc
 			;{type "string" required (true)}
-			;session to remove
-			session (null)
+			;the id of the session to remove
+			target_session (null)
 		)
 		(call !ValidateParameters)
-		(destroy_entities session)
+		(destroy_entities target_session)
 
 		;if any case references this session, remove the session id
 		(map
 			(lambda
-				(if (= session (retrieve_from_entity (current_value) !internalLabelSession))
+				(if (= target_session (retrieve_from_entity (current_value) !internalLabelSession))
 					(assign_to_entities (current_value) (associate !internalLabelSession (null)))
 				)
 			)

--- a/unit_tests/ut_h_react_distance_ratio.amlg
+++ b/unit_tests/ut_h_react_distance_ratio.amlg
@@ -104,7 +104,7 @@
 
 	;Remove session containing duplicates so that validating results is simpler.
 	(call_entity "howso" "delete_session" (assoc
-		session "duplicates"
+		target_session "duplicates"
 	))
 	(call_entity "howso" "train" (assoc
 		features context_features

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -552,7 +552,7 @@
 
 ;VERIFY EXPECTED FEATURE VALUES
 
-	(call_entity "howso" "delete_session" (assoc session "iris_session"))
+	(call_entity "howso" "delete_session" (assoc target_session "iris_session"))
 
 	(call_entity "howso" "train" (assoc
 		features (append context_labels action_labels)


### PR DESCRIPTION
Renames the "session" parameter of `#delete_session` to "target_session" to help differentiate session parameters that indicate the active session of the user from parameters used to specify a specific non-active session.