### PR TITLE
22394: Fixes an issue where features with shared deviations would not function in details that use residuals

### DIFF
--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -35,6 +35,7 @@
 			(assign (assoc
 				residuals_map
 					(call !ExpandResidualValuesToUncertainty (assoc
+						using_shared_deviations (true)
 						feature_residuals_map
 							(call !CalculateFeatureResiduals (assoc
 								features features
@@ -419,6 +420,7 @@
 						)
 
 						(call !ExpandResidualValuesToUncertainty  (assoc
+							using_shared_deviations (true)
 							feature_residuals_map
 								(call !CalculateFeatureResiduals (assoc
 									features features

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -159,7 +159,13 @@
 		)
 
 		;return the output map with capped residual values
-		(assign (assoc output_map (call !ExpandResidualValuesToUncertainty  (assoc feature_residuals_map output_map)) ))
+		(assign (assoc
+			output_map
+				(call !ExpandResidualValuesToUncertainty  (assoc
+					feature_residuals_map output_map
+					using_shared_deviations use_shared_deviations
+				))
+		))
 		(assign
 			"hyperparam_map"
 			["featureResiduals"]

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -142,7 +142,14 @@
 							(/ (* 2 (current_value)) (+ 1 num_training_cases))
 
 							;else set continuous lower residual bound to:  gap / ln(num_cases + 1)
-							(/ (* 2 (current_value)) (log (+ 1 num_training_cases)) )
+							(if (current_value)
+								(/ (* 2 (current_value)) (log (+ 1 num_training_cases)) )
+
+								;if gap is 0, to prevent a 0 smallest residual,
+								;Using n+1, n+2, or n+.5 are all possible considerations of Laplacian smoothing to apply a Bayesian approach for
+								;estimating the probability of having no incorrect predictions.  We chose .5 assuming the Jeffreys prior approach.
+								(/ 1 (+ 0.5 num_training_cases))
+							)
 						)
 					)
 					feature_half_min_gap_map
@@ -170,6 +177,7 @@
 	;parameters:
 	; feature_residuals_map: output assoc from CalculateFeatureResiduals containing a map of feature -> residual value in the 'residual_map' key
 	;					i.e.: { "residual_map" : { "featureA" : 3.4... } }
+	; using_shared_deviations: boolean, default (null). If true, will only use parent features and expand according to the shared deviations groups
 	#!ExpandResidualValuesToUncertainty
 	(set
 		feature_residuals_map
@@ -267,7 +275,10 @@
 
 					;if using shared deviations, map over a reduced residuals map with only features that are not
 					; in a shared deviations group or are the primary keys of a shared deviations group
-					(if (size !sharedDeviationsMap)
+					(if (and
+							using_shared_deviations
+							(size !sharedDeviationsMap)
+						)
 						(remove
 							(get feature_residuals_map "residual_map")
 							!sharedDeviationsNonPrimaryFeatures
@@ -278,7 +289,10 @@
 				)
 			)
 
-			(if (size !sharedDeviationsMap)
+			(if (and
+					(size !sharedDeviationsMap)
+					using_shared_deviations
+				)
 				(call !ExpandForSharedDeviations (assoc compressed_values temp_residual_map))
 				temp_residual_map
 			)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -290,8 +290,8 @@
 			)
 
 			(if (and
-					(size !sharedDeviationsMap)
 					using_shared_deviations
+					(size !sharedDeviationsMap)
 				)
 				(call !ExpandForSharedDeviations (assoc compressed_values temp_residual_map))
 				temp_residual_map


### PR DESCRIPTION
When computing react details that include feature residuals upon features that use shared deviations, these residuals would not be computed correctly.