### PR TITLE
22419: Fixes ut_h_time_series_datetime test to use updated logic

### DIFF
--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -403,43 +403,28 @@
 				(lambda (= "owner" (get series_features (current_value))) )
 				(indices series_features)
 			))
+		first_gen_series_indices (indices (get result [1 "payload" "action_values" 0]))
+		second_gen_series_indices (indices (get result [1 "payload" "action_values" 1]))
 	))
 
-	(call assert_true (assoc
+	;expect a list of 99, 100, 101, but may stop earlier so only check those that were returned
+	(call assert_same (assoc
+		exp (unzip [99 100 101] first_gen_series_indices)
 		obs
-			(contains_value
-				;expect a list of 99, 100, 101, but may stop earlier so any of the later values may be null
-				(list "99100101" "99100(null)" "99(null)(null)")
-				(apply "concat"
-					(map
-						(lambda (unparse (current_value)))
-						(list
-							(get result (list 1 "payload" "action_values" 0 0 value_index))
-							(get result (list 1 "payload" "action_values" 0 1 value_index))
-							(get result (list 1 "payload" "action_values" 0 2 value_index))
-						)
-					)
-				)
+			(map
+				(lambda (get (current_value) value_index))
+				(get result (list 1 "payload" "action_values" 0))
 			)
 	))
 
 	(print "Second Series Context values match exactly as provided: ")
-	(call assert_true (assoc
+	;expect a list of 100, 100.1, 100.5, 101, but may stop earlier so only check those that were returned
+	(call assert_same (assoc
+		exp (unzip [100 100.1 100.5 101] second_gen_series_indices)
 		obs
-			(contains_value
-				;expect a list of 100, 100.1, 100.5, 101, but may stop earlier so any of the later values may be null
-				(list "100100.1100.5101" "100100.1100.5(null)" "100100.1(null)(null)" "100(null)(null)(null)")
-				(apply "concat"
-					(map
-						(lambda (unparse (current_value)))
-						(list
-							(get result (list 1 "payload" "action_values" 1 0 value_index))
-							(get result (list 1 "payload" "action_values" 1 1 value_index))
-							(get result (list 1 "payload" "action_values" 1 2 value_index))
-							(get result (list 1 "payload" "action_values" 1 3 value_index))
-						)
-					)
-				)
+			(map
+				(lambda (get (current_value) value_index))
+				(get result (list 1 "payload" "action_values" 1))
 			)
 	))
 

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -409,11 +409,16 @@
 		obs
 			(contains_value
 				;expect a list of 99, 100, 101, but may stop earlier so any of the later values may be null
-				(list "99100101" "99100null" "99nullnull")
-				(concat
-					(get result (list 1 "payload" "action_values" 0 0 value_index))
-					(get result (list 1 "payload" "action_values" 0 1 value_index))
-					(get result (list 1 "payload" "action_values" 0 2 value_index))
+				(list "99100101" "99100(null)" "99(null)(null)")
+				(apply "concat"
+					(map
+						(lambda (unparse (current_value)))
+						(list
+							(get result (list 1 "payload" "action_values" 0 0 value_index))
+							(get result (list 1 "payload" "action_values" 0 1 value_index))
+							(get result (list 1 "payload" "action_values" 0 2 value_index))
+						)
+					)
 				)
 			)
 	))
@@ -423,12 +428,17 @@
 		obs
 			(contains_value
 				;expect a list of 100, 100.1, 100.5, 101, but may stop earlier so any of the later values may be null
-				(list "100100.1100.5101" "100100.1100.5null" "100100.1nullnull" "100nullnullnull" )
-				(concat
-					(get result (list 1 "payload" "action_values" 1 0 value_index))
-					(get result (list 1 "payload" "action_values" 1 1 value_index))
-					(get result (list 1 "payload" "action_values" 1 2 value_index))
-					(get result (list 1 "payload" "action_values" 1 3 value_index))
+				(list "100100.1100.5101" "100100.1100.5(null)" "100100.1(null)(null)" "100(null)(null)(null)")
+				(apply "concat"
+					(map
+						(lambda (unparse (current_value)))
+						(list
+							(get result (list 1 "payload" "action_values" 1 0 value_index))
+							(get result (list 1 "payload" "action_values" 1 1 value_index))
+							(get result (list 1 "payload" "action_values" 1 2 value_index))
+							(get result (list 1 "payload" "action_values" 1 3 value_index))
+						)
+					)
 				)
 			)
 	))


### PR DESCRIPTION
Amalgam updates changed the behavior when a (null) is used in a (concat) which broke this test. Refactoring the assertion that was broken to use different logic to achieve the same result.