### PR TITLE
22317: Updates `#update_trainee` to support updating contained subtrainees, MAJOR

### DIFF
--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -89,6 +89,7 @@
 		; 	}
 		; }
 		(assoc)
+		(call !ValidateParameters)
 		(call !Return (assoc payload (assoc "count" (call !GetNumTrainingCases) ) ))
 	)
 

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -214,6 +214,17 @@
 		)
 		(call !ValidateParameters)
 
+		(if (!= !revision 0)
+			(conclude
+				(call !Return (assoc errors
+					(list (concat
+						"This Trainee has had modifications and cannot be used for upgrading. "
+						"Please use a new Trainee to upgrade old Trainees."
+					))
+				))
+			)
+		)
+
 		;create a temporary subtrainee from the latest howso code
 		(declare (assoc
 			new_trainee_path

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -426,7 +426,8 @@
 			case_and_session_entities
 		)
 
-		;TODO: migrate on contained trainees
+		(declare (assoc new_trainee_entity contained_entity_path))
+
 		;iterate over all the applicable migration script versions and apply each one in order
 		(call !execute_migration_scripts)
 
@@ -444,7 +445,7 @@
 
 					;recursively migrate all the attributes and contained entities
 					(call !MigrateSubtrainee (assoc
-						migration_trainee (current_value 1)
+						migration_trainee (append migration_trainee !traineeContainer (current_value 1))
 						contained_entity_path new_contained_entity_path
 						new_labels new_labels
 					))
@@ -465,7 +466,7 @@
 						(!= (null) (get (current_value) "auto_derive_on_train"))
 						(!= (null) (get (current_value) "derived_feature_code"))
 					))
-					(retrieve_from_entity "!featureAttributes")
+					(retrieve_from_entity new_trainee_entity "!featureAttributes")
 				)
 		)
 
@@ -485,7 +486,7 @@
 				)
 
 				;cache all the custom specified derivation code into trainee
