### PR TITLE
22299: Aligns the error response when undefined parameters are given and disables unnamed keys for `details` parameters

### DIFF
--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -403,10 +403,20 @@
 		(if (size undefined_parameters)
 			(conclude (conclude
 				(call !Return (assoc
+					error_code "invalid"
 					errors
 						(list (concat
-							"The following given parameters are not supported for " label_name ": "
-							(apply "concat" (trunc (weave undefined_parameters ", ")))
+							"The following given parameters are not supported for \"" label_name "\": "
+							(apply
+								"concat"
+								(trunc (weave
+									(map
+										(lambda (concat "\"" (current_value) "\""))
+										undefined_parameters
+									)
+									", "
+								))
+							)
 							"."
 						))
 				))
@@ -663,7 +673,10 @@
 													(concat
 														"The following indices are not accepted within the given value: "
 														(apply "concat" (trunc (weave
-															(indices (remove given_value (indices (get specification "indices"))))
+															(map
+																(lambda (concat "\"" (current_value) "\""))
+																(indices (remove given_value (indices (get specification "indices"))))
+															)
 															", "
 														)))
 														"."
@@ -763,7 +776,16 @@
 					errors
 						(list (concat
 							"The following parameters contain invalid values: "
-							(apply "concat" (trunc (weave invalid_params ", ")))
+							(apply
+								"concat"
+								(trunc (weave
+									(map
+										(lambda (concat "\"" (current_value) "\""))
+										invalid_params
+									)
+									", "
+								))
+							)
 							"."
 						))
 					error_details (keep parameter_validity_map invalid_params)

--- a/howso/typing.amlg
+++ b/howso/typing.amlg
@@ -762,6 +762,7 @@
 		ReactDetails
 			(assoc
 				type "assoc"
+				additional_indices (false)
 				indices
 					(assoc
 						influential_cases
@@ -1215,6 +1216,7 @@
 		ReactAggregateDetails
 			(assoc
 				type "assoc"
+				additional_indices (false)
 				indices
 					(assoc
 						action_condition

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -239,12 +239,13 @@
 					{not_real_detail (true)}
 			))
 	))
-
+	(print "Calling react with an unknown key in details: ")
     (call assert_same (assoc
         obs 0
         exp (first result)
     ))
 
+	(print "Error map has the right information: ")
 	(call assert_true (assoc
 		obs (contains_index (get result [1 "errors"]) "details")
 	))

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -230,5 +230,24 @@
 		obs (get_type_string result)
 	))
 
+	(assign (assoc
+		result
+			(call_entity "howso" "react" (assoc
+				context_features features
+                context_values [(last data)]
+				details
+					{not_real_detail (true)}
+			))
+	))
+
+    (call assert_same (assoc
+        obs 0
+        exp (first result)
+    ))
+
+	(call assert_true (assoc
+		obs (contains_index (get result [1 "errors"]) "details")
+	))
+
 	(call exit_if_failures (assoc msg unit_test_name ))
 )


### PR DESCRIPTION
Here I alter the parameter validation code to make sure the error reported when undefined parameters are detected matches the form of the error that is reported when parameters contain invalid values.

While I'm here, I noticed that we were not erroring on bad keys in `details` dictionaries, so I went ahead and enabled that check. 

Also add double quotes around parameter/label names in the error responses.