### PR TITLE
22442: Adds extra check when determining whether to output "reduce_data" status

### DIFF
--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -817,7 +817,8 @@
 				))
 
 				;else, add the new cases to the total number since the last data reduction
-				;and notify the user if skip_reduce_data is set
+				; and notify the user that a reduce_data call is needed/recommended if skip_reduce_data is set
+				; rather than performing it now.
 				(seq
 					;ensure we only set the reduce_data status output if a reduction is actually necessary.
 					(if (and
@@ -1007,7 +1008,8 @@
 	#!AutoAnalyzeIfNeeded
 	(if (>= !dataMassChangeSinceLastAnalyze !autoAnalyzeThreshold)
 		(if skip_auto_analyze
-			;if skip_auto_analyze, send back "analyze" status so users knows an analyze is needed
+			;if skip_auto_analyze, send back "analyze" status so users knows an analyze is needed/recommended
+			; rather than performing it now.
 			(assign (assoc status_output "analyze"))
 
 			;otherwise do the analyze

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -819,7 +819,11 @@
 				;else, add the new cases to the total number since the last data reduction
 				;and notify the user if skip_reduce_data is set
 				(seq
-					(if skip_reduce_data
+					;ensure we only set the reduce_data status output if a reduction is actually necessary.
+					(if (and
+							(>= (+ !dataMassChangeSinceLastDataReduction batch_size) !autoAblationMaxNumCases)
+							skip_reduce_data
+						)
 						(assign (assoc status_output "reduce_data"))
 					)
 					(accum_to_entities (assoc


### PR DESCRIPTION
Previously, the `"reduce_data"` status would be output if `skip_reduce_data` was set to `(true)`, regardless of whether a data reduction was actually necessary.