### PR TITLE
22428: Adds `condition_session` parameter to `#move_cases`, MINOR

### DIFF
--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -586,6 +586,9 @@
 			;{ref "Condition"}
 			;assoc of feature->value(s) (no value = must have feature, one value = must equal exactly the value, two values = inclusive between). Ignored if case_indices is specified.
 			condition (assoc)
+			;{type "string"}
+			;session from which to move cases (even if by condition).
+			condition_session (null)
 			;{ref "Precision"}
 			;flag, whether to query for 'exact' matches; if set to 'similar' will move num_cases with the most similar values. Ignored if case_indices is specified.
 			precision "exact"


### PR DESCRIPTION
This parameter was already referenced in the code, but didn't make it into the header when parameter validation was added - effectively disabling the parameter. This PR re-adds the parameter to the labels signature, bringing support to the parameter once more.