### PR TITLE
22488: Fixes an issue in `#react_series` where the first row of a series could only generate null feature values as all data was disallowed from the query

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -554,6 +554,8 @@
 					"series_has_terminators" (false)
 					;flag, set to true if a series must end on a terminator value
 					"stop_on_terminator" (false)
+					;the minimum time to bound queries including the time feature below when using a universal time feature
+					"minimum_time_bound" (null)
 				)
 
 			;list of supported details for react series

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -459,6 +459,15 @@
 			)
 		)
 
+		(if (and !tsTimeFeature !tsTimeFeatureUniversal)
+			(call !UpdateMinimumTimeBound (assoc
+				hyperparam_map
+					(call !GetHyperparameters (assoc
+						feature (null)
+					))
+			))
+		)
+
 		;if auto ablation is enabled or the user has specifically requested to cache influence weight entropies, do so
 		(if
 			!autoAblationEnabled
@@ -893,6 +902,12 @@
 			weight_feature weight_feature
 			use_case_weights use_case_weights
 		))
+
+		(if (and !tsTimeFeature !tsTimeFeatureUniversal)
+			(call !UpdateMinimumTimeBound (assoc
+				hyperparam_map baseline_hyperparameter_map
+			))
+		)
 	)
 
 	;updates baseline_hyperparameter_map

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -461,10 +461,7 @@
 
 		(if (and !tsTimeFeature !tsTimeFeatureUniversal)
 			(call !UpdateMinimumTimeBound (assoc
-				hyperparam_map
-					(call !GetHyperparameters (assoc
-						feature (null)
-					))
+				hyperparam_map (call !GetHyperparameters (assoc feature (null) ))
 			))
 		)
 

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1381,5 +1381,33 @@
 				use_case_weights use_case_weights
 			))
 		)
+
+		;when doing time-series flows, the minimum time bound needs to be defined
+		(if (and
+				!tsTimeFeature
+				!tsTimeFeatureUniversal
+				(not (get !tsModelFeaturesMap "minimum_time_bound"))
+			)
+			#!UpdateMinimumTimeBound
+			;update "minimum_time_bound" which is the stored minimum time value that can be used as an upper bound
+			;in queries when the time feature is universal
+			;needs "hyperparam_map"
+			(assign_to_entities (assoc
+				!tsModelFeaturesMap
+					(set
+						!tsModelFeaturesMap
+						["minimum_time_bound"]
+						(retrieve_from_entity
+							(last
+								(contained_entities (list
+									(query_exists !tsTimeFeature)
+									(query_min !tsTimeFeature (get hyperparam_map "k"))
+								))
+							)
+							!tsTimeFeature
+						)
+					)
+			))
+		)
 	)
 )

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1388,10 +1388,10 @@
 				!tsTimeFeatureUniversal
 				(not (get !tsModelFeaturesMap "minimum_time_bound"))
 			)
-			#!UpdateMinimumTimeBound
 			;update "minimum_time_bound" which is the stored minimum time value that can be used as an upper bound
 			;in queries when the time feature is universal
 			;needs "hyperparam_map"
+			#!UpdateMinimumTimeBound
 			(assign_to_entities (assoc
 				!tsModelFeaturesMap
 					(set

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -628,7 +628,10 @@
 	#!ComputeTimeSeriesFilterQuery
 	(if !tsTimeFeatureUniversal
 		;if time feature is universal, only consider cases that are not in the future
-		(list (query_less_or_equal_to !tsTimeFeature (get context_map !tsTimeFeature)) )
+		(list (query_less_or_equal_to
+			!tsTimeFeature
+			(max (get context_map !tsTimeFeature) (get !tsModelFeaturesMap "minimum_time_bound"))
+		))
 
 		;else not universal and only applies to this specific series, if series IDs are provided
 		(if

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -1143,6 +1143,7 @@
 			!nominalClassProbabilitiesMap (assoc)
 			!expectedValuesMap (assoc)
 			!featureMarginalStatsMap (assoc)
+			!tsModelFeaturesMap (set !tsModelFeaturesMap ["minimum_time_bound"] (null))
 		))
 	)
 


### PR DESCRIPTION
When doing series generation with a universal time feature, a situation could often arise where the first row of a series would generate many null values as the time value generated would be before that of any data in the model. In this case, the internal queries to populate other feature values would restrict the use of cases with time values larger than that of the context, which would be all the training data in this context.

Here lies a fix that puts a minimum bound on how restrictive this logic can be. Specifically, the model will now always have access to at least the K'th lowest time-value in the trained data.