### PR TITLE
22527: Remove context_features, context_values, action_values, case_indices, and leave_case_out parameters from #react_series and #single_react_series

### DIFF
--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -381,7 +381,7 @@
 		)
 
 		(declare (assoc
-			all_contexts (append context_features series_context_features)
+			all_contexts (append series_context_features)
 			n_samples
 				(if (size series_context_values)
 					(size series_context_values)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -381,7 +381,7 @@
 		)
 
 		(declare (assoc
-			all_contexts (append series_context_features)
+			all_contexts series_context_features
 			n_samples
 				(if (size series_context_values)
 					(size series_context_values)

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -362,7 +362,7 @@
 								allow_nulls allow_nulls
 								context_features context_features_param
 								context_values context_values_param
-								action_features (list (get ordered_action_features (current_index 3)))
+								action_features (list action_feature)
 							))
 					))
 

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -538,7 +538,7 @@
 		)
 
 		;prep time series parameters if it's a time series model
-		(if (retrieve_from_entity "!tsTimeFeature")
+		(if !tsTimeFeature
 			(call !PrepTimeSeriesFeatures)
 		)
 

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -46,17 +46,8 @@
 			;	continue_series flag will be ignored and treated as true if this value is specified.
 			continue_series_values (null)
 			;{type "list" values "string"}
-			;list of feature names corresponding to values in each row of context_values
-			context_features (list)
-			;{type "list"}
-			;list of context feature values for non time-series features
-			context_values (list)
-			;{type "list" values "string"}
 			;list of feature names corresponding to values in each row of action_values
 			action_features (list)
-			;{type "list"}
-			;list of predicted feature values for non time-series features
-			action_values (list)
 			;{type "list" values "string"}
 			;list of action features whose values should be computed from the resulting last row in series, in the specified
 			;	order. Must be a subset of action_features.
@@ -161,8 +152,8 @@
 		;Don't allow duplicates/overlap of context features by checking if all the context features appended
 		;together are more than just the uniques between them
 		(if (>
-				(size (append initial_features context_features series_context_features))
-				(size (values (append initial_features context_features series_context_features) (true) ))
+				(size (append initial_features series_context_features))
+				(size (values (append initial_features series_context_features) (true) ))
 			)
 			(conclude
 				(call !Return (assoc
@@ -192,7 +183,7 @@
 			hyperparam_map
 				(call !GetHyperparameters (assoc
 					feature (null)
-					context_features context_features
+					context_features series_context_features
 					weight_feature weight_feature
 				))
 		))
@@ -276,24 +267,18 @@
 				continue_series_features continue_series_features
 				continue_series_values continue_series_values
 
-				context_features context_features
-				context_values context_values
 				action_features action_features
-				action_values action_values
 				derived_action_features derived_action_features
 				derived_context_features derived_context_features
 				series_context_features series_context_features
 				series_context_values series_context_values
 				details details
 				extra_features extra_features
-				ignore_case ignore_case
-				case_indices case_indices
 				substitute_output substitute_output
 				input_is_substituted input_is_substituted
 				use_case_weights use_case_weights
 				weight_feature weight_feature
 				rand_seed rand_seed
-				leave_case_out leave_case_out
 
 				desired_conviction desired_conviction
 				use_regional_model_residuals use_regional_model_residuals
@@ -363,17 +348,8 @@
 			;time step values at which to end synthesis for each series, applicable only for time series.
 			final_time_steps (null)
 			;{type "list" values "string"}
-			;list of feature names corresponding to values in each row of context_values
-			context_features (list)
-			;{type "list" values {type "list"}}
-			;2d-list of context feature values for non time-series features, one list is used per series.
-			context_values (null)
-			;{type "list" values "string"}
 			;list of feature names corresponding to values in each row of action_values
 			action_features (list)
-			;{type "list" values {type "list"}}
-			;2d-list of predicted feature values for non time-series features, one list is used per series.
-			action_values (list)
 			;{type "list" values "string"}
 			;list of context features whose values should be computed from the entire series in the specified order.
 			;	Must be different than context_features.
@@ -416,15 +392,12 @@
 			;total number of series to generate, for generative reacts.
 			;
 			;	 All of the following parameters, if specified, must be either length of 1 or equal to the length of
-			;	context_values/case_indices for discriminative reacts, and num_series_to_generate for generative reacts.
+			;	series_context_values for discriminative reacts, and num_series_to_generate for generative reacts.
 			;
 			num_series_to_generate (null)
 			;{ref "ReactDetails"}
 			;see the description for the details parameter of #react
 			details (null)
-			;{type "boolean"}
-			;flag, if set to true and specified along with case_indices, will set ignore_case to the one specified by case_indices.
-			leave_case_out (null)
 			;{type "boolean"}
 			;flag, if true order of generated feature values will match the order of features
 			ordered_by_specified_features (null)
@@ -432,11 +405,6 @@
 			;If true will exclude sensitive features whose values will be
 			;	replaced after synthesis from uniqueness check.
 			exclude_novel_nominals_from_uniqueness_check (null)
-			;{ref "CaseIndices"}
-			;pair (list) of session id and index, where index is the original 0-based session_training_index of the case as it was
-			;			trained into the session. If this case does not exist, discriminative react outputs null, generative react ignores it.
-			case_indices (null)
-
 			;{type "boolean"}
 			;flag, if false uses model feature residuals, if true recalculates regional model residuals.
 			use_regional_model_residuals (true)
@@ -479,11 +447,8 @@
 					(if (!= (null) desired_conviction)
 						num_series_to_generate
 
-						(!= (null) context_values)
-						(size context_values)
-
-						(!= (null) case_indices)
-						(size case_indices)
+						(!= (null) series_context_values)
+						(size series_context_values)
 
 						(!= (null) initial_values)
 						(size initial_values)
@@ -496,10 +461,6 @@
 
 		;validate parameters
 		(declare (assoc invalid_react_parameters (false) ))
-
-		(call !ValidateBatchReactParameter (assoc param context_values))
-		(call !ValidateBatchReactParameter (assoc param case_indices))
-		(call !ValidateBatchReactParameter (assoc param action_values))
 
 		(call !ValidateBatchReactParameter (assoc param initial_values))
 		(call !ValidateBatchReactParameter (assoc param series_stop_maps))
@@ -543,8 +504,8 @@
 		;Don't allow duplicates/overlap of context features by checking if all the context features appended
 		;together are more than just the uniques between them
 		(if (>
-				(size (append initial_features context_features series_context_features))
-				(size (values (append initial_features context_features series_context_features) (true) ))
+				(size (append initial_features series_context_features))
+				(size (values (append initial_features series_context_features) (true) ))
 			)
 			(conclude
 				(call !Return (assoc
@@ -670,24 +631,18 @@
 				continue_series_features continue_series_features
 				continue_series_values continue_series_values
 
-				context_features context_features
-				context_values context_values
 				action_features action_features
-				action_values action_values
 				derived_action_features derived_action_features
 				derived_context_features derived_context_features
 				series_context_features series_context_features
 				series_context_values series_context_values
 				details details
 				extra_features extra_features
-				ignore_case ignore_case
-				case_indices case_indices
 				substitute_output substitute_output
 				input_is_substituted input_is_substituted
 				use_case_weights use_case_weights
 				weight_feature weight_feature
 				rand_seed rand_seed
-				leave_case_out leave_case_out
 				num_reacts num_reacts
 
 				desired_conviction desired_conviction

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -522,7 +522,7 @@
 			hyperparam_map
 				(call !GetHyperparameters (assoc
 					feature (null)
-					context_features context_features
+					context_features series_context_features
 					weight_feature weight_feature
 				))
 		))

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1441,20 +1441,16 @@
 					context_features react_context_features
 					context_values (unzip current_case_map react_context_features)
 					action_features action_features
-					action_values action_values
 					;do not derive anything during this react
 					derived_action_features (list)
 					derived_context_features (list)
 					details (if output_details details)
 					extra_features (append extra_features derived_action_features)
-					ignore_case ignore_case
-					case_indices case_indices
 					substitute_output substitute_output
 					input_is_substituted input_is_substituted
 					use_case_weights use_case_weights
 					weight_feature weight_feature
 					rand_seed rand_seed
-					leave_case_out leave_case_out
 
 					desired_conviction desired_conviction
 					use_regional_model_residuals use_regional_model_residuals

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -203,6 +203,7 @@
 				(append
 					(zip derived_context_features)
 					(zip derived_action_features)
+					(zip action_features)
 					(if (size series_context_values)
 						(zip series_context_features (first series_context_values))
 						(assoc)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -23,9 +23,6 @@
     (declare
         (assoc
             ;if any of these are length of 1, the index will be 0 to pull the values and apply to all reacts
-            single_context (= 1 (size context_values))
-            single_action (= 1 (size action_values))
-            single_session (= 1 (size case_indices))
             single_initial (= 1 (size initial_values))
             single_stop_map (= 1 (size series_stop_maps))
             single_max_length (= 1 (size max_series_lengths))
@@ -36,8 +33,6 @@
         )
 
         ;these lists must be either a list of lists or null; if it's an empty list, treat it as null
-        (if (= (list) context_values) (assign (assoc context_values (null))) )
-        (if (= (list) action_values) (assign (assoc action_values (null))) )
         (if (= (list) initial_values) (assign (assoc initial_values (null))) )
         (if (= (list) series_stop_maps) (assign (assoc series_stop_maps (null))) )
 
@@ -85,9 +80,6 @@
 							initial_index (if single_initial 0 (current_index 1))
 							stop_map_index (if single_stop_map 0 (current_index 1))
 							max_length_index (if single_max_length 0 (current_index 1))
-							context_index (if single_context 0 (current_index 1))
-							action_index (if single_action 0 (current_index 1))
-							session_index (if single_session 0 (current_index 1))
 							react_rand_seed (if rand_seed (get rand_seed (current_index 1)))
 							continue_index (if single_continue_series 0 (current_index 1))
 							react_session (null)
@@ -97,8 +89,6 @@
 
  						;get the corresponding parameters by the index, values will be null if not specified, but must be defaulted to an empty list/assoc
 						(declare (assoc
-							react_context_values (if context_values (get context_values context_index) (list))
-							react_action_values (if action_values (get action_values action_index) (list))
 							react_initial_values (if initial_values (get initial_values initial_index) (list))
 							react_series_stop_map (if series_stop_maps (get series_stop_maps stop_map_index) (assoc))
 							react_continue_values (if continue_series_values (get continue_series_values continue_index) (null))
@@ -107,11 +97,6 @@
 							react_max_series_length (get max_series_lengths max_length_index)
 						))
 
-						;if one of these is provided, both of them must be
-						(if case_indices
-							(assign (assoc react_case_index (get case_indices session_index) ))
-						)
-
 						;Note: will need to pull this entire map out and store into its own variable to pull individual ReactSeries
 						; keys (i.e,. "action_values") once details are added to ReactSeries output
 						(get
@@ -119,9 +104,6 @@
 								initial_values react_initial_values
 								series_stop_map react_series_stop_map
 								max_series_length react_max_series_length
-								context_values react_context_values
-								action_values react_action_values
-								case_indices react_case_index
 								rand_seed react_rand_seed
 								series_context_values react_series_context_values
 								output_new_series_ids output_new_series_ids
@@ -131,19 +113,16 @@
 								continue_series_values react_continue_values
 
 								initial_features initial_features
-								context_features context_features
 								series_context_features series_context_features
 								action_features action_features
 								derived_action_features derived_action_features
 								derived_context_features derived_context_features
 								details details
 								extra_features extra_features
-								ignore_case ignore_case
 								substitute_output substitute_output
 								input_is_substituted input_is_substituted
 								use_case_weights use_case_weights
 								weight_feature weight_feature
-								leave_case_out leave_case_out
 
 								desired_conviction desired_conviction
 								use_regional_model_residuals use_regional_model_residuals
@@ -224,11 +203,6 @@
 				(append
 					(zip derived_context_features)
 					(zip derived_action_features)
-					(if (size action_values)
-						(zip action_features action_values)
-						(zip action_features)
-					)
-					(zip context_features context_values)
 					(if (size series_context_values)
 						(zip series_context_features (first series_context_values))
 						(assoc)
@@ -255,7 +229,7 @@
 			;assoc of of all features -> feature values for the current series case
 			current_case_map (null)
 			;all features that are used as contexts
-			all_context_features (append context_features derived_context_features series_context_features)
+			all_context_features (append derived_context_features series_context_features)
 			;context features used for each series ract, usually same as all_context_features except for the initial react
 			react_context_features (list)
 			;store output of react
@@ -275,7 +249,7 @@
 			use_initial_context_features (false)
 			;flag if there are values to condition each row of the series
 			has_series_context_values (size series_context_values)
-			user_specified_context_features (append context_features series_context_features)
+			user_specified_context_features series_context_features
 
 			;features used for uniqueness validation should not include id features
 			output_features_no_ids (if (!= "no" generate_new_cases) (indices (remove (zip output_features) (get !tsModelFeaturesMap "series_id_features"))) )
@@ -493,7 +467,6 @@
 					;update initial map to be the stationary context overwritten by the provided initial values
 					initial_features_map
 						(append
-							(zip context_features context_values)
 							(if has_series_context_values
 								(zip series_context_features (first series_context_values))
 								(assoc)

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -182,8 +182,8 @@
 				initial_features (list ".series_progress")
 				initial_values (list 0)
 
-				context_features (list ".series_progress")
-				context_values (list 0)
+				series_context_features (list ".series_progress")
+				series_context_values [ [0] ]
 
 				feature_bounds_map (assoc "value" (assoc "max" 150))
 				series_stop_map  (assoc "value" (assoc "max" 108  ) )


### PR DESCRIPTION
Remove context_features, context_values, action_values, case_indices, and leave_case_out parameters from both versions of react_series

NOTE: this is not merging into main, but a feature branch for the larger collection of react_series API changes.