### PR TITLE
22320: Adds validation to Trainee names to allow only alphanumeric characters on hierarchy operations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,8 @@ Return types of methods should be specified by comments on the assoc with the pa
 | max_size            | Only applicable when `type` is "assoc". Value should be an integer.
 | enum                | Only applicable when `type` is "string". A list of possible values for the string.
 | pattern             | Only applicable when `type` is "string". A string regex pattern that the given value must match on. (It is recommended to include the start of string and end of string symbols in this pattern.)
+| min_length          | Only applicable when `type` is "string". The inclusive minimum length of the given string.
+| max_length          | Only applicable when `type` is "string". The inclusive maximum length of the given string.
 | min                 | Only applicable when `type` is "number". The inclusive minimum value.
 | exclusive_min       | Only applicable when `type` is "number". The exclusive minimum value.
 | max                 | Only applicable when `type` is "number". The inclusive maximum value.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,8 @@ Return types of methods should be specified by comments on the assoc with the pa
 | max_indices         | Only applicable when `type` is "list". Value should be an integer.
 | min_indices         | Only applicable when `type` is "assoc". Value should be an integer.
 | max_size            | Only applicable when `type` is "assoc". Value should be an integer.
-| enum                | Only applicable when `type` is "string". A list of possible values for the string
+| enum                | Only applicable when `type` is "string". A list of possible values for the string.
+| pattern             | Only applicable when `type` is "string". A string regex pattern that the given value must match on. (It is recommended to include the start of string and end of string symbols in this pattern.)
 | min                 | Only applicable when `type` is "number". The inclusive minimum value.
 | exclusive_min       | Only applicable when `type` is "number". The exclusive minimum value.
 | max                 | Only applicable when `type` is "number". The inclusive maximum value.

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -670,8 +670,7 @@
 				(if (contains_index custom_hyperparam_map "subtraineeName")
 					(get custom_hyperparam_map "subtraineeName")
 
-					;TODO: do something a bit more robust/human here
-					(concat "ResidualSubTrainee-" (round (rand) 6))
+					(concat "ResidualSubTrainee" (round (* 100000 (rand)) (null) 0))
 				)
 		))
 

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -11,7 +11,7 @@
 		; 	description "The map showing the full hierarchy of the Trainee and all of its subtrainees."
 		; }
 		(assoc
-			;{type "list" values "string"}
+			;{ref "TraineeNamePath"}
 			;path to this trainee as a list of path labels
 			path_list []
 		)
@@ -33,7 +33,7 @@
 			;{type "string" required (true)}
 			;unique id of trainee
 			id (null)
-			;{type "list" values "string" required (true)}
+			;{ref "TraineeNamePath" required (true)}
 			;list of strings, entity path to parent of trainee
 			entity_path (null)
 		)
