### PR TITLE
22353: Fixes an issue where warnings regarding analyses using case_weights were given incorrectly

### DIFF
--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -127,7 +127,7 @@
 			))
 
 			;warn if specified weight_feature hasn't been analyzed
-			(and use_case_weights (!= weight_feature (get hyperparam_map (list "paramPath" 2))))
+			(and use_case_weights (!= weight_feature (last (get hyperparam_map "paramPath"))))
 			(accum (assoc
 				warnings
 					(associate (concat

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -194,7 +194,7 @@
 		(call !UpdateCaseWeightParameters)
 
 		;warn if specified weight_feature hasn't been analyzed
-		(if (and use_case_weights (!= weight_feature (get hyperparam_map (list "paramPath" 3))))
+		(if (and use_case_weights (!= weight_feature (last (get hyperparam_map "paramPath"))))
 			(accum (assoc
 				warnings
 					(associate (concat


### PR DESCRIPTION
In a previous change the `paramPath` structure of hyperparameter maps were changed and now the weight feature is not always in the same index, but it should always be the last item.