### PR TITLE
22568: Fixes an issue where the series progress prediction uses too little of available context in TS forecasting

### DIFF
--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1320,7 +1320,7 @@
 												;the "root" lag/delta features are in "delta_features" as well
 												;but have no ts_order defined
 												(not (contains_index (get !featureAttributes (current_value)) "ts_order"))
-												(<= (get !featureAttributes [(current_value 1) "ts_order"]) last_series_index)
+												(<= (get ts_feature_lag_amount_map (current_value)) last_series_index)
 											)
 											(contains_value features (current_value))
 										))
@@ -1330,7 +1330,7 @@
 									(filter
 										(lambda (and
 											(!= time_lag_feature_name (current_value))
-											(<= (get !featureAttributes [(current_value 1) "max_row_lag"]) last_series_index)
+											(<= (get ts_feature_lag_amount_map (current_value)) last_series_index)
 											(contains_value features (current_value))
 										))
 										(get !tsModelFeaturesMap "lag_features")
@@ -1338,7 +1338,7 @@
 									;rates that are populated based on last series index
 									(filter
 										(lambda (and
-											(<= (get !featureAttributes [(current_value 1) "ts_order"]) last_series_index)
+											(<= (get ts_feature_lag_amount_map (current_value)) last_series_index)
 											(contains_value features (current_value))
 										))
 										(get !tsModelFeaturesMap "rate_features")

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1303,13 +1303,46 @@
 					(assoc
 						initial_progress_context_features
 							(let
-								(assoc time_delta_feature_name (concat "." !tsTimeFeature "_delta_1") )
+								(assoc
+									time_delta_feature_name (concat "." !tsTimeFeature "_delta_1")
+									time_lag_feature_name (concat "." !tsTimeFeature "_lag_1")
+								)
+								;use all value, delta, and rate features to determine initial series progress
+								;exclude time feature (and its derived features)
 								(append
-									;use all value, delta, and rate features to determine initial series progress
-									;exclude time feature (and delta)
+									;derived action features that are not the time feature
 									(filter (lambda (!= !tsTimeFeature (current_value))) derived_action_features)
-									(filter (lambda (!= time_delta_feature_name (current_value))) (get !tsModelFeaturesMap "delta_features"))
-									(get !tsModelFeaturesMap "rate_features")
+									;non-time-deltas that are populated based on last series index
+									(filter
+										(lambda (and
+											(!= time_delta_feature_name (current_value))
+											(or
+												;the "root" lag/delta features are in "delta_features" as well
+												;but have no ts_order defined
+												(not (contains_index (get !featureAttributes (current_value)) "ts_order"))
+												(<= (get !featureAttributes [(current_value 1) "ts_order"]) last_series_index)
+											)
+											(contains_value features (current_value))
+										))
+										(get !tsModelFeaturesMap "delta_features")
+									)
+									;non-time-lags that are populated based on last series index
+									(filter
+										(lambda (and
+											(!= time_lag_feature_name (current_value))
+											(<= (get !featureAttributes [(current_value 1) "max_row_lag"]) last_series_index)
+											(contains_value features (current_value))
+										))
+										(get !tsModelFeaturesMap "lag_features")
+									)
+									;rates that are populated based on last series index
+									(filter
+										(lambda (and
+											(<= (get !featureAttributes [(current_value 1) "ts_order"]) last_series_index)
+											(contains_value features (current_value))
+										))
+										(get !tsModelFeaturesMap "rate_features")
+									)
 								)
 							)
 					)


### PR DESCRIPTION
TS forecasting used an initial series progress prediction that did not properly utilize available lag features, this fixes that.