@@ -47,13 +47,13 @@
 	#rename_subtrainee
 	(declare
 		(assoc
-			;{type "list" values "string" min_size 1}
+			;{ref "TraineeNamePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to rename
 			path (null)
 			;{type "string"}
 			;id of child trainee to rename. Ignored if path is specified
 			child_id (null)
-			;{type "string" required (true)}
+			;{ref "TraineeName" required (true)}
 			;new path label of child trainee
 			label (null)
 		)
@@ -117,7 +117,7 @@
 			;{type "string" required (true)}
 			;name of method to execute
 			method (null)
-			;{type "list" values "string"}
+			;{ref "TraineeNamePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee for execution of method
 			path (null)
 			;{type "string"}
@@ -168,7 +168,7 @@
 			;{type "string"}
 			;path to the file (optional)
 			filepath (null)
-			;{type "list" values "string" required (true)}
+			;{ref "TraineeNamePath" required (true)}
 			;list of strings specifying the user-friendly path of the child subtrainee to create
 			;including the label of the child as the last value in the path
 			path (null)
@@ -245,7 +245,7 @@
 			;{type "string" required (true)}
 			;name to load (without extension)
 			filename (null)
-			;{type "list" values "string" required (true)}
+			;{ref "TraineeNamePath" required (true)}
 			;list of strings specifying the user-friendly path of the child subtrainee to load
 			;including the label of the child as the last value in the path
 			path (null)
@@ -346,7 +346,7 @@
 			;{type "string" required (true)}
 			;name to store (without extension)
 			filename (null)
-			;{type "list" values "string"}
+			;{ref "TraineeNamePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to save
 			;including the label of the child as the last value in the path
 			path (null)
@@ -408,7 +408,7 @@
 	#delete_subtrainee
 	(declare
 		(assoc
-			;{type "list" values "string"}
+			;{ref "TraineeNamePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to delete
 			;including the label of the child as the last value in the path
 			path (null)
@@ -471,14 +471,14 @@
 		; 	}
 		; }
 		(assoc
-			;{type "list" values "string" required (true)}
+			;{ref "TraineeNamePath" required (true)}
 			;list of strings specifying the resulting destination user-friendly path of the child subtrainee.
 			;including the label of the child as the last value in the path
 			target_path (null)
 			;{type "string" required (true)}
 			;new unique id of copied target trainee
 			target_id (null)
-			;{type "list" values "string"}
+			;{ref "TraineeNamePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to copy.
 			source_path (null)
 			;{type "string"}
@@ -566,14 +566,14 @@
 		; 	}
 		; }
 		(assoc
-			;{type "list" values "string"}
+			;{ref "TraineeNamePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to move cases to.
 			target_path (null)
 			;{type "string"}
 			;id of target trainee to move cases to. Ignored if target_path is specified.
 			;	If neither target_path nor target_id are specified, moves cases to the trainee itself.
 			target_id (null)
-			;{type "list" values "string"}
+			;{ref "TraineeNamePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee from which to move cases.
 			source_path (null)
 			;{type "string"}
@@ -758,7 +758,7 @@
 			;{type "assoc" additional_indices "string"}
 			;map of contained trainee path label to its unique id
 			path_to_id_map (null)
-			;{type "assoc" additional_indices "string"}
+			;{type "assoc" additional_indices {ref "TraineeNamePath"}}
 			;map of contained trainee unique id to its path label
 			id_to_path_map (null)
 			;{type "assoc" additional_indices "boolean"}
@@ -766,6 +766,48 @@
 			is_contained_map (null)
 		)
 		(call !ValidateParameters)
+
+		;need to manually verify the labels in path_to_id_map and is_contained_map are alphanumeric
+		;no mechanism to check the patterns of the indices in the type system
+		(let
+			(assoc
+				invalid_labels_path_to_id_map
+					(filter
+						(lambda
+							(= (null) (substr (current_value) "^[a-zA-Z0-9_]+$"))
+						)
+						(indices path_to_id_map)
+					)
+				invalid_labels_is_contained_map
+					(filter
+						(lambda
+							(= (null) (substr (current_value) "^[a-zA-Z0-9_]+$"))
+						)
+						(indices is_contained_map)
+					)
+			)
+
+			(if (size invalid_labels_path_to_id_map)
+				(conclude (conclude
+					(call !Return (assoc
+						errors [(concat
+							"The following Trainee names are not alphanumeric in \"path_to_id_map\": "
+							(trunc (weave invalid_labels_path_to_id_map ", "))
+						)]
+					))
+				))
+
+				(size invalid_labels_is_contained_map)
+				(conclude (conclude
+					(call !Return (assoc
+						errors [(concat
+							"The following Trainee names are not alphanumeric in \"is_contained_map\": "
+							(trunc (weave invalid_labels_is_contained_map ", "))
+						)]
+					))
+				))
+			)
+		)
 
 		(declare (assoc bump_revision (false) ))
 

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -788,24 +788,24 @@
 			)
 
 			(if (size invalid_labels_path_to_id_map)
-				(conclude (conclude
+				(conclude
 					(call !Return (assoc
 						errors [(concat
 							"The following Trainee names are not alphanumeric in \"path_to_id_map\": "
 							(trunc (weave invalid_labels_path_to_id_map ", "))
 						)]
 					))
-				))
+				)
 
 				(size invalid_labels_is_contained_map)
-				(conclude (conclude
+				(conclude
 					(call !Return (assoc
 						errors [(concat
 							"The following Trainee names are not alphanumeric in \"is_contained_map\": "
 							(trunc (weave invalid_labels_is_contained_map ", "))
 						)]
 					))
-				))
+				)
 			)
 		)
 

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -791,7 +791,7 @@
 				(conclude
 					(call !Return (assoc
 						errors [(concat
-							"The following Trainee names are not alphanumeric in \"path_to_id_map\": "
+							"The following path labels contain invalid characters in \"path_to_id_map\": "
 							(trunc (weave invalid_labels_path_to_id_map ", "))
 						)]
 					))
@@ -801,7 +801,7 @@
 				(conclude
 					(call !Return (assoc
 						errors [(concat
-							"The following Trainee names are not alphanumeric in \"is_contained_map\": "
+							"The following path labels contain invalid characters in \"is_contained_map\": "
 							(trunc (weave invalid_labels_is_contained_map ", "))
 						)]
 					))

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -11,7 +11,7 @@
 		; 	description "The map showing the full hierarchy of the Trainee and all of its subtrainees."
 		; }
 		(assoc
-			;{ref "TraineeNamePath"}
+			;{ref "TraineePath"}
 			;path to this trainee as a list of path labels
 			path_list []
 		)
@@ -47,13 +47,13 @@
 	#rename_subtrainee
 	(declare
 		(assoc
-			;{ref "TraineeNamePath"}
+			;{ref "TraineePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to rename
 			path (null)
 			;{type "string"}
 			;id of child trainee to rename. Ignored if path is specified
 			child_id (null)
-			;{ref "TraineeName" required (true)}
+			;{ref "TraineePathLabel" required (true)}
 			;new path label of child trainee
 			label (null)
 		)
@@ -117,7 +117,7 @@
 			;{type "string" required (true)}
 			;name of method to execute
 			method (null)
-			;{ref "TraineeNamePath"}
+			;{ref "TraineePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee for execution of method
 			path (null)
 			;{type "string"}
@@ -168,7 +168,7 @@
 			;{type "string"}
 			;path to the file (optional)
 			filepath (null)
-			;{ref "TraineeNamePath" required (true)}
+			;{ref "TraineePath" required (true)}
 			;list of strings specifying the user-friendly path of the child subtrainee to create
 			;including the label of the child as the last value in the path
 			path (null)
@@ -245,7 +245,7 @@
 			;{type "string" required (true)}
 			;name to load (without extension)
 			filename (null)
-			;{ref "TraineeNamePath" required (true)}
+			;{ref "TraineePath" required (true)}
 			;list of strings specifying the user-friendly path of the child subtrainee to load
 			;including the label of the child as the last value in the path
 			path (null)
@@ -346,7 +346,7 @@
 			;{type "string" required (true)}
 			;name to store (without extension)
 			filename (null)
-			;{ref "TraineeNamePath"}
+			;{ref "TraineePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to save
 			;including the label of the child as the last value in the path
 			path (null)
@@ -408,7 +408,7 @@
 	#delete_subtrainee
 	(declare
 		(assoc
-			;{ref "TraineeNamePath"}
+			;{ref "TraineePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to delete
 			;including the label of the child as the last value in the path
 			path (null)
@@ -471,14 +471,14 @@
 		; 	}
 		; }
 		(assoc
-			;{ref "TraineeNamePath" required (true)}
+			;{ref "TraineePath" required (true)}
 			;list of strings specifying the resulting destination user-friendly path of the child subtrainee.
 			;including the label of the child as the last value in the path
 			target_path (null)
 			;{type "string" required (true)}
 			;new unique id of copied target trainee
 			target_id (null)
-			;{ref "TraineeNamePath"}
+			;{ref "TraineePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to copy.
 			source_path (null)
 			;{type "string"}
@@ -566,14 +566,14 @@
 		; 	}
 		; }
 		(assoc
-			;{ref "TraineeNamePath"}
+			;{ref "TraineePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee to move cases to.
 			target_path (null)
 			;{type "string"}
 			;id of target trainee to move cases to. Ignored if target_path is specified.
 			;	If neither target_path nor target_id are specified, moves cases to the trainee itself.
 			target_id (null)
-			;{ref "TraineeNamePath"}
+			;{ref "TraineePath"}
 			;list of strings specifying the user-friendly path of the child subtrainee from which to move cases.
 			source_path (null)
 			;{type "string"}
@@ -758,7 +758,7 @@
 			;{type "assoc" additional_indices "string"}
 			;map of contained trainee path label to its unique id
 			path_to_id_map (null)
-			;{type "assoc" additional_indices {ref "TraineeName"}}
+			;{type "assoc" additional_indices {ref "TraineePathLabel"}}
 			;map of contained trainee unique id to its path label
 			id_to_path_map (null)
 			;{type "assoc" additional_indices "boolean"}
@@ -774,14 +774,14 @@
 				invalid_labels_path_to_id_map
 					(filter
 						(lambda
-							(= (null) (substr (current_value) "^[a-zA-Z0-9_]+$"))
+							(= (null) (substr (current_value) "^[^.\\s]+$"))
 						)
 						(indices path_to_id_map)
 					)
 				invalid_labels_is_contained_map
 					(filter
 						(lambda
-							(= (null) (substr (current_value) "^[a-zA-Z0-9_]+$"))
+							(= (null) (substr (current_value) "^[^.\\s]+$"))
 						)
 						(indices is_contained_map)
 					)

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -33,7 +33,7 @@
 			;{type "string" required (true)}
 			;unique id of trainee
 			id (null)
-			;{ref "TraineeNamePath" required (true)}
+			;{type "list" values "string"}
 			;list of strings, entity path to parent of trainee
 			entity_path (null)
 		)
@@ -758,7 +758,7 @@
 			;{type "assoc" additional_indices "string"}
 			;map of contained trainee path label to its unique id
 			path_to_id_map (null)
-			;{type "assoc" additional_indices {ref "TraineeNamePath"}}
+			;{type "assoc" additional_indices {ref "TraineeName"}}
 			;map of contained trainee unique id to its path label
 			id_to_path_map (null)
 			;{type "assoc" additional_indices "boolean"}

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -567,11 +567,31 @@
 											[{ message "The value must be a string."}]
 
 											(and
+												(contains_index specification "min_length")
+												;returns (null) if pattern is not matched
+												(< (size given_value) (get specification "min_length"))
+											)
+											[{ message (concat "The value's length must be at least: " (get specification "min_length") ".")}]
+
+											(and
+												(contains_index specification "max_length")
+												;returns (null) if pattern is not matched
+												(> (size given_value) (get specification "max_length"))
+											)
+											[{ message (concat "The value's length must no greater than: " (get specification "max_length") ".")}]
+
+											(and
 												(contains_index specification "pattern")
 												;returns (null) if pattern is not matched
 												(= (null) (substr given_value (get specification "pattern")))
 											)
-											[{ message "The value does not match the specified pattern."}]
+											[{
+												message
+													(concat
+														"The value does not match the specified pattern: "
+														"\""(get specification "pattern") "\"."
+													)
+											}]
 
 											(and
 												(contains_index specification "enum")

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -567,6 +567,13 @@
 											[{ message "The value must be a string."}]
 
 											(and
+												(contains_index specification "pattern")
+												;returns (null) if pattern is not matched
+												(= (null) (substr given_value (get specification "pattern")))
+											)
+											[{ message "The value does not match the specified pattern."}]
+
+											(and
 												(contains_index specification "enum")
 												(not (contains_value (get specification "enum") given_value))
 											)

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -571,14 +571,14 @@
 												;returns (null) if pattern is not matched
 												(< (size given_value) (get specification "min_length"))
 											)
-											[{ message (concat "The value's length must be at least: " (get specification "min_length") ".")}]
+											[{ message (concat "The value's length must be at least: " (get specification "min_length") " characters.")}]
 
 											(and
 												(contains_index specification "max_length")
 												;returns (null) if pattern is not matched
 												(> (size given_value) (get specification "max_length"))
 											)
-											[{ message (concat "The value's length must no greater than: " (get specification "max_length") ".")}]
+											[{ message (concat "The value's length must no greater than: " (get specification "max_length") " characters.")}]
 
 											(and
 												(contains_index specification "pattern")

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -1892,11 +1892,13 @@
 			(assoc
 				type "list"
 				values {ref "TraineeName"}
+				description "The list of Trainee names that describes the hierarchical path from the Trainee called to the Trainee desired."
 			)
 		TraineeName
 			(assoc
 				type "string"
 				pattern "^[a-zA-Z0-9_]+$"
+				description "The human-readable name of the Trainee. Must contain only alphanumeric characters."
 			)
 	)
 )

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -1849,6 +1849,11 @@
 								values "string"
 								description "A list of possible values when the type is a string."
 							}
+						"pattern"
+							{
+								type "string"
+								description "A regex pattern that the given value must match on."
+							}
 						"required"
 							{
 								type "boolean"
@@ -1882,6 +1887,16 @@
 				type "string"
 				enum ["string" "list" "assoc" "number" "null" "boolean" "any"]
 				description "The string name of the type a value should be."
+			)
+		TraineeNamePath
+			(assoc
+				type "list"
+				values {ref "TraineeName"}
+			)
+		TraineeName
+			(assoc
+				type "string"
+				pattern "^[a-zA-Z0-9_]+$"
 			)
 	)
 )

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -1902,13 +1902,13 @@
 			(assoc
 				type "list"
 				values {ref "TraineePathLabel"}
-				description "The list of Trainee names that describes the hierarchical path from the Trainee called to the Trainee desired."
+				description "A list of human-readable labels describing the hierarchical path of the Trainee."
 			)
 		TraineePathLabel
 			(assoc
 				type "string"
 				pattern "^[^.\\s]+$"
-				description "The human-readable name of the Trainee. Must contain only alphanumeric characters."
+				description "The human-readable label of the Trainee in a hierarchy."
 				max_length 256
 			)
 	)

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -1854,6 +1854,16 @@
 								type "string"
 								description "A regex pattern that the given value must match on."
 							}
+						"min_length"
+							{
+								type "number"
+								description "The inclusive lower limit for the length of a given string."
+							}
+						"max_length"
+							{
+								type "number"
+								description "The inclusive upper limit for the length of a given string."
+							}
 						"required"
 							{
 								type "boolean"
@@ -1888,17 +1898,18 @@
 				enum ["string" "list" "assoc" "number" "null" "boolean" "any"]
 				description "The string name of the type a value should be."
 			)
-		TraineeNamePath
+		TraineePath
 			(assoc
 				type "list"
-				values {ref "TraineeName"}
+				values {ref "TraineePathLabel"}
 				description "The list of Trainee names that describes the hierarchical path from the Trainee called to the Trainee desired."
 			)
-		TraineeName
+		TraineePathLabel
 			(assoc
 				type "string"
-				pattern "^[a-zA-Z0-9_]+$"
+				pattern "^[^.\\s]+$"
 				description "The human-readable name of the Trainee. Must contain only alphanumeric characters."
+				max_length 256
 			)
 	)
 )

--- a/unit_tests/ut_h_hierarchy_by_name.amlg
+++ b/unit_tests/ut_h_hierarchy_by_name.amlg
@@ -102,6 +102,33 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "rename_subtrainee" (assoc
+				path ["invalid"]
+				label "AA--,34"
+			))
+	))
+	(print "Can't rename - non-alphanumeric name: ")
+	(call assert_same (assoc
+		obs (get result (list 1 "code"))
+		exp "invalid"
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "copy_subtrainee" (assoc
+				target_path ["A"]
+				target_id "uniqueid"
+				source_path ["A" "c.-32"]
+			))
+	))
+	(print "Can't copy - non-alphanumeric label in path: ")
+	(call assert_same (assoc
+		obs (get result (list 1 "code"))
+		exp "invalid"
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "rename_subtrainee" (assoc
 				path (list "A" "c")
 				label "b"
 			))

--- a/unit_tests/ut_h_hierarchy_by_name.amlg
+++ b/unit_tests/ut_h_hierarchy_by_name.amlg
@@ -99,6 +99,7 @@
 		exp "Invalid path specified."
 	))
 