-				(assign_to_entities (assoc
+				(assign_to_entities new_trainee_entity (assoc
 					!featureCustomDerivedMethods
 						(call !ComposeCustomDerivedMethods (assoc
 							custom_derived_features_map custom_derived_features_map

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -476,7 +476,7 @@
 						(!= (null) (get (current_value) "auto_derive_on_train"))
 						(!= (null) (get (current_value) "derived_feature_code"))
 					))
-					(retrieve_from_entity new_trainee_entity "!featureAttributes")
+					(retrieve_from_entity "!featureAttributes")
 				)
 		)
 
@@ -496,7 +496,7 @@
 				)
 
 				;cache all the custom specified derivation code into trainee
-				(assign_to_entities new_trainee_entity (assoc
+				(assign_to_entities (assoc
 					!featureCustomDerivedMethods
 						(call !ComposeCustomDerivedMethods (assoc
 							custom_derived_features_map custom_derived_features_map

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -241,33 +241,21 @@
 
 		;if amalgam trainee is specified, load and upgrade it
 		(if trainee_amlg_filepath
-			(call !MigrateSubtrainee (assoc
-				migration_trainee (call (load (concat trainee_amlg_filepath trainee ".amlg") ))
-				contained_entity_path []
-				new_labels (call get_export_attributes)
-			))
-
-			;if not importing metadata from saved file, upgrade trainee in place
-			(= (null) trainee_json_filepath)
 			(let
-				(assoc
-					;create a list of all the matadata labels
-					labels_to_keep (call_entity new_trainee_path "get_export_attributes")
-					old_labels (call get_export_attributes)
-				)
+				(assoc t (call (load (concat trainee_amlg_filepath trainee ".amlg") )) )
 
-				;keep only those that are in the old trainee
-				(assign (assoc
-					labels_to_keep (filter (lambda (contains_label (current_value))) labels_to_keep)
+				(call !MigrateSubtrainee (assoc
+					migration_trainee (first (first t))
+					contained_entity_path []
+					new_labels (call get_export_attributes)
 				))
 
-				;set import_metadata_map to values from the old trainee
-				(assign (assoc
-					import_metadata_map (zip labels_to_keep (retrieve_from_entity labels_to_keep))
-				))
+				;cleanup
+				(destroy_entities t new_trainee_path)
 			)
 
-			;else overwrite old version from exported file instead of from trainee
+			;else loading from json
+			;overwrite old version from exported file instead of from trainee
 			(seq
 				(assign (assoc
 					;metadata json should be in the format of: { label : value }
@@ -342,42 +330,42 @@
 							(parse (get import_metadata_map "!featureCustomDerivedMethods"))
 						)
 				))
-			)
-		)
 
-		;overwrite this trainee code with the new code, this does not overwrite contained entities (cases, sessions),
-		;but does overwrite all labels including versions with new ones
-		(assign_entity_roots (retrieve_entity_root new_trainee_path))
-		(destroy_entities new_trainee_path)
+				;overwrite this trainee code with the new code, this does not overwrite contained entities (cases, sessions),
+				;but does overwrite all labels including versions with new ones
+				(assign_entity_roots (retrieve_entity_root new_trainee_path))
+				(destroy_entities new_trainee_path)
 
-		;for each label pull its value from the old trainee and overwrite it in the new one
-		(assign_to_entities import_metadata_map)
+				;for each label pull its value from the old trainee and overwrite it in the new one
+				(assign_to_entities import_metadata_map)
 
-		;import cases and sessions from saved json and re-create them in the trainee
-		(if import_cases_and_sessions_map
-			;iterate over all the entities and re-create them as contained entities with corresponding features and values
-			(map
-				(lambda
-					(create_entities
-						(current_index)
-						(set_type
-							(zip_labels
-								(indices (current_value))
-								(values (current_value))
+				;import cases and sessions from saved json and re-create them in the trainee
+				(if import_cases_and_sessions_map
+					;iterate over all the entities and re-create them as contained entities with corresponding features and values
+					(map
+						(lambda
+							(create_entities
+								(current_index)
+								(set_type
+									(zip_labels
+										(indices (current_value))
+										(values (current_value))
+									)
+									(null)
+								)
 							)
-							(null)
 						)
+						import_cases_and_sessions_map
 					)
 				)
-				import_cases_and_sessions_map
+
+				;iterate over all the applicable migration script versions and apply each one in order
+				(call !execute_migration_scripts)
+
+				;recreate custom derive feature code on trainee if it has derived features
+				(call !recreate_feature_custom_derived_methods)
 			)
 		)
-
-		;iterate over all the applicable migration script versions and apply each one in order
-		(call !execute_migration_scripts)
-
-		;recreate custom derive feature code on trainee if it has derived features
-		(call !recreate_feature_custom_derived_methods)
 
 		(accum_to_entities (assoc !revision 1))
 
@@ -421,7 +409,7 @@
 
 		(map
 			(lambda
-				(move_entities [migration_trainee (current_value 1)] contained_entity_path)
+				(move_entities (append migration_trainee (current_value)) contained_entity_path)
 			)
 			case_and_session_entities
 		)

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -198,6 +198,10 @@
 			;base path to Howso Engine Core installation
 			root_filepath (null)
 			;{type "string"}
+			;path from which to load previously exported amlg trainee
+			;	If specified, trainee_json_filepath is ignored
+			trainee_amlg_filepath (null)
+			;{type "string"}
 			;path from which to load previously exported meta.json and exp.json files.
 			;	If unspecified, expects them to be located in the base installation /migrations/ directory.
 			trainee_json_filepath (null)
@@ -235,8 +239,16 @@
 			import_cases_and_sessions_map (null)
 		))
 
-		;if not importing metadata from saved file, upgrade trainee in place
-		(if (= (null) trainee_json_filepath)
+		;if amalgam trainee is specified, load and upgrade it
+		(if trainee_amlg_filepath
+			(call !MigrateSubtrainee (assoc
+				migration_trainee (call (load (concat trainee_amlg_filepath trainee ".amlg") ))
+				contained_entity_path []
+				new_labels (call get_export_attributes)
+			))
+
+			;if not importing metadata from saved file, upgrade trainee in place
+			(= (null) trainee_json_filepath)
 			(let
 				(assoc
 					;create a list of all the matadata labels
@@ -379,6 +391,67 @@
 		)
 
 		(call !Return)
+	)
+
+	#!MigrateSubtrainee
+	(declare
+		(assoc
+			migration_trainee (null)
+			new_labels []
+			contained_entity_path []
+		)
+
+		(declare (assoc
+			old_labels (call_entity migration_trainee "get_export_attributes")
+			case_and_session_entities (filter (lambda (!= !traineeContainer (current_value))) (contained_entities migration_trainee))
+		))
+
+		(declare (assoc
+			import_metadata_map
+				(map
+					(lambda
+						(call_entity migration_trainee "debug_label" (assoc label (current_index 1) ))
+					)
+					(zip old_labels)
+				)
+		))
+
+		;set the attributes
+		(assign_to_entities contained_entity_path import_metadata_map)
+
+		(map
+			(lambda
+				(move_entities [migration_trainee (current_value 1)] contained_entity_path)
+			)
+			case_and_session_entities
+		)
+
+		;TODO: migrate on contained trainees
+		;iterate over all the applicable migration script versions and apply each one in order
+		(call !execute_migration_scripts)
+
+		;recreate custom derive feature code on trainee if it has derived features
+		(call !recreate_feature_custom_derived_methods)
+
+		;if there are subtrainees, need to recursively upgrade those as well
+		(if (size (contained_entities [migration_trainee !traineeContainer]))
+			(map
+				(lambda (let
+					(assoc new_contained_entity_path (append contained_entity_path !traineeContainer (current_value 1)) )
+
+					;create a new trainee with the same id and relative path
+					(clone_entities new_trainee_path new_contained_entity_path)
+
+					;recursively migrate all the attributes and contained entities
+					(call !MigrateSubtrainee (assoc
+						migration_trainee (current_value 1)
+						contained_entity_path new_contained_entity_path
+						new_labels new_labels
+					))
+				))
+				(contained_entities [migration_trainee !traineeContainer])
+			)
+		)
 	)
 
 

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -206,8 +206,8 @@
 			;	If unspecified, expects them to be located in the base installation /migrations/ directory.
 			trainee_json_filepath (null)
 			;{type "boolean"}
-			;flag, if true will load each case from its individual file
-			separate_files (false)
+			;if true, then will import and use the trainee information in the subtrainee named ".old_trainee"
+			preloaded (false)
 		)
 		(call !ValidateParameters)
 
@@ -240,13 +240,28 @@
 		))
 
 		;if amalgam trainee is specified, load and upgrade it
-		(if trainee_amlg_filepath
+		(if (or trainee_amlg_filepath preloaded)
 			(let
-				(assoc t (call (load (concat trainee_amlg_filepath trainee ".amlg") )) )
+				(assoc
+					;t (call (load (concat trainee_amlg_filepath trainee ".amlg") ))
+					t
+						(if preloaded
+							[!traineeContainer ".old_trainee"]
 
-				(call !MigrateSubtrainee (assoc
-					migration_trainee (first (first t))
-					contained_entity_path []
+							;else must load the old trainee properly
+							(load_entity
+								(concat trainee_amlg_filepath trainee ".amlg")
+								[!traineeContainer ".old_trainee"]
+								"amlg"
+								(false)
+								;assume flattened
+								{execute_on_load (true)}
+							)
+						)
+				)
+
+				(call !UpgradeFromSubTrainee (assoc
+					migration_trainee t
 					new_labels (call get_export_attributes)
 				))
 
@@ -381,12 +396,12 @@
 		(call !Return)
 	)
 
-	#!MigrateSubtrainee
+	#!UpgradeFromSubTrainee
 	(declare
 		(assoc
+			;entity id to "import" from
 			migration_trainee (null)
 			new_labels []
-			contained_entity_path []
 		)
 
 		(declare (assoc
@@ -394,6 +409,7 @@
 			case_and_session_entities (filter (lambda (!= !traineeContainer (current_value))) (contained_entities migration_trainee))
 		))
 
+		;get all the old labels
 		(declare (assoc
 			import_metadata_map
 				(map
@@ -403,19 +419,15 @@
 					(zip old_labels)
 				)
 		))
-
-		;set the attributes
-		;TODO: make this work for private labels of contained entities
-		(assign_to_entities contained_entity_path import_metadata_map)
+		;assign all the old labels into the current entity/trainee
+		(assign_to_entities import_metadata_map)
 
 		(map
 			(lambda
-				(move_entities (append migration_trainee (current_value)) (append contained_entity_path (current_value)))
+				(move_entities (append migration_trainee (current_value)) [(current_value)])
 			)
 			case_and_session_entities
 		)
-
-		(declare (assoc new_trainee_entity contained_entity_path))
 
 		;iterate over all the applicable migration script versions and apply each one in order
 		(call !execute_migration_scripts)
@@ -427,17 +439,26 @@
 		(if (size (contained_entities (append migration_trainee !traineeContainer)))
 			(map
 				(lambda (let
-					(assoc new_contained_entity_path (append contained_entity_path !traineeContainer (current_value 1)) )
+					(assoc new_contained_entity_path (append !traineeContainer (current_value 1)) )
 
-					;create a new trainee with the same id and relative path
+					;create a new trainee with the same id and relative path to the current entity
 					(clone_entities new_trainee_path new_contained_entity_path)
 
-					;recursively migrate all the attributes and contained entities
-					(call !MigrateSubtrainee (assoc
-						migration_trainee (append migration_trainee !traineeContainer (current_value 1))
-						contained_entity_path new_contained_entity_path
-						new_labels new_labels
+					;move the subtrainee that needs upgrading into the trainee that will do its upgrading
+					(move_entities
+						(append migration_trainee !traineeContainer (current_value))
+						(append new_contained_entity_path !traineeContainer ".old_trainee")
+					)
+
+					;recursively upgrade that subtrainee and any subtrainees it may have
+					(set_entity_root_permission new_contained_entity_path (true))
+					(call_entity new_contained_entity_path "upgrade_trainee" (assoc
+						trainee (current_value 1)
+						;specify its already preloaded with the ".old_trainee" subtrainee
+						preloaded (true)
+						root_filepath root_filepath
 					))
+					(set_entity_root_permission new_contained_entity_path (false))
 				))
 				(contained_entities (append migration_trainee !traineeContainer))
 			)

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -206,7 +206,10 @@
 			;	If unspecified, expects them to be located in the base installation /migrations/ directory.
 			trainee_json_filepath (null)
 			;{type "boolean"}
-			;if true, then will import and use the trainee information in the subtrainee named ".old_trainee"
+			;boolean flag used automatically by #upgrade_trainee when upgrading subtrainees. Not recommended to be used
+			;manually by the user.
+			;if true, then will import and use the trainee information in the subtrainee named ".old_trainee" rather
+			;than load a trainee from the filesystem.
 			preloaded (false)
 		)
 		(call !ValidateParameters)
@@ -243,7 +246,6 @@
 		(if (or trainee_amlg_filepath preloaded)
 			(let
 				(assoc
-					;t (call (load (concat trainee_amlg_filepath trainee ".amlg") ))
 					t
 						(if preloaded
 							[!traineeContainer ".old_trainee"]
@@ -262,7 +264,6 @@
 
 				(call !UpgradeFromSubTrainee (assoc
 					migration_trainee t
-					new_labels (call get_export_attributes)
 				))
 
 				;cleanup
@@ -396,12 +397,17 @@
 		(call !Return)
 	)
 
+	;Helper method for the upgrade process that is responsible for upgrading an older Trainee saved as a subtrainee
+	;whose entity ID/path is specified by "migration_trainee".
+	;This method retrieves an assoc of all of the export attributes of the older Trainee and assigns the value of each attribute
+	;onto itself, then calls the migrations necessary to update these values appropriately
+	;Additionally this method will also move the case/session entities from the older trainee into itself and recursively repeat
+	;this process for any subtrainees within the older trainee.
 	#!UpgradeFromSubTrainee
 	(declare
 		(assoc
 			;entity id to "import" from
 			migration_trainee (null)
-			new_labels []
 		)
 
 		(declare (assoc
@@ -422,6 +428,8 @@
 		;assign all the old labels into the current entity/trainee
 		(assign_to_entities import_metadata_map)
 
+		;iterates through each case or session entity within the migration trainee and moves it
+		;up into the current trainee under the same name
 		(map
 			(lambda
 				(move_entities (append migration_trainee (current_value)) [(current_value)])

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -405,11 +405,12 @@
 		))
 
 		;set the attributes
+		;TODO: make this work for private labels of contained entities
 		(assign_to_entities contained_entity_path import_metadata_map)
 
 		(map
 			(lambda
-				(move_entities (append migration_trainee (current_value)) contained_entity_path)
+				(move_entities (append migration_trainee (current_value)) (append contained_entity_path (current_value)))
 			)
 			case_and_session_entities
 		)
@@ -423,7 +424,7 @@
 		(call !recreate_feature_custom_derived_methods)
 
 		;if there are subtrainees, need to recursively upgrade those as well
-		(if (size (contained_entities [migration_trainee !traineeContainer]))
+		(if (size (contained_entities (append migration_trainee !traineeContainer)))
 			(map
 				(lambda (let
 					(assoc new_contained_entity_path (append contained_entity_path !traineeContainer (current_value 1)) )
@@ -438,7 +439,7 @@
 						new_labels new_labels
 					))
 				))
-				(contained_entities [migration_trainee !traineeContainer])
+				(contained_entities (append migration_trainee !traineeContainer))
 			)
 		)
 	)

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -257,7 +257,7 @@
 		(if (or trainee_amlg_filepath preloaded)
 			(let
 				(assoc
-					t
+					old_trainee
 						(if preloaded
 							[!traineeContainer ".old_trainee"]
 
@@ -274,11 +274,11 @@
 				)
 
 				(call !UpgradeFromSubTrainee (assoc
-					migration_trainee t
+					migration_trainee old_trainee
 				))
 
 				;cleanup
-				(destroy_entities t new_trainee_path)
+				(destroy_entities old_trainee)
 			)
 
 			;else loading from json
@@ -358,11 +358,6 @@
 						)
 				))
 
-				;overwrite this trainee code with the new code, this does not overwrite contained entities (cases, sessions),
-				;but does overwrite all labels including versions with new ones
-				(assign_entity_roots (retrieve_entity_root new_trainee_path))
-				(destroy_entities new_trainee_path)
-
 				;for each label pull its value from the old trainee and overwrite it in the new one
 				(assign_to_entities import_metadata_map)
 
@@ -395,6 +390,7 @@
 		)
 
 		(accum_to_entities (assoc !revision 1))
+		(destroy_entities new_trainee_path)
 
 		;print statement for use in utility scripts: upgrade_trainee and export_trainee
 		(print

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -34,17 +34,17 @@
 				)
 		))
 
-		(assign_to_entities (assoc !hyperparameterMetadataMap hp_map ))
+		(assign_to_entities new_trainee_entity (assoc !hyperparameterMetadataMap hp_map ))
 	)
 "65.0.11"
 	(let
 		(assoc old_half_gaps (get import_metadata_map "cachedFeatureMinGapMap") )
-		(assign_to_entities (assoc !cachedFeatureHalfMinGapMap old_half_gaps))
+		(assign_to_entities new_trainee_entity (assoc !cachedFeatureHalfMinGapMap old_half_gaps))
 	)
 "66.2.0"
 	(let
 		(assoc non_string_nominals_map (get import_metadata_map "nonStringNominalFeaturesMap"))
-		(assign_to_entities (assoc !numericNominalFeaturesMap non_string_nominals_map))
+		(assign_to_entities new_trainee_entity (assoc !numericNominalFeaturesMap non_string_nominals_map))
 	)
 "67.0.0"
 	(let
@@ -138,7 +138,7 @@
 			hp_map
 		)
 
-		(assign_to_entities (assoc
+		(assign_to_entities new_trainee_entity (assoc
 			!hyperparameterMetadataMap hp_map
 			!hyperparameterParamPaths hp_param_paths
 			!residualsMap residuals_map
@@ -226,7 +226,7 @@
 			param_paths
 		)
 
-		(assign_to_entities (assoc !hyperparameterMetadataMap hp_map ))
+		(assign_to_entities new_trainee_entity (assoc !hyperparameterMetadataMap hp_map ))
 	)
 ;Rename defaultFeatures to trainedFeatures, also defaultFeaturesContextKey to trainedFeaturesContextKey
 "74.1.2"
@@ -235,7 +235,7 @@
 			default_features (get import_metadata_map "defaultFeatures")
 			default_features_key (get import_metadata_map "defaultFeaturesContextKey")
 		)
-		(assign_to_entities (assoc
+		(assign_to_entities new_trainee_entity (assoc
 			!trainedFeatures default_features
 			!trainedFeaturesContextKey default_features_key
 		))
@@ -265,14 +265,14 @@
 							(get import_metadata_map old_label_name)
 
 							;else keep current value as-is
-							(retrieve_from_entity (current_index))
+							(retrieve_from_entity new_trainee_entity (current_index))
 						)
 					))
 					(zip labels_to_update)
 				)
 		))
 
-		(assign_to_entities updated_model_atributes_map)
+		(assign_to_entities new_trainee_entity updated_model_atributes_map)
 		(accum (assoc
 			import_metadata_map updated_model_atributes_map
 		))
@@ -336,7 +336,7 @@
 			residuals_map
 		)
 
-		(assign_to_entities (assoc
+		(assign_to_entities new_trainee_entity (assoc
 			!hyperparameterMetadataMap hyperparameter_metadata_map
 			!defaultHyperparameters default_hyperparameter_map
 		))
@@ -379,7 +379,7 @@
 				)
 		))
 
-		(assign_to_entities (assoc !derivedFeaturesMap derived_features_map ))
+		(assign_to_entities new_trainee_entity (assoc !derivedFeaturesMap derived_features_map ))
 	)
 "88.0.0"
 	(let
@@ -426,7 +426,7 @@
 			!hyperparameterParamPaths
 		)
 
-		(assign_to_entities (assoc
+		(assign_to_entities new_trainee_entity (assoc
 			!hyperparameterParamPaths (values new_paths (true))
 			!hyperparameterMetadataMap new_hp_params
 		))

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -34,17 +34,17 @@
 				)
 		))
 
-		(assign_to_entities new_trainee_entity (assoc !hyperparameterMetadataMap hp_map ))
+		(assign_to_entities (assoc !hyperparameterMetadataMap hp_map ))
 	)
 "65.0.11"
 	(let
 		(assoc old_half_gaps (get import_metadata_map "cachedFeatureMinGapMap") )
-		(assign_to_entities new_trainee_entity (assoc !cachedFeatureHalfMinGapMap old_half_gaps))
+		(assign_to_entities (assoc !cachedFeatureHalfMinGapMap old_half_gaps))
 	)
 "66.2.0"
 	(let
 		(assoc non_string_nominals_map (get import_metadata_map "nonStringNominalFeaturesMap"))
-		(assign_to_entities new_trainee_entity (assoc !numericNominalFeaturesMap non_string_nominals_map))
+		(assign_to_entities (assoc !numericNominalFeaturesMap non_string_nominals_map))
 	)
 "67.0.0"
 	(let
@@ -138,7 +138,7 @@
 			hp_map
 		)
 
-		(assign_to_entities new_trainee_entity (assoc
+		(assign_to_entities (assoc
 			!hyperparameterMetadataMap hp_map
 			!hyperparameterParamPaths hp_param_paths
 			!residualsMap residuals_map
@@ -226,7 +226,7 @@
 			param_paths
 		)
 
-		(assign_to_entities new_trainee_entity (assoc !hyperparameterMetadataMap hp_map ))
+		(assign_to_entities (assoc !hyperparameterMetadataMap hp_map ))
 	)
 ;Rename defaultFeatures to trainedFeatures, also defaultFeaturesContextKey to trainedFeaturesContextKey
 "74.1.2"
@@ -235,7 +235,7 @@
 			default_features (get import_metadata_map "defaultFeatures")
 			default_features_key (get import_metadata_map "defaultFeaturesContextKey")
 		)
-		(assign_to_entities new_trainee_entity (assoc
+		(assign_to_entities (assoc
 			!trainedFeatures default_features
 			!trainedFeaturesContextKey default_features_key
 		))
@@ -265,14 +265,14 @@
 							(get import_metadata_map old_label_name)
 
 							;else keep current value as-is
-							(retrieve_from_entity new_trainee_entity (current_index))
+							(retrieve_from_entity (current_index))
 						)
 					))
 					(zip labels_to_update)
 				)
 		))
 
-		(assign_to_entities new_trainee_entity updated_model_atributes_map)
+		(assign_to_entities updated_model_atributes_map)
 		(accum (assoc
 			import_metadata_map updated_model_atributes_map
 		))
@@ -336,7 +336,7 @@
 			residuals_map
 		)
 
-		(assign_to_entities new_trainee_entity (assoc
+		(assign_to_entities (assoc
 			!hyperparameterMetadataMap hyperparameter_metadata_map
 			!defaultHyperparameters default_hyperparameter_map
 		))
@@ -379,7 +379,7 @@
 				)
 		))
 
-		(assign_to_entities new_trainee_entity (assoc !derivedFeaturesMap derived_features_map ))
+		(assign_to_entities (assoc !derivedFeaturesMap derived_features_map ))
 	)
 "88.0.0"
 	(let
@@ -426,7 +426,7 @@
 			!hyperparameterParamPaths
 		)
 
-		(assign_to_entities new_trainee_entity (assoc
+		(assign_to_entities (assoc
 			!hyperparameterParamPaths (values new_paths (true))
 			!hyperparameterMetadataMap new_hp_params
 		))

--- a/unit_tests/unit_test.amlg
+++ b/unit_tests/unit_test.amlg
@@ -398,6 +398,9 @@
 	#exit_if_failures
 	(if (> num_failed_asserts 0)
 		(seq
+			(if cleanup_method
+				(call cleanup_method)
+			)
 			(print "Number of failed asserts: " num_failed_asserts " \n")
 			(if (!= (null) msg)
 				(print "[FAILED: " msg "]\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n")

--- a/unit_tests/ut_h_upgrade_htest.amlg
+++ b/unit_tests/ut_h_upgrade_htest.amlg
@@ -204,5 +204,12 @@
 
 	(call exit_if_failures {msg "Cases not preserved correctly."})
 
+	(if (= (system "os") "Windows")
+		(system "system" "del htest.amlg")
+
+		;else posix
+		(system "system" "rm htest.amlg")
+	)
+
 	(call exit_if_failures (assoc msg unit_test_name ))
 )

--- a/unit_tests/ut_h_upgrade_htest.amlg
+++ b/unit_tests/ut_h_upgrade_htest.amlg
@@ -1,0 +1,97 @@
+(seq
+	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_update_htest.amlg"))
+
+	(declare (assoc result (null)))
+
+	; (call_entity "howso" "create_subtrainee" (assoc path ["A"] child_id "A"))
+
+	; (call_entity "howso" "create_subtrainee" (assoc path ["A" "b"] child_id "b" ))
+
+	; (call_entity "howso" "create_subtrainee" (assoc path ["A" "b" "c1"] child_id "c1" ))
+
+	; (call_entity "howso" "create_subtrainee" (assoc path ["A" "b" "c2"] child_id "c2" ))
+
+
+	; (call_entity "howso" "train" (assoc
+	; 	features (list "a" "b" "c")
+	; 	cases
+	; 		(list
+	; 			(list 10 20 30)
+	; 			(list 11 22 33)
+	; 			(list 12 24 36)
+	; 			(list 13 26 39)
+	; 		)
+	; ))
+
+	; (call_entity "howso" "execute_on_subtrainee" (assoc
+	; 	path ["A"]
+	; 	method "train"
+	; 	payload
+	; 		(assoc
+	; 			features (list "x" "y")
+	; 			cases
+	; 				(list
+	; 					(list 1 1)
+	; 					(list 2 1)
+	; 				)
+	; 		)
+	; ))
+
+	; (call_entity "howso" "execute_on_subtrainee" (assoc
+	; 	path ["A" "b"]
+	; 	method "train"
+	; 	payload
+	; 		(assoc
+	; 			features (list "x" "y")
+	; 			cases
+	; 				(list
+	; 					(list 3 3)
+	; 					(list 4 4)
+	; 					(list 5 5)
+	; 				)
+	; 		)
+	; ))
+
+	; (call_entity "howso" "execute_on_subtrainee" (assoc
+	; 	path ["A" "b" "c1"]
+	; 	method "train"
+	; 	payload
+	; 		(assoc
+	; 			features (list "x" "y" "z")
+	; 			cases
+	; 				(list
+	; 					(list 1 1 3)
+	; 					(list 1 2 4)
+	; 					(list 1 3 5)
+	; 				)
+	; 		)
+	; ))
+
+	; (call_entity "howso" "execute_on_subtrainee" (assoc
+	; 	path ["A" "b" "c2"]
+	; 	method "train"
+	; 	payload
+	; 		(assoc
+	; 			features (list "x" "y" "w")
+	; 			cases
+	; 				(list
+	; 					(list 4 4 4)
+	; 					(list 5 5 5)
+	; 				)
+	; 		)
+	; ))
+
+	; (store_entity "./htest.amlg" "howso" "amlg" (false) {flatten (true)})
+
+	(call_entity "howso" "upgrade_trainee" (assoc
+		trainee "htest"
+		root_filepath "../"
+		trainee_amlg_filepath "./"
+	))
+
+	(print (call_entity "howso" "get_hierarchy"))
+
+
+	(call exit_if_failures (assoc msg unit_test_name ))
+)

--- a/unit_tests/ut_h_upgrade_htest.amlg
+++ b/unit_tests/ut_h_upgrade_htest.amlg
@@ -1,88 +1,93 @@
 (seq
 	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
-	(call (load "unit_test_howso.amlg") (assoc name "ut_h_update_htest.amlg"))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_update_htest.amlg" do_return_validation (false)))
 
 	(declare (assoc result (null)))
 
-	; (call_entity "howso" "create_subtrainee" (assoc path ["A"] child_id "A"))
+	(call_entity "howso" "create_subtrainee" (assoc path ["A"] child_id "A"))
 
-	; (call_entity "howso" "create_subtrainee" (assoc path ["A" "b"] child_id "b" ))
+	(call_entity "howso" "create_subtrainee" (assoc path ["A" "b"] child_id "b" ))
 
-	; (call_entity "howso" "create_subtrainee" (assoc path ["A" "b" "c1"] child_id "c1" ))
+	(call_entity "howso" "create_subtrainee" (assoc path ["A" "b" "c1"] child_id "c1" ))
 
-	; (call_entity "howso" "create_subtrainee" (assoc path ["A" "b" "c2"] child_id "c2" ))
+	(call_entity "howso" "create_subtrainee" (assoc path ["A" "b" "c2"] child_id "c2" ))
 
 
-	; (call_entity "howso" "train" (assoc
-	; 	features (list "a" "b" "c")
-	; 	cases
-	; 		(list
-	; 			(list 10 20 30)
-	; 			(list 11 22 33)
-	; 			(list 12 24 36)
-	; 			(list 13 26 39)
-	; 		)
-	; ))
+	(call_entity "howso" "train" (assoc
+		features (list "a" "b" "c")
+		cases
+			(list
+				(list 10 20 30)
+				(list 11 22 33)
+				(list 12 24 36)
+				(list 13 26 39)
+			)
+	))
 
-	; (call_entity "howso" "execute_on_subtrainee" (assoc
-	; 	path ["A"]
-	; 	method "train"
-	; 	payload
-	; 		(assoc
-	; 			features (list "x" "y")
-	; 			cases
-	; 				(list
-	; 					(list 1 1)
-	; 					(list 2 1)
-	; 				)
-	; 		)
-	; ))
+	(call_entity "howso" "execute_on_subtrainee" (assoc
+		path ["A"]
+		method "train"
+		payload
+			(assoc
+				features (list "x" "y")
+				cases
+					(list
+						(list 1 1)
+						(list 2 1)
+					)
+			)
+	))
 
-	; (call_entity "howso" "execute_on_subtrainee" (assoc
-	; 	path ["A" "b"]
-	; 	method "train"
-	; 	payload
-	; 		(assoc
-	; 			features (list "x" "y")
-	; 			cases
-	; 				(list
-	; 					(list 3 3)
-	; 					(list 4 4)
-	; 					(list 5 5)
-	; 				)
-	; 		)
-	; ))
+	(call_entity "howso" "execute_on_subtrainee" (assoc
+		path ["A" "b"]
+		method "train"
+		payload
+			(assoc
+				features (list "x" "y")
+				cases
+					(list
+						(list 3 3)
+						(list 4 4)
+						(list 5 5)
+					)
+			)
+	))
 
-	; (call_entity "howso" "execute_on_subtrainee" (assoc
-	; 	path ["A" "b" "c1"]
-	; 	method "train"
-	; 	payload
-	; 		(assoc
-	; 			features (list "x" "y" "z")
-	; 			cases
-	; 				(list
-	; 					(list 1 1 3)
-	; 					(list 1 2 4)
-	; 					(list 1 3 5)
-	; 				)
-	; 		)
-	; ))
+	(call_entity "howso" "execute_on_subtrainee" (assoc
+		path ["A" "b" "c1"]
+		method "train"
+		payload
+			(assoc
+				features (list "x" "y" "z")
+				cases
+					(list
+						(list 1 1 3)
+						(list 1 2 4)
+						(list 1 3 5)
+					)
+			)
+	))
 
-	; (call_entity "howso" "execute_on_subtrainee" (assoc
-	; 	path ["A" "b" "c2"]
-	; 	method "train"
-	; 	payload
-	; 		(assoc
-	; 			features (list "x" "y" "w")
-	; 			cases
-	; 				(list
-	; 					(list 4 4 4)
-	; 					(list 5 5 5)
-	; 				)
-	; 		)
-	; ))
+	(call_entity "howso" "execute_on_subtrainee" (assoc
+		path ["A" "b" "c2"]
+		method "train"
+		payload
+			(assoc
+				features (list "x" "y" "w")
+				cases
+					(list
+						(list 4 4 4)
+						(list 5 5 5)
+					)
+			)
+	))
 
-	; (store_entity "./htest.amlg" "howso" "amlg" (false) {flatten (true)})
+	(store_entity "./htest.amlg" "howso" "amlg" (false) {flatten (true)})
+
+	;reset howso entity to be blank trainee
+	(call (load "unit_test_howso.amlg")
+		(assoc name "ut_h_update_htest.amlg" skip_init (true) do_return_validation (false))
+	)
 
 	(call_entity "howso" "upgrade_trainee" (assoc
 		trainee "htest"

--- a/unit_tests/ut_h_upgrade_htest.amlg
+++ b/unit_tests/ut_h_upgrade_htest.amlg
@@ -97,6 +97,112 @@
 
 	(print (call_entity "howso" "get_hierarchy"))
 
+	;Checking feature attributes
+	(assign (assoc
+		result
+			(call_entity "howso" "execute_on_subtrainee" (assoc
+				path ["A" "b" "c2"]
+				method "get_feature_attributes"
+				payload {}
+			))
+	))
+	(call keep_result_payload)
+	(print "Feature Attributes of c2 preserved: ")
+	(call assert_same (assoc
+		obs (zip (indices result))
+		exp (zip ["x" "y" "w"])
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "execute_on_subtrainee" (assoc
+				path ["A" "b"]
+				method "get_feature_attributes"
+				payload {}
+			))
+	))
+	(call keep_result_payload)
+	(print "Feature Attributes of b preserved: ")
+	(call assert_same (assoc
+		obs (zip (indices result))
+		exp (zip ["x" "y"])
+	))
+
+	(assign (assoc
+		result (call_entity "howso" "get_feature_attributes" {})
+	))
+	(call keep_result_payload)
+	(print "Feature Attributes of root preserved: ")
+	(call assert_same (assoc
+		obs (zip (indices result))
+		exp (zip ["a" "b" "c"])
+	))
+
+	(call exit_if_failures {msg "Feature Attributes not preserved correctly."})
+
+	;Checking Parent IDs
+	(assign (assoc
+		result
+			(call_entity "howso" "execute_on_subtrainee" (assoc
+				path ["A" "b"]
+				method "debug_label"
+				payload {label "!parentId"}
+			))
+	))
+	(print "Parent of b: ")
+	(call assert_same (assoc
+		obs result
+		exp "A"
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "execute_on_subtrainee" (assoc
+				path ["A" "b" "c1"]
+				method "debug_label"
+				payload {label "!parentId"}
+			))
+	))
+	(print "Parent of c1: ")
+	(call assert_same (assoc
+		obs result
+		exp "b"
+	))
+
+	(call exit_if_failures {msg "Parent Ids not preserved correctly."})
+
+	;Checking num cases
+	(assign (assoc
+		result
+			(call_entity "howso" "execute_on_subtrainee" (assoc
+				path ["A" "b"]
+				method "get_num_training_cases"
+				payload {}
+			))
+	))
+	(call keep_result_payload)
+	(print "Num training cases in b: ")
+	(call assert_same (assoc
+		obs (get result "count")
+		exp 3
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "execute_on_subtrainee" (assoc
+				path ["A" "b" "c2"]
+				method "get_num_training_cases"
+				payload {}
+			))
+	))
+	(call keep_result_payload)
+	(print "Num training cases in c2: ")
+	(call assert_same (assoc
+		obs (get result "count")
+		exp 2
+	))
+
+	(call exit_if_failures {msg "Cases not preserved correctly."})
 
 	(call exit_if_failures (assoc msg unit_test_name ))
 )

--- a/unit_tests/ut_h_upgrade_htest.amlg
+++ b/unit_tests/ut_h_upgrade_htest.amlg
@@ -138,7 +138,10 @@
 		exp (zip ["a" "b" "c"])
 	))
 
-	(call exit_if_failures {msg "Feature Attributes not preserved correctly."})
+	(call exit_if_failures {
+		msg "Feature Attributes not preserved correctly."
+		cleanup_method cleanup_htest
+	})
 
 	;Checking Parent IDs
 	(assign (assoc
@@ -169,7 +172,10 @@
 		exp "b"
 	))
 
-	(call exit_if_failures {msg "Parent Ids not preserved correctly."})
+	(call exit_if_failures {
+		msg "Parent Ids not preserved correctly."
+		cleanup_method cleanup_htest
+	})
 
 	;Checking num cases
 	(assign (assoc
@@ -202,8 +208,12 @@
 		exp 2
 	))
 
-	(call exit_if_failures {msg "Cases not preserved correctly."})
+	(call exit_if_failures {
+		msg "Cases not preserved correctly."
+		cleanup_method cleanup_htest
+	})
 
+	#cleanup_htest
 	(if (= (system "os") "Windows")
 		(system "system" "del htest.amlg")
 

--- a/unit_tests/ut_howso.amlg
+++ b/unit_tests/ut_howso.amlg
@@ -70,6 +70,7 @@
 				"ut_h_constraints.amlg"
 				"ut_h_hierarchy_by_id.amlg"
 				"ut_h_hierarchy_by_name.amlg"
+				"ut_h_upgrade_htest.amlg"
 				"ut_h_weighted_residuals_cont.amlg"
 				"ut_h_weighted_residuals_nom.amlg"
 


### PR DESCRIPTION
Updates `#update_trainee` to account for subtrainees and upgrade them as well in a recursive fashion allowing for the entire horde of Trainees to be upgraded properly. 

Also added a call to `#!ValidateParameters` within `#get_num_training_cases` as it was missing there. This ensures that this method is not called with invalid parameters (any parameters in the case of this label). 

This PR also removes the inactive parameter, `separate_files` from `#upgrade_trainee`. Specifying this parameter after this change will return an error that the `separate_files` parameter is not supported for this label. Simply removing this parameter from the call should resolve the issue.