+	;alphanumeric validation checks
 	(assign (assoc
 		result
 			(call_entity "howso" "rename_subtrainee" (assoc
@@ -125,6 +126,22 @@
 		obs (get result (list 1 "code"))
 		exp "invalid"
 	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "set_hierarchy_relationships" (assoc
+				is_contained_map
+					{
+						".a3*71" (true)
+					}
+			))
+	))
+	(print "Can't set hierarchy relationships - non-alphanumeric index in is_contained_map: ")
+	(call assert_same (assoc
+		obs (get result 0)
+		exp 0
+	))
+	;end of alphanumeric checks
 
 	(assign (assoc
 		result

--- a/unit_tests/ut_h_hierarchy_by_name.amlg
+++ b/unit_tests/ut_h_hierarchy_by_name.amlg
@@ -104,7 +104,7 @@
 		result
 			(call_entity "howso" "rename_subtrainee" (assoc
 				path ["invalid"]
-				label "AA--,34"
+				label "AA--.34"
 			))
 	))
 	(print "Can't rename - non-alphanumeric name: ")
@@ -122,6 +122,24 @@
 			))
 	))
 	(print "Can't copy - non-alphanumeric label in path: ")
+	(call assert_same (assoc
+		obs (get result (list 1 "code"))
+		exp "invalid"
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "copy_subtrainee" (assoc
+				target_path ["A"]
+				target_id "uniqueid"
+				source_path
+					[
+						"A"
+						(apply "concat" (range (lambda "a") 1 259 1))
+					]
+			))
+	))
+	(print "Can't copy - one too-large label in path: ")
 	(call assert_same (assoc
 		obs (get result (list 1 "code"))
 		exp "invalid"


### PR DESCRIPTION
This PR adds an extra layer of validation to hierarchy operations that specify a Trainee name. These names must contain only alphanumeric characters, so this PR adds logic to validate this for those labels.

This is done by adding new attribute, "pattern", to the type specification for strings; and "min_length" and "max_length" to define size limits for string. This allows the users/devs to specify a specific regex pattern that string values must match as well as length constraints for parameter validation

This wasn't enough though for all names that came through so there are also a couple manual checks added for parameters where Trainee names were given as indices within (assoc)'s.