### PR TITLE
22551: Renames 'initial_values'/'initial_features' to 'series_id_features'/'series_id_values' and adds 'leave_series_out' flag

### DIFF
--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -381,7 +381,7 @@
 		)
 
 		(declare (assoc
-			all_contexts (append context_features series_context_features)
+			all_contexts (append series_context_features)
 			n_samples
 				(if (size series_context_values)
 					(size series_context_values)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -381,7 +381,7 @@
 		)
 
 		(declare (assoc
-			all_contexts (append series_context_features)
+			all_contexts series_context_features
 			n_samples
 				(if (size series_context_values)
 					(size series_context_values)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -331,16 +331,6 @@
 	)
 
 	;automatically prepare inputs for BatchReactSeries for a time series model and outputs an updated assoc of react parameters.
-	;Ouputs null if no prep is needed and a string message if there was a validation error. On success, outputs:
-	; (assoc
-	;	"action_features" action_features - list of features
-	;	"initial_features" initial_features - list of features
-	;	"initial_values" initial_values - list of list of values
-	;	"derived_action_features" derived_action_features - list of features
-	;	"derived_context_features" derived_context_features - list of features
-	;	"series_stop_maps" series_stop_maps - list of assocs
-	; )
-	;
 	;parameters:
 	; init_time_steps: optional, time step values at which to begin synthesis
 	; final_time_steps:  optional, time step values at which to end synthesis
@@ -393,114 +383,111 @@
 				)
 		))
 
-		;The default initial features/values set the `start` feature to true.
-		(if (= 0 (size initial_features) (size initial_values))
-			;if all id features should be new, we do not need to retain IDs
-			(if output_new_series_ids
+		;if generating new series ids or series ids are given, only initial series progress of zero is needed
+		(if (or output_new_series_ids (size series_id_values))
+			(assign (assoc
+				initial_features (list ".series_progress")
+				initial_values (list (list 0.0))
+			))
+
+			;else if we want to retain the existing IDs, we must specify them as
+			;initial features (and matching initial values).
+			(let
+				(assoc
+					all_contexts_set (zip all_contexts)
+					series_id_features (list)
+				)
+
 				(assign (assoc
-					initial_features (list ".series_progress")
-					initial_values (list (list 0.0))
+					;Only ID features which are not already specified as contexts should be in initial values
+					series_id_features
+						(filter
+							(lambda (not (contains_index all_contexts_set (current_value)) ) )
+							(get !tsModelFeaturesMap "series_id_features")
+						)
 				))
 
-				;else if we want to retain the existing IDs, we must specify them as
-				;initial features (and matching initial values).
-				(let
-					(assoc
-						all_contexts_set (zip all_contexts)
-						series_id_features (list)
-					)
-
-					(assign (assoc
-						;Only ID features which are not already specified as contexts should be in initial values
-						series_id_features
-							(filter
-								(lambda (not (contains_index all_contexts_set (current_value)) ) )
-								(get !tsModelFeaturesMap "series_id_features")
-							)
-					))
-
-					;ID features may be in one of the context lists
-					;(series_context or context features). It's possible that no IDs actually need to be set as initial.
-					(if (size series_id_features)
-						(let
-							(assoc
-								initial_values_list
-									;if continuing an untrained series, use the id values from the specified data
-									(if (size continue_series_values)
-										(map
-											(lambda
-												;only keep the series id values
-												(unzip
-													;create an assoc of features -> values from first row of series
-													(zip continue_series_features (first (current_value)))
-													series_id_features
-												)
-											)
-											;list of lists of values
-											continue_series_values
-										)
-
-										;else pull all unique id feature combos from dataset and sample n_samples worth
-										(map
-											(lambda
-												;a list of feature values for each unique conjuction
-												;each item in the list if there were two series id features would look like so:
-												;(list 12345 800)
-												(map
-													(lambda
-														;covnvert value back to number if feature is non-string
-														(if (contains_index !numericNominalFeaturesMap (get series_id_features (current_index)))
-															(+ (current_value))
-															;else leave id as string
-															(current_value)
-														)
-													)
-													(parse (current_value))
-												)
-											)
-
-											;unique conjuctions of feature values for all the series features in an unparsed list (string) format
-											;each item in the list if there were two series id features would look like so: "(list 12345 800)"
-											(values
-												(map
-													(lambda
-														(unparse (retrieve_from_entity (current_value) series_id_features))
-													)
-													(call !AllCases)
-												)
-												(true)
-											)
-										)
-									)
-							)
-
-							(assign (assoc
-								initial_values_list
-									;when explicitly provided a list of untrained series to continue, keep that list
-									(if (size continue_series_values)
-										initial_values_list
-
-										;keeping n_samples worth of ids, sample randomly with replacement
-										(rand initial_values_list n_samples)
-									)
-								initial_features (append (list ".series_progress") series_id_features)
-							))
-
-							(assign (assoc
-								initial_values
+				;ID features may be in one of the context lists
+				;(series_context or context features). It's possible that no IDs actually need to be set as initial.
+				(if (size series_id_features)
+					(let
+						(assoc
+							initial_values_list
+								;if continuing an untrained series, use the id values from the specified data
+								(if (size continue_series_values)
 									(map
-										(lambda (append (list 0.0) (current_value)) )
-										initial_values_list
+										(lambda
+											;only keep the series id values
+											(unzip
+												;create an assoc of features -> values from first row of series
+												(zip continue_series_features (first (current_value)))
+												series_id_features
+											)
+										)
+										;list of lists of values
+										continue_series_values
 									)
-							))
+
+									;else pull all unique id feature combos from dataset and sample n_samples worth
+									(map
+										(lambda
+											;a list of feature values for each unique conjuction
+											;each item in the list if there were two series id features would look like so:
+											;(list 12345 800)
+											(map
+												(lambda
+													;covnvert value back to number if feature is non-string
+													(if (contains_index !numericNominalFeaturesMap (get series_id_features (current_index)))
+														(+ (current_value))
+														;else leave id as string
+														(current_value)
+													)
+												)
+												(parse (current_value))
+											)
+										)
+
+										;unique conjuctions of feature values for all the series features in an unparsed list (string) format
+										;each item in the list if there were two series id features would look like so: "(list 12345 800)"
+										(values
+											(map
+												(lambda
+													(unparse (retrieve_from_entity (current_value) series_id_features))
+												)
+												(call !AllCases)
+											)
+											(true)
+										)
+									)
+								)
 						)
 
-						;else
 						(assign (assoc
-							initial_features (list ".series_progress")
-							initial_values (list (list 0.0))
+							initial_values_list
+								;when explicitly provided a list of untrained series to continue, keep that list
+								(if (size continue_series_values)
+									initial_values_list
+
+									;keeping n_samples worth of ids, sample randomly with replacement
+									(rand initial_values_list n_samples)
+								)
+							initial_features (append (list ".series_progress") series_id_features)
+						))
+
+						(assign (assoc
+							initial_values
+								(map
+									(lambda (append (list 0.0) (current_value)) )
+									initial_values_list
+								)
 						))
 					)
+
+					;else
+					(assign (assoc
+						initial_features (list ".series_progress")
+						initial_values (list (list 0.0))
+					))
 				)
 			)
 		)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -115,6 +115,7 @@
 							ordered_by_specified_features ordered_by_specified_features
 							generate_new_cases "no"
 							preserve_feature_values preserve_feature_values
+							holdout_queries holdout_queries
 						))
 				))
 

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -839,6 +839,7 @@
 			preserve_feature_values (list)
 			new_case_threshold "min"
 			pre_generated_uniques_map (null)
+			holdout_queries (list)
 		)
 
 		(if (!= (null) rand_seed)
@@ -941,6 +942,7 @@
 									original_substitute_output substitute_output
 									substitute_output substitute_output
 									current_attempt 0
+									custom_extra_filtering_queries holdout_queries
 								))
 						))
 					)
@@ -981,6 +983,7 @@
 									original_substitute_output substitute_output
 									substitute_output substitute_output
 									current_attempt (+ 1 (current_index 2))
+									custom_extra_filtering_queries holdout_queries
 								))
 						))
 
@@ -1079,6 +1082,7 @@
 									force_targetless (true)
 									ignore_case (null)
 									hyperparam_map hyperparam_map
+									custom_extra_filtering_queries holdout_queries
 								))
 						))
 					)
@@ -1125,6 +1129,7 @@
 							preserve_feature_values preserve_feature_values
 							new_case_threshold new_case_threshold
 							allow_nulls allow_nulls
+							filtering_queries holdout_queries
 						))
 				)
 

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -362,7 +362,7 @@
 								allow_nulls allow_nulls
 								context_features context_features_param
 								context_values context_values_param
-								action_features (list (get ordered_action_features (current_index 3)))
+								action_features (list action_feature)
 							))
 					))
 

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -33,6 +33,10 @@
 	;   			case weights will be used if the trainee has them.
 	; has_dependent_features: flag, defaults to !hasDependentFeatures, when false forces react with no dependencies
 	;
+	; filtering_queries: for details, caching filtering queries and the local candidate cases map
+	; the list of white and black-list queries to filter down the whole dataset prior to running query_nearest;
+	; such as query_not_in_entity_list on ignore_case when it's specifies
+	;
 	;returns:
 	; if details is not specified returns the react object { 'action_values': [values of the actions matching action_features] }
 	; otherwise additionally returns the appropriate requested audit data in the react object as well
@@ -64,6 +68,7 @@
 			new_case_threshold "min"
 			has_dependent_features !hasDependentFeatures
 			impute_react (false)
+			filtering_queries (list)
 
 			;local variables, should not be passed in as a parameter
 			valid_weight_feature (false)
@@ -242,11 +247,6 @@
 					(and (= (assoc) (get_type details)) (get details "influential_cases"))
 					(and (= (assoc) (get_type details)) (get details "boundary_cases"))
 				)
-
-			;for details, caching filtering queries and the local candidate cases map
-			;the list of white and black-list queries to filter down the whole dataset prior to running query_nearest;
-			;such as query_not_in_entity_list on ignore_case when it's specified
-			filtering_queries (list)
 
 			;cached result map of candidate cases -> weights from the reaction, can be re-used by some details
 			cached_candidate_cases_map (null)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -112,6 +112,10 @@
 			;flag, default is true, only applicable if a substitution value map has been set. If set to false, will not substitute categorical feature values.
 			substitute_output (true)
 			;{type "boolean"}
+			;flag, default is true. if true and series IDs are specified with series_id_values, then that series' cases will be held out of queries made within the
+			;react_series call.
+			leave_series_out (true)
+			;{type "boolean"}
 			;flag, if set to true assumes provided categorical (nominal or ordinal) feature values already been substituted.
 			input_is_substituted (false)
 			;{ref "GenerateNewCases"}
@@ -282,6 +286,7 @@
 				substitute_output substitute_output
 				input_is_substituted input_is_substituted
 				use_case_weights use_case_weights
+				leave_series_out leave_series_out
 				weight_feature weight_feature
 				rand_seed rand_seed
 
@@ -438,6 +443,10 @@
 			;flag, default is true, only applicable if a substitution value map has been set. If set to false, will not substitute categorical feature values.
 			substitute_output (true)
 			;{type "boolean"}
+			;flag, default is true. if true and series IDs are specified with series_id_values, then that series' cases will be held out of queries made within the
+			;react_series call.
+			leave_series_out (true)
+			;{type "boolean"}
 			;flag, if set to true assumes provided categorical (nominal or ordinal) feature values already been substituted.
 			input_is_substituted (false)
 		)
@@ -526,8 +535,6 @@
 		(if !hasDateTimeFeatures
 			(call !ValidateDateTimeInputs (assoc single_series (false)))
 		)
-
-
 
 		(call !ValidateDerivedActionFeaturesIsSubset)
 		(declare (assoc
@@ -652,6 +659,7 @@
 				substitute_output substitute_output
 				input_is_substituted input_is_substituted
 				use_case_weights use_case_weights
+				leave_series_out leave_series_out
 				weight_feature weight_feature
 				rand_seed rand_seed
 				num_reacts num_reacts

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -538,7 +538,7 @@
 		)
 
 		;prep time series parameters if it's a time series model
-		(if (retrieve_from_entity "!tsTimeFeature")
+		(if !tsTimeFeature
 			(call !PrepTimeSeriesFeatures)
 		)
 

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -112,9 +112,9 @@
 			;flag, default is true, only applicable if a substitution value map has been set. If set to false, will not substitute categorical feature values.
 			substitute_output (true)
 			;{type "boolean"}
-			;flag, default is true. if true and series IDs are specified with series_id_values, then that series' cases will be held out of queries made within the
+			;flag, if true and series IDs are specified with series_id_values, then that series' cases will be held out of queries made within the
 			;react_series call.
-			leave_series_out (true)
+			leave_series_out (false)
 			;{type "boolean"}
 			;flag, if set to true assumes provided categorical (nominal or ordinal) feature values already been substituted.
 			input_is_substituted (false)
@@ -443,9 +443,9 @@
 			;flag, default is true, only applicable if a substitution value map has been set. If set to false, will not substitute categorical feature values.
 			substitute_output (true)
 			;{type "boolean"}
-			;flag, default is true. if true and series IDs are specified with series_id_values, then that series' cases will be held out of queries made within the
+			;flag, if true and series IDs are specified with series_id_values, then that series' cases will be held out of queries made within the
 			;react_series call.
-			leave_series_out (true)
+			leave_series_out (false)
 			;{type "boolean"}
 			;flag, if set to true assumes provided categorical (nominal or ordinal) feature values already been substituted.
 			input_is_substituted (false)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -46,17 +46,8 @@
 			;	continue_series flag will be ignored and treated as true if this value is specified.
 			continue_series_values (null)
 			;{type "list" values "string"}
-			;list of feature names corresponding to values in each row of context_values
-			context_features (list)
-			;{type "list"}
-			;list of context feature values for non time-series features
-			context_values (list)
-			;{type "list" values "string"}
 			;list of feature names corresponding to values in each row of action_values
 			action_features (list)
-			;{type "list"}
-			;list of predicted feature values for non time-series features
-			action_values (list)
 			;{type "list" values "string"}
 			;list of action features whose values should be computed from the resulting last row in series, in the specified
 			;	order. Must be a subset of action_features.
@@ -161,8 +152,8 @@
 		;Don't allow duplicates/overlap of context features by checking if all the context features appended
 		;together are more than just the uniques between them
 		(if (>
-				(size (append initial_features context_features series_context_features))
-				(size (values (append initial_features context_features series_context_features) (true) ))
+				(size (append initial_features series_context_features))
+				(size (values (append initial_features series_context_features) (true) ))
 			)
 			(conclude
 				(call !Return (assoc
@@ -192,7 +183,7 @@
 			hyperparam_map
 				(call !GetHyperparameters (assoc
 					feature (null)
-					context_features context_features
+					context_features series_context_features
 					weight_feature weight_feature
 				))
 		))
@@ -276,24 +267,18 @@
 				continue_series_features continue_series_features
 				continue_series_values continue_series_values
 
-				context_features context_features
-				context_values context_values
 				action_features action_features
-				action_values action_values
 				derived_action_features derived_action_features
 				derived_context_features derived_context_features
 				series_context_features series_context_features
 				series_context_values series_context_values
 				details details
 				extra_features extra_features
-				ignore_case ignore_case
-				case_indices case_indices
 				substitute_output substitute_output
 				input_is_substituted input_is_substituted
 				use_case_weights use_case_weights
 				weight_feature weight_feature
 				rand_seed rand_seed
-				leave_case_out leave_case_out
 
 				desired_conviction desired_conviction
 				use_regional_model_residuals use_regional_model_residuals
@@ -363,17 +348,8 @@
 			;time step values at which to end synthesis for each series, applicable only for time series.
 			final_time_steps (null)
 			;{type "list" values "string"}
-			;list of feature names corresponding to values in each row of context_values
-			context_features (list)
-			;{type "list" values {type "list"}}
-			;2d-list of context feature values for non time-series features, one list is used per series.
-			context_values (null)
-			;{type "list" values "string"}
 			;list of feature names corresponding to values in each row of action_values
 			action_features (list)
-			;{type "list" values {type "list"}}
-			;2d-list of predicted feature values for non time-series features, one list is used per series.
-			action_values (list)
 			;{type "list" values "string"}
 			;list of context features whose values should be computed from the entire series in the specified order.
 			;	Must be different than context_features.
@@ -416,15 +392,12 @@
 			;total number of series to generate, for generative reacts.
 			;
 			;	 All of the following parameters, if specified, must be either length of 1 or equal to the length of
-			;	context_values/case_indices for discriminative reacts, and num_series_to_generate for generative reacts.
+			;	series_context_values for discriminative reacts, and num_series_to_generate for generative reacts.
 			;
 			num_series_to_generate (null)
 			;{ref "ReactDetails"}
 			;see the description for the details parameter of #react
 			details (null)
-			;{type "boolean"}
-			;flag, if set to true and specified along with case_indices, will set ignore_case to the one specified by case_indices.
-			leave_case_out (null)
 			;{type "boolean"}
 			;flag, if true order of generated feature values will match the order of features
 			ordered_by_specified_features (null)
@@ -432,11 +405,6 @@
 			;If true will exclude sensitive features whose values will be
 			;	replaced after synthesis from uniqueness check.
 			exclude_novel_nominals_from_uniqueness_check (null)
-			;{ref "CaseIndices"}
-			;pair (list) of session id and index, where index is the original 0-based session_training_index of the case as it was
-			;			trained into the session. If this case does not exist, discriminative react outputs null, generative react ignores it.
-			case_indices (null)
-
 			;{type "boolean"}
 			;flag, if false uses model feature residuals, if true recalculates regional model residuals.
 			use_regional_model_residuals (true)
@@ -479,11 +447,8 @@
 					(if (!= (null) desired_conviction)
 						num_series_to_generate
 
-						(!= (null) context_values)
-						(size context_values)
-
-						(!= (null) case_indices)
-						(size case_indices)
+						(!= (null) series_context_values)
+						(size series_context_values)
 
 						(!= (null) initial_values)
 						(size initial_values)
@@ -496,10 +461,6 @@
 
 		;validate parameters
 		(declare (assoc invalid_react_parameters (false) ))
-
-		(call !ValidateBatchReactParameter (assoc param context_values))
-		(call !ValidateBatchReactParameter (assoc param case_indices))
-		(call !ValidateBatchReactParameter (assoc param action_values))
 
 		(call !ValidateBatchReactParameter (assoc param initial_values))
 		(call !ValidateBatchReactParameter (assoc param series_stop_maps))
@@ -543,8 +504,8 @@
 		;Don't allow duplicates/overlap of context features by checking if all the context features appended
 		;together are more than just the uniques between them
 		(if (>
-				(size (append initial_features context_features series_context_features))
-				(size (values (append initial_features context_features series_context_features) (true) ))
+				(size (append initial_features series_context_features))
+				(size (values (append initial_features series_context_features) (true) ))
 			)
 			(conclude
 				(call !Return (assoc
@@ -670,24 +631,18 @@
 				continue_series_features continue_series_features
 				continue_series_values continue_series_values
 
-				context_features context_features
-				context_values context_values
 				action_features action_features
-				action_values action_values
 				derived_action_features derived_action_features
 				derived_context_features derived_context_features
 				series_context_features series_context_features
 				series_context_values series_context_values
 				details details
 				extra_features extra_features
-				ignore_case ignore_case
-				case_indices case_indices
 				substitute_output substitute_output
 				input_is_substituted input_is_substituted
 				use_case_weights use_case_weights
 				weight_feature weight_feature
 				rand_seed rand_seed
-				leave_case_out leave_case_out
 				num_reacts num_reacts
 
 				desired_conviction desired_conviction

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -9,13 +9,13 @@
 	(declare
 		(assoc
 			;{type "list" values "string"}
-			;list of features to condition just the first case in a series, overwrites context_features and
-			;	derived_context_features for that first case. All specified initial features must be in one of: context_features, action_features,
-			;	derived_context_features or derived_action_features. If provided a value that isn't in one of those lists, it will be ignored.
-			initial_features (list)
-			;{type "list"}
-			;list of values corresponding to the initial_features, used to condition just the first case in a series.
-			initial_values (null)
+			;list of series ID features used to uniquely select a trained series.
+			;	This list should contain all ID features, but the order can vary depending on the order of the
+			;	features values given in series_id_values.
+			series_id_features (list)
+			;{type "list" values "any"}
+			;list of values whose order corresponds to the list of features defined in series_id_features, used to identify trained series.
+			series_id_values (null)
 			;{type "assoc"}
 			;assoc of feature -> stop conditions:
 			;	for continuous features:  { feature:  { "min" : val,  "max": val } } - stops series when feature value exceeds max or is smaller than min
@@ -125,7 +125,10 @@
 
 		(call !ValidateFeatures)
 
-		(declare (assoc invalid_react_parameters (null)))
+		(declare (assoc
+			invalid_react_parameters (null)
+			warnings (assoc)
+		))
 
 		(if series_stop_map
 			(assign (assoc
@@ -145,41 +148,32 @@
 			)
 		)
 
-		(if !hasDateTimeFeatures
-			(call !ValidateDateTimeInputs (assoc single_series (true)))
-		)
+		(let
+			(assoc invalid_ts_details (indices (remove (zip requested_details) !tsSupportedDetails) ) )
 
-		;Don't allow duplicates/overlap of context features by checking if all the context features appended
-		;together are more than just the uniques between them
-		(if (>
-				(size (append initial_features series_context_features))
-				(size (values (append initial_features series_context_features) (true) ))
-			)
-			(conclude
-				(call !Return (assoc
-					errors (list "There must not be overlap between features specified in initial_features, context_features, and/or series_context_features.")
+			(if (size invalid_ts_details)
+				(accum (assoc
+					warnings
+						(associate
+							(concat
+								"The following details are not officially supported for react series: "
+								(apply "concat" (map (lambda (concat (current_value) ",") ) invalid_ts_details) )
+								". Behavior is experimental."
+							)
+						)
 				))
 			)
 		)
 
-		(declare (assoc output_features action_features))
+		(if !hasDateTimeFeatures
+			(call !ValidateDateTimeInputs (assoc single_series (true)))
+		)
 
 		(call !ValidateDerivedActionFeaturesIsSubset)
 
-		;this can get appended to in later logic, but should not appear required in the API so it's default is (null)
-		(if (= (null) initial_values)
-			(assign (assoc initial_values (list) ))
-		)
-		;prep time series parameters if it's a time series model
-		(if (retrieve_from_entity "!tsTimeFeature")
-			(call !PrepTimeSeriesFeatures (assoc
-				;singular series
-				n_samples 1
-				single_series (true)
-			))
-		)
 
 		(declare (assoc
+			output_features action_features
 			hyperparam_map
 				(call !GetHyperparameters (assoc
 					feature (null)
@@ -192,6 +186,15 @@
 
 		;check and update caches if necessary
 		(call !PreReactCacheChecks)
+
+		;prep time series parameters if it's a time series model
+		(if !tsTimeFeature
+			(call !PrepTimeSeriesFeatures (assoc
+				;singular series
+				n_samples 1
+				single_series (true)
+			))
+		)
 
 		;if user passed in a series for continuing, create a temporary trainee to derive all the necessary values (lags, deltas, etc.)
 		;and then overwrite the passed continue_series_values with the additional derived feature values
@@ -257,8 +260,8 @@
 
 		(call !Return
 			(call !ReactSeries (assoc
-				initial_features initial_features
-				initial_values initial_values
+				series_id_features series_id_features
+				series_id_values series_id_values
 				series_stop_map series_stop_maps
 				max_series_length max_series_length
 				output_new_series_ids output_new_series_ids
@@ -267,6 +270,8 @@
 				continue_series_features continue_series_features
 				continue_series_values continue_series_values
 
+				initial_features initial_features
+				initial_values initial_values
 				action_features action_features
 				derived_action_features derived_action_features
 				derived_context_features derived_context_features
@@ -301,13 +306,13 @@
 		;returns {ref "ReactSeriesResponse"}
 		(assoc
 			;{type "list" values "string"}
-			;list of features to condition just the first case in a series, overwrites context_features and
-			;	derived_context_features for that first case. All specified initial features must be in one of: context_features, action_features,
-			;	derived_context_features or derived_action_features. If provided a value that isn't in one of those lists, it will be ignored.
-			initial_features (list)
-			;{type "list" values {type "list"}}
-			;2d-list of values corresponding to the initial_features, used to condition just the first case in a series. One list is used per series.
-			initial_values (null)
+			;list of series ID features used to uniquely select a trained series.
+			;	This list should contain all ID features, but the order can vary depending on the order of the
+			;	features values given in series_id_values.
+			series_id_features (list)
+			;{type "list" values {type "list" values "any"}}
+			;2d-list of values whose order corresponds to the list of features defined in series_id_features, used to identify trained series.
+			series_id_values (null)
 			;{type "list" values {type "assoc"} }
 			;list of assocs of feature -> stop conditions:
 			;	for continuous features:  { feature:  { "min" : val,  "max": val } } - stops series when feature value exceeds max or is smaller than min
@@ -450,8 +455,8 @@
 						(!= (null) series_context_values)
 						(size series_context_values)
 
-						(!= (null) initial_values)
-						(size initial_values)
+						(!= (null) series_id_values)
+						(size series_id_values)
 
 						(!= (null) continue_series_values)
 						(size continue_series_values)
@@ -460,9 +465,13 @@
 		))
 
 		;validate parameters
-		(declare (assoc invalid_react_parameters (false) ))
+		(declare (assoc
+			invalid_react_parameters (false)
+			warnings (assoc)
+			output_features action_features
+		))
 
-		(call !ValidateBatchReactParameter (assoc param initial_values))
+		(call !ValidateBatchReactParameter (assoc param series_id_valuess))
 		(call !ValidateBatchReactParameter (assoc param series_stop_maps))
 		(call !ValidateBatchReactParameter (assoc param max_series_lengths))
 
@@ -497,28 +506,33 @@
 			)
 		)
 
-		(if !hasDateTimeFeatures
-			(call !ValidateDateTimeInputs (assoc single_series (false)))
-		)
+		(let
+			(assoc invalid_ts_details (indices (remove (zip requested_details) !tsSupportedDetails) ) )
 
-		;Don't allow duplicates/overlap of context features by checking if all the context features appended
-		;together are more than just the uniques between them
-		(if (>
-				(size (append initial_features series_context_features))
-				(size (values (append initial_features series_context_features) (true) ))
-			)
-			(conclude
-				(call !Return (assoc
-					errors (list "There must not be overlap between features specified in initial_features, context_features, and/or series_context_features.")
+			(if (size invalid_ts_details)
+				(accum (assoc
+					warnings
+						(associate
+							(concat
+								"The following details are not officially supported for react series: "
+								(apply "concat" (map (lambda (concat (current_value) ",") ) invalid_ts_details) )
+								". Behavior is experimental."
+							)
+						)
 				))
 			)
 		)
 
-		(declare (assoc output_features action_features))
+		(if !hasDateTimeFeatures
+			(call !ValidateDateTimeInputs (assoc single_series (false)))
+		)
+
+
 
 		(call !ValidateDerivedActionFeaturesIsSubset)
-
 		(declare (assoc
+			initial_features (list)
+			initial_values (null)
 			hyperparam_map
 				(call !GetHyperparameters (assoc
 					feature (null)
@@ -532,14 +546,9 @@
 		;check and update caches if necessary
 		(call !PreReactCacheChecks)
 
-		;this can get appended to in later logic, but should not appear required in the API so it's default is (null)
-		(if (= (null) initial_values)
-			(assign (assoc initial_values (list) ))
-		)
-
 		;prep time series parameters if it's a time series model
 		(if !tsTimeFeature
-			(call !PrepTimeSeriesFeatures)
+			(call !PrepTimeSeriesFeatures (assoc n_samples num_reacts))
 		)
 
 		;if user passed in a series for continuing, create a temporary trainee to derive all the necessary values (lags, deltas, etc.)
@@ -620,8 +629,8 @@
 
 		(call !Return
 			(call !BatchReactSeries (assoc
-				initial_features initial_features
-				initial_values initial_values
+				series_id_features series_id_features
+				series_id_values series_id_values
 				series_stop_maps series_stop_maps
 				max_series_lengths max_series_lengths
 				output_new_series_ids output_new_series_ids
@@ -631,6 +640,8 @@
 				continue_series_features continue_series_features
 				continue_series_values continue_series_values
 
+				initial_features initial_features
+				initial_values initial_values
 				action_features action_features
 				derived_action_features derived_action_features
 				derived_context_features derived_context_features

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -495,7 +495,7 @@
 			output_features action_features
 		))
 
-		(call !ValidateBatchReactParameter (assoc param series_id_valuess))
+		(call !ValidateBatchReactParameter (assoc param series_id_values))
 		(call !ValidateBatchReactParameter (assoc param series_stop_maps))
 		(call !ValidateBatchReactParameter (assoc param max_series_lengths))
 

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -33,9 +33,8 @@
 			;	relevant series ID, but is allowed to change the series ID that it tracks based on its current context. If "no", does not track any particular series ID.
 			series_id_tracking "fixed"
 			;{type "boolean"}
-			;flag, default is false.  When true will attempt to continue existing series instead of starting new series.
-			;	If initial_values provide series IDs, it will continue those explicitly specified IDs, otherwise it will randomly select series to continue.
-			;	Note: terminated series with terminators cannot be continued and will result in null output.
+			;flag, default is false.  When true, react_series will do a forecast of a series.
+			;	When true, either series_id_values or continue_series_values must be specified.
 			continue_series (false)
 			;{type "list" values "string"}
 			;list of features corresponding to the values in each row of continue_series_values.
@@ -126,7 +125,6 @@
 			generate_new_cases "no"
 		)
 		(call !ValidateParameters)
-
 		(call !ValidateFeatures)
 
 		(declare (assoc
@@ -165,6 +163,24 @@
 								". Behavior is experimental."
 							)
 						)
+				))
+			)
+		)
+
+		(if (and
+				continue_series
+				(not (xor
+					(size series_id_values)
+					(size continue_series_values)
+				))
+			)
+			(conclude
+				(call !Return (assoc
+					errors
+						(list (concat
+							"When using the continue_series flag, either series_id_values or continue_series_values "
+							"must be specified, but not both."
+						))
 				))
 			)
 		)
@@ -339,9 +355,8 @@
 			;	relevant series ID, but is allowed to change the series ID that it tracks based on its current context. If "no", does not track any particular series ID.
 			series_id_tracking "fixed"
 			;{type "boolean"}
-			;flag, default is false.  When true will attempt to continue existing series instead of starting new series.
-			;	If initial_values provide series IDs, it will continue those explicitly specified IDs, otherwise it will randomly select series to continue.
-			;	Note: terminated series with terminators cannot be continued and will result in null output.
+			;flag, default is false.  When true, react_series will do a forecast of a series.
+			;	When true, either series_id_values or continue_series_values must be specified.
 			continue_series (false)
 			;{type "list" values "string"}
 			;list of features corresponding to the values in each row of continue_series_values.
@@ -528,6 +543,24 @@
 								". Behavior is experimental."
 							)
 						)
+				))
+			)
+		)
+
+		(if (and
+				continue_series
+				(not (xor
+					(size series_id_values)
+					(size continue_series_values)
+				))
+			)
+			(conclude
+				(call !Return (assoc
+					errors
+						(list (concat
+							"When using the continue_series flag, either series_id_values or continue_series_values "
+							"must be specified, but not both."
+						))
 				))
 			)
 		)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -522,7 +522,7 @@
 			hyperparam_map
 				(call !GetHyperparameters (assoc
 					feature (null)
-					context_features context_features
+					context_features series_context_features
 					weight_feature weight_feature
 				))
 		))

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1441,20 +1441,16 @@
 					context_features react_context_features
 					context_values (unzip current_case_map react_context_features)
 					action_features action_features
-					action_values action_values
 					;do not derive anything during this react
 					derived_action_features (list)
 					derived_context_features (list)
 					details (if output_details details)
 					extra_features (append extra_features derived_action_features)
-					ignore_case ignore_case
-					case_indices case_indices
 					substitute_output substitute_output
 					input_is_substituted input_is_substituted
 					use_case_weights use_case_weights
 					weight_feature weight_feature
 					rand_seed rand_seed
-					leave_case_out leave_case_out
 
 					desired_conviction desired_conviction
 					use_regional_model_residuals use_regional_model_residuals

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -127,6 +127,7 @@
 								substitute_output substitute_output
 								input_is_substituted input_is_substituted
 								use_case_weights use_case_weights
+								leave_series_out leave_series_out
 								weight_feature weight_feature
 
 								desired_conviction desired_conviction
@@ -266,6 +267,23 @@
 			series_generate_attempts 0
 		))
 
+		(declare (assoc
+			;list of queries that holds out any data required, used to hold out cases from series being forecasted
+			;or used as contexts
+			;NOTE: this currently holds out the disjunction over the matches on series IDs.
+			;Meaning that when there is more than one ID feature, any series with a single matching ID feature value
+			;will be held out, this may be revisited and adjusted to be more selective for the holdout process.
+			holdout_queries
+				(if (and leave_series_out (size series_id_values))
+					(values (map
+						(lambda (query_not_equals (current_index) (current_value)))
+						(zip series_id_features series_id_values)
+					))
+
+					(list)
+				)
+		))
+
 		(assign (assoc
 			max_series_length
 				(if has_series_context_values
@@ -359,7 +377,6 @@
 				series_detail_values_map (map (lambda (list)) (zip requested_details))
 			))
 		)
-
 
 		(let
 			(assoc context_map (zip user_specified_context_features))
@@ -1309,7 +1326,7 @@
 									use_case_weights use_case_weights
 									weight_feature weight_feature
 									rand_seed rand_seed
-									leave_case_out leave_case_out
+									holdout_queries holdout_queries
 
 									desired_conviction desired_conviction
 									use_regional_model_residuals use_regional_model_residuals

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -203,6 +203,7 @@
 				(append
 					(zip derived_context_features)
 					(zip derived_action_features)
+					(zip action_features)
 					(if (size series_context_values)
 						(zip series_context_features (first series_context_values))
 						(assoc)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -718,6 +718,7 @@
 									weight_feature weight_feature
 									rand_seed rand_seed
 									leave_case_out leave_case_out
+									holdout_queries holdout_queries
 
 									desired_conviction desired_conviction
 									use_regional_model_residuals use_regional_model_residuals
@@ -1159,33 +1160,10 @@
 				))
 			)
 
-			;else user has not specified untrained data, must either select using series_id_values, or a random series
+			;else user has not specified untrained data, must select the data of a trained series using series_id_values
 			(seq
 				;populate an assoc of id feature -> value, if conditioned on a series, otherwise select a random series
-				(assign (assoc
-					id_values_map
-						;if initial_features_map has series id features, use them
-						(if (size series_id_values)
-							;get ID feature values from initial map
-							(zip series_id_features series_id_values)
-
-							;else randomly pick IDs by selecting a case at random and using its series ids
-							(zip
-								series_id_features
-								(retrieve_from_entity
-									;pick a case at random
-									(first
-										(contained_entities (list
-											(query_exists !internalLabelSession)
-											(query_sample 1)
-										))
-									)
-									;pull the random case's ID features
-									series_id_features
-								)
-							)
-						)
-				))
+				(assign (assoc id_values_map (zip series_id_features series_id_values) ))
 
 				;pull the necessary number of cases from the series
 				(assign (assoc
@@ -1508,6 +1486,7 @@
 					preserve_feature_values preserve_feature_values
 					new_case_threshold new_case_threshold
 					pre_generated_uniques_map pre_generated_uniques_map
+					holdout_queries holdout_queries
 				))
 		))
 

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -23,9 +23,6 @@
     (declare
         (assoc
             ;if any of these are length of 1, the index will be 0 to pull the values and apply to all reacts
-            single_context (= 1 (size context_values))
-            single_action (= 1 (size action_values))
-            single_session (= 1 (size case_indices))
             single_initial (= 1 (size initial_values))
             single_stop_map (= 1 (size series_stop_maps))
             single_max_length (= 1 (size max_series_lengths))
@@ -36,8 +33,6 @@
         )
 
         ;these lists must be either a list of lists or null; if it's an empty list, treat it as null
-        (if (= (list) context_values) (assign (assoc context_values (null))) )
-        (if (= (list) action_values) (assign (assoc action_values (null))) )
         (if (= (list) initial_values) (assign (assoc initial_values (null))) )
         (if (= (list) series_stop_maps) (assign (assoc series_stop_maps (null))) )
 
@@ -85,9 +80,6 @@
 							initial_index (if single_initial 0 (current_index 1))
 							stop_map_index (if single_stop_map 0 (current_index 1))
 							max_length_index (if single_max_length 0 (current_index 1))
-							context_index (if single_context 0 (current_index 1))
-							action_index (if single_action 0 (current_index 1))
-							session_index (if single_session 0 (current_index 1))
 							react_rand_seed (if rand_seed (get rand_seed (current_index 1)))
 							continue_index (if single_continue_series 0 (current_index 1))
 							react_session (null)
@@ -97,8 +89,6 @@
 
  						;get the corresponding parameters by the index, values will be null if not specified, but must be defaulted to an empty list/assoc
 						(declare (assoc
-							react_context_values (if context_values (get context_values context_index) (list))
-							react_action_values (if action_values (get action_values action_index) (list))
 							react_initial_values (if initial_values (get initial_values initial_index) (list))
 							react_series_stop_map (if series_stop_maps (get series_stop_maps stop_map_index) (assoc))
 							react_continue_values (if continue_series_values (get continue_series_values continue_index) (null))
@@ -107,11 +97,6 @@
 							react_max_series_length (get max_series_lengths max_length_index)
 						))
 
-						;if one of these is provided, both of them must be
-						(if case_indices
-							(assign (assoc react_case_index (get case_indices session_index) ))
-						)
-
 						;Note: will need to pull this entire map out and store into its own variable to pull individual ReactSeries
 						; keys (i.e,. "action_values") once details are added to ReactSeries output
 						(get
@@ -119,9 +104,6 @@
 								initial_values react_initial_values
 								series_stop_map react_series_stop_map
 								max_series_length react_max_series_length
-								context_values react_context_values
-								action_values react_action_values
-								case_indices react_case_index
 								rand_seed react_rand_seed
 								series_context_values react_series_context_values
 								output_new_series_ids output_new_series_ids
@@ -131,19 +113,16 @@
 								continue_series_values react_continue_values
 
 								initial_features initial_features
-								context_features context_features
 								series_context_features series_context_features
 								action_features action_features
 								derived_action_features derived_action_features
 								derived_context_features derived_context_features
 								details details
 								extra_features extra_features
-								ignore_case ignore_case
 								substitute_output substitute_output
 								input_is_substituted input_is_substituted
 								use_case_weights use_case_weights
 								weight_feature weight_feature
-								leave_case_out leave_case_out
 
 								desired_conviction desired_conviction
 								use_regional_model_residuals use_regional_model_residuals
@@ -224,11 +203,6 @@
 				(append
 					(zip derived_context_features)
 					(zip derived_action_features)
-					(if (size action_values)
-						(zip action_features action_values)
-						(zip action_features)
-					)
-					(zip context_features context_values)
 					(if (size series_context_values)
 						(zip series_context_features (first series_context_values))
 						(assoc)
@@ -255,7 +229,7 @@
 			;assoc of of all features -> feature values for the current series case
 			current_case_map (null)
 			;all features that are used as contexts
-			all_context_features (append context_features derived_context_features series_context_features)
+			all_context_features (append derived_context_features series_context_features)
 			;context features used for each series ract, usually same as all_context_features except for the initial react
 			react_context_features (list)
 			;store output of react
@@ -275,7 +249,7 @@
 			use_initial_context_features (false)
 			;flag if there are values to condition each row of the series
 			has_series_context_values (size series_context_values)
-			user_specified_context_features (append context_features series_context_features)
+			user_specified_context_features series_context_features
 
 			;features used for uniqueness validation should not include id features
 			output_features_no_ids (if (!= "no" generate_new_cases) (indices (remove (zip output_features) (get !tsModelFeaturesMap "series_id_features"))) )
@@ -493,7 +467,6 @@
 					;update initial map to be the stationary context overwritten by the provided initial values
 					initial_features_map
 						(append
-							(zip context_features context_values)
 							(if has_series_context_values
 								(zip series_context_features (first series_context_values))
 								(assoc)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -23,7 +23,8 @@
     (declare
         (assoc
             ;if any of these are length of 1, the index will be 0 to pull the values and apply to all reacts
-            single_initial (= 1 (size initial_values))
+            single_series_ids (= 1 (size series_id_values))
+			single_initial (= 1 (size initial_values))
             single_stop_map (= 1 (size series_stop_maps))
             single_max_length (= 1 (size max_series_lengths))
 			single_continue_series (= 1 (size continue_series_values))
@@ -33,7 +34,8 @@
         )
 
         ;these lists must be either a list of lists or null; if it's an empty list, treat it as null
-        (if (= (list) initial_values) (assign (assoc initial_values (null))) )
+        (if (= (list) series_id_values) (assign (assoc series_id_values (null))) )
+		(if (= (list) initial_values) (assign (assoc initial_values (null))) )
         (if (= (list) series_stop_maps) (assign (assoc series_stop_maps (null))) )
 
         (if (size series_context_values)
@@ -67,7 +69,6 @@
 		)
 
 		(declare (assoc
-			warnings (assoc)
 			requested_details (indices (filter details))
 			output_details (contains_value (values details) (true))
 		))
@@ -77,6 +78,7 @@
 				||(range
 					(lambda (let
 						(assoc
+							ids_index (if single_series_ids 0 (current_index 1))
 							initial_index (if single_initial 0 (current_index 1))
 							stop_map_index (if single_stop_map 0 (current_index 1))
 							max_length_index (if single_max_length 0 (current_index 1))
@@ -89,6 +91,7 @@
 
  						;get the corresponding parameters by the index, values will be null if not specified, but must be defaulted to an empty list/assoc
 						(declare (assoc
+							react_series_ids (if series_id_values (get series_id_values ids_index) (list))
 							react_initial_values (if initial_values (get initial_values initial_index) (list))
 							react_series_stop_map (if series_stop_maps (get series_stop_maps stop_map_index) (assoc))
 							react_continue_values (if continue_series_values (get continue_series_values continue_index) (null))
@@ -101,7 +104,8 @@
 						; keys (i.e,. "action_values") once details are added to ReactSeries output
 						(get
 							(call !ReactSeries (assoc
-								initial_values react_initial_values
+								series_id_features series_id_features
+								series_id_values react_series_ids
 								series_stop_map react_series_stop_map
 								max_series_length react_max_series_length
 								rand_seed react_rand_seed
@@ -113,6 +117,7 @@
 								continue_series_values react_continue_values
 
 								initial_features initial_features
+								initial_values react_initial_values
 								series_context_features series_context_features
 								action_features action_features
 								derived_action_features derived_action_features
@@ -347,23 +352,6 @@
 			requested_details (indices (filter (lambda (current_value)) details))
 			output_details (contains_value (values details) (true))
 		))
-
-		(let
-			(assoc invalid_ts_details (indices (remove (zip requested_details) !tsSupportedDetails) ) )
-
-			(if (size invalid_ts_details)
-				(accum (assoc
-					warnings
-						(associate
-							(concat
-								"The following details are not officially supported for react series: "
-								(apply "concat" (map (lambda (concat (current_value) ",") ) invalid_ts_details) )
-								". Behavior is experimental."
-							)
-						)
-				))
-			)
-		)
 
 		(if output_details
 			(declare (assoc
@@ -1067,7 +1055,11 @@
 	#!PrepContinueReactSeries
 	(let
 		(assoc
-			series_id_features (get !tsModelFeaturesMap "series_id_features")
+			series_id_features
+				(if (size series_id_features)
+					series_id_features
+					(get !tsModelFeaturesMap "series_id_features")
+				)
 			id_values_map (assoc)
 			existing_series_cases (list)
 		)
@@ -1097,8 +1089,6 @@
 				))
 			)
 		)
-
-
 
 		;if user has provided series data to continue, populate series_data with the provided values
 		(if (size continue_series_values)
@@ -1152,15 +1142,15 @@
 				))
 			)
 
-			;else user has not specified existing cases, pull the necessary last few cases from the series to account for largest lag amount
+			;else user has not specified untrained data, must either select using series_id_values, or a random series
 			(seq
 				;populate an assoc of id feature -> value, if conditioned on a series, otherwise select a random series
 				(assign (assoc
 					id_values_map
 						;if initial_features_map has series id features, use them
-						(if (size (filter (unzip initial_features_map series_id_features)))
+						(if (size series_id_values)
 							;get ID feature values from initial map
-							(keep initial_features_map series_id_features)
+							(zip series_id_features series_id_values)
 
 							;else randomly pick IDs by selecting a case at random and using its series ids
 							(zip
@@ -1183,42 +1173,21 @@
 				;pull the necessary number of cases from the series
 				(assign (assoc
 					existing_series_cases
-						(contained_entities (append
-							(map
-								(lambda (query_equals (current_value) (get id_values_map (current_value))))
-								series_id_features
-							)
-							;if an initial time value is provided, limit existing series cases to those before the specified initial time
-							(if (contains_index initial_features_map !tsTimeFeature)
-								(list
-									;using both query_less_or_equal_to and query_not_equals is same effect as 'query less than'
-									(query_less_or_equal_to
-										!tsTimeFeature
-										(if (contains_index !featureDateTimeMap !tsTimeFeature)
-											(call !ConvertDateToEpoch (assoc
-												date (get initial_features_map !tsTimeFeature)
-												feature !tsTimeFeature
-											))
+						(call !RetrieveTrainedSeriesData (assoc
+							id_values_map id_values_map
+							num_cases_needed largest_max_row_lag
+							exclusive_upper_time_bound
+								;if an initial time value is provided, limit existing series cases to those before the specified initial time
+								(if (contains_index initial_features_map !tsTimeFeature)
+									(if (contains_index !featureDateTimeMap !tsTimeFeature)
+										(call !ConvertDateToEpoch (assoc
+											date (get initial_features_map !tsTimeFeature)
+											feature !tsTimeFeature
+										))
 
-											(get initial_features_map !tsTimeFeature)
-										)
-									)
-									(query_not_equals
-										!tsTimeFeature
-										(if (contains_index !featureDateTimeMap !tsTimeFeature)
-											(call !ConvertDateToEpoch (assoc
-												date (get initial_features_map !tsTimeFeature)
-												feature !tsTimeFeature
-											))
-
-											(get initial_features_map !tsTimeFeature)
-										)
+										(get initial_features_map !tsTimeFeature)
 									)
 								)
-								(list)
-							)
-							;select the necessary count of previous cases to reference lags
-							(query_max !tsTimeFeature largest_max_row_lag)
 						))
 				))
 
@@ -1331,6 +1300,30 @@
 			)
 		)
 	)
+
+	#!RetrieveTrainedSeriesData
+	;params:
+	;  id_values_map: assoc of series id feature name to id value
+	;  exclusive_upper_time_bound: an upper bound time value that all retrieved cases must be before chronologically
+	;  num_cases_needed: the number of cases to retrieve
+	(contained_entities (append
+		(map
+			(lambda (query_equals (current_value) (get id_values_map (current_value))))
+			(indices id_values_map)
+		)
+		;if a lower bound for time is provided, limit existing series cases to those before the specified initial time
+		(if exclusive_upper_time_bound
+			(list
+				;using both query_less_or_equal_to and query_not_equals is same effect as 'query less than'
+				(query_less_or_equal_to !tsTimeFeature exclusive_upper_time_bound)
+				(query_not_equals  !tsTimeFeature exclusive_upper_time_bound)
+			)
+			(list)
+		)
+		;select the necessary count of previous cases to reference lags
+		(query_max !tsTimeFeature num_cases_needed)
+	))
+
 
 	;Helper method for ReactSeries that synthesises action_features and derives derived_action_features to create a series case
 	;and then tests it for uniqueness and retries as necessary until a unique case is created

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -51,6 +51,7 @@
 			case_indices (null)
 			new_case_threshold "min"
 			leave_case_out (false)
+			custom_extra_filtering_queries (list)
 
 			;local variable
 			valid_weight_feature (false)
@@ -493,6 +494,7 @@
 					approximate_residual (and (not feature_is_nominal) (not use_regional_model_residuals))
 					ignore_case (or ignore_case (if leave_case_out preserve_case_id))
 					action_feature_is_dependent action_feature_is_dependent
+					custom_extra_filtering_queries custom_extra_filtering_queries
 				))
 		))
 
@@ -565,7 +567,11 @@
 		(assoc
 			case_id
 				(first
-					(contained_entities (list
+					(contained_entities (append
+						(if custom_extra_filtering_queries
+							custom_extra_filtering_queries
+							(list)
+						)
 						(query_exists !internalLabelSession)
 						(if valid_weight_feature
 							;select case using weighted random
@@ -601,6 +607,7 @@
 					approximate_residual (and (not feature_is_nominal) (not use_regional_model_residuals))
 					ignore_case (or ignore_case (if leave_case_out preserve_case_id))
 					action_feature_is_dependent action_feature_is_dependent
+					custom_extra_filtering_queries (list)
 				))
 		))
 
@@ -661,6 +668,10 @@
 				(compute_on_contained_entities (append
 					(if ignore_case
 						(query_not_in_entity_list (list ignore_case))
+						(list)
+					)
+					(if custom_extra_filtering_queries
+						custom_extra_filtering_queries
 						(list)
 					)
 					dependent_queries_list
@@ -745,6 +756,10 @@
 						(compute_on_contained_entities (append
 							(if ignore_case
 								(query_not_in_entity_list (list ignore_case))
+								(list)
+							)
+							(if custom_extra_filtering_queries
+								custom_extra_filtering_queries
 								(list)
 							)
 							dependent_queries_list

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -548,6 +548,7 @@
 							approximate_residual (true)
 							ignore_case (or ignore_case (if leave_case_out preserve_case_id))
 							action_feature_is_dependent action_feature_is_dependent
+							custom_extra_filtering_queries custom_extra_filtering_queries
 						))
 				))
 
@@ -607,7 +608,7 @@
 					approximate_residual (and (not feature_is_nominal) (not use_regional_model_residuals))
 					ignore_case (or ignore_case (if leave_case_out preserve_case_id))
 					action_feature_is_dependent action_feature_is_dependent
-					custom_extra_filtering_queries (list)
+					custom_extra_filtering_queries custom_extra_filtering_queries
 				))
 		))
 

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -591,6 +591,10 @@
 							(query_not_in_entity_list (list ignore_case))
 							(list)
 						)
+						(if custom_extra_filtering_queries
+							custom_extra_filtering_queries
+							(list)
+						)
 						dependent_queries_list
 						cached_time_series_filter_query
 						(query_nearest_generalized_distance

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -357,6 +357,7 @@
 								leave_case_out leave_case_out
 								preserve_feature_values preserve_feature_values
 								new_case_threshold new_case_threshold
+								custom_extra_filtering_queries custom_extra_filtering_queries
 							))
 					)
 

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -173,34 +173,6 @@
 	 	obs result
 		exp "Failed to react_series: invalid stopping condition specified for value"
 	 ))
-
-
-	;test duplication of context features
-	(assign (assoc
-		result
-			(call_entity "howso" "single_react_series" (assoc
-				initial_features (list ".series_progress")
-				initial_values (list 0)
-
-				series_context_features (list ".series_progress")
-				series_context_values [ [0] ]
-
-				feature_bounds_map (assoc "value" (assoc "max" 150))
-				series_stop_map  (assoc "value" (assoc "max" 108  ) )
-				desired_conviction 4.5
-
-				max_series_length 10
-				use_regional_model_residuals (false)
-			))
-	))
-	(call keep_result_errors)
-
-	(print "Verify invalid context features: ")
-	 (call assert_same (assoc
-	 	obs result
-		exp "There must not be overlap between features specified in initial_features, context_features, and/or series_context_features."
-	 ))
-
 	(call exit_if_failures (assoc msg "Stop Map and Parameter verification."))
 
 	(assign (assoc
@@ -286,7 +258,7 @@
 	(print "Series length respected: ")
 	(call assert_true (assoc obs (<= (size series) 10)))
 
-	;grab the firsrt synthed date
+	;grab the first synthed date
 	(assign (assoc result (get result (list 1 "payload" "action_values" 0 0 6)) ))
 
 	;convert date to epoch (number)

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -182,8 +182,8 @@
 				initial_features (list ".series_progress")
 				initial_values (list 0)
 
-				context_features (list ".series_progress")
-				context_values (list 0)
+				series_context_features (list ".series_progress")
+				series_context_values [ [0] ]
 
 				feature_bounds_map (assoc "value" (assoc "max" 150))
 				series_stop_map  (assoc "value" (assoc "max" 108  ) )

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -340,8 +340,8 @@
 				continue_series (true)
 				init_time_steps (list 10)
 				output_new_series_ids (false)
-				initial_features (list "stock")
-				initial_values (list (list "stk_A") (list "stk_A") (list "stkB") (list "stkB") (list "stoC"))
+				series_id_features (list "stock")
+				series_id_values (list (list "stk_A") (list "stk_A") (list "stkB") (list "stkB") (list "stoC"))
 			))
 	))
 	(call keep_result_payload)
@@ -382,8 +382,8 @@
 				continue_series (true)
 				init_time_steps (list 10)
 				output_new_series_ids (false)
-				initial_features (list "stock")
-				initial_values (list (list "fake_stock"))
+				series_id_features (list "stock")
+				series_id_values (list (list "fake_stock"))
 			))
 	))
 	(call keep_result_warnings)
@@ -439,17 +439,17 @@
 
 	(print "Batch react series failed to continue series with a warning: ")
 	(call assert_same (assoc
-		obs (last result)
+		obs (get result [1 "payload"])
 		exp
 			(assoc
-				payload
-					(assoc
-						action_features (list "stock" "time" "value")
-						;3 nulls, one for each series
-						action_values (list (null) (null) (null))
-					)
-				warnings (list "Can't continue terminated series.")
+				action_features (list "stock" "time" "value")
+				;3 nulls, one for each series
+				action_values (list (null) (null) (null))
 			)
+	))
+	(call assert_same (assoc
+		obs (zip (get result [1 "warnings"]))
+		exp (zip (list "Can't continue terminated series." "There are no cached hyperparameters in this trainee. This operation was executed using a set of predefined default hyperparameters. Please run analyze() with your desired parameters."))
 	))
 
 	(assign (assoc
@@ -464,16 +464,16 @@
 
 	(print "Single react series failed to continue series with a warning: ")
 	(call assert_same (assoc
-		obs (last result)
+		obs (get result [1 "payload"])
 		exp
 			(assoc
-				payload
-					(assoc
-						action_features (list "stock" "time" "value")
-						action_values (null)
-					)
-				warnings (list "Can't continue terminated series.")
+				action_features (list "stock" "time" "value")
+				action_values (null)
 			)
+	))
+	(call assert_same (assoc
+		obs (zip (get result [1 "warnings"]))
+		exp (zip (list "Can't continue terminated series." "There are no cached hyperparameters in this trainee. This operation was executed using a set of predefined default hyperparameters. Please run analyze() with your desired parameters."))
 	))
 
 

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -518,6 +518,7 @@
 					use_regional_model_residuals (false)
 					output_new_series_ids (false)
 					continue_series_features features
+					continue_series (true)
 					continue_series_values
 						(list
 							;validate that the time series will be sorted correctly

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -162,61 +162,14 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "react_series" (assoc
-
 				num_series_to_generate 30
 				action_features (list "stock" "time" "value")
 				desired_conviction 5
 				use_regional_model_residuals (false)
 				continue_series (true)
-			))
-	))
-	(call keep_result_payload)
-	(assign (assoc series_list (get result "action_values") ))
-
-	(assign (assoc
-		series_lengths
-			(map
-				(lambda (size (current_value)))
-				series_list
-			)
-	))
-
-	(print "Continue series initial time steps correct: ")
-	(call assert_same (assoc
-		exp (range (true) 1 30 1)
-		obs
-			;should results in a list of 30 (true) statemenents
-			(map
-				(lambda (let
-					(assoc first_series_case (first (current_value 1)) )
-					;the time step of the first case in each synthed series is one of the next
-					;3 possible timesteps for each of the 3 originally trained series
-					;where each case is a list of [id, time, value]
-					(contains_value (list 16 19 23) (get first_series_case 1))
-				))
-				series_list
-			)
-	))
-
-	(print "Continued average series length is notably shorter: ")
-	(call assert_approximate (assoc
-		obs (/ (apply "+" series_lengths) (size series_lengths))
-		exp 4.5
-		thresh 1.8
-	))
-
-	(call exit_if_failures (assoc msg "Unconditioned continue series."))
-
-	(assign (assoc
-		result
-			(call_entity "howso" "react_series" (assoc
-				num_series_to_generate 30
-				action_features (list "stock" "time" "value")
-				desired_conviction 5
-				use_regional_model_residuals (false)
-				continue_series (true)
+				series_id_features (list "stock")
+				series_id_values (list (list "stk_A"))
 				init_time_steps (list 13)
-
 			))
 	))
 	(call keep_result_payload)
@@ -250,8 +203,8 @@
 	(print "Continued average series length from middle is medium length: ")
 	(call assert_approximate (assoc
 		obs (/ (apply "+" series_lengths) (size series_lengths))
-		exp 7.3
-		thresh 2.8
+		exp 4
+		thresh 2
 	))
 
 	(call exit_if_failures (assoc msg "Conditioned start continue series."))
@@ -266,7 +219,8 @@
 				continue_series (true)
 				init_time_steps (list 10)
 				final_time_steps (list 17)
-
+				series_id_features (list "stock")
+				series_id_values (list (list "stk_A"))
 			))
 	))
 	(call keep_result_payload)
@@ -394,6 +348,50 @@
 		obs (contains_value result "There is no series trained with the set of IDs:\nstock: fake_stock\n")
 	))
 
+	(assign (assoc
+		result
+			(call_entity "howso" "react_series" (assoc
+				num_series_to_generate 1
+				action_features (list "stock" "time" "value" ".value_lag_2")
+				desired_conviction 5
+				use_regional_model_residuals (false)
+				continue_series (true)
+				init_time_steps (list 10)
+				output_new_series_ids (false)
+			))
+	))
+	(call keep_result_errors)
+
+	(print "Error given when continue_series is set but no data is given: ")
+	(call assert_same (assoc
+		obs result
+		exp "When using the continue_series flag, either series_id_values or continue_series_values must be specified, but not both."
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "react_series" (assoc
+				num_series_to_generate 1
+				action_features (list "stock" "time" "value" ".value_lag_2")
+				desired_conviction 5
+				use_regional_model_residuals (false)
+				continue_series (true)
+				init_time_steps (list 10)
+				output_new_series_ids (false)
+				series_id_features (list "stock")
+				series_id_values (list (list "fake_stock"))
+				continue_series_features (list "stock" "time" "value")
+				continue_series_values [ [ ["stk_A" 1 3] ] ]
+			))
+	))
+	(call keep_result_errors)
+
+	(print "Error given when continue_series is set but both data are given: ")
+	(call assert_same (assoc
+		obs result
+		exp "When using the continue_series flag, either series_id_values or continue_series_values must be specified, but not both."
+	))
+
 	;set attributes to verify that continue doesn't work on terminated series
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes
@@ -435,6 +433,8 @@
 				desired_conviction 5
 				use_regional_model_residuals (false)
 				continue_series (true)
+				series_id_features ["stock"]
+				series_id_values [["stk_A"]]
 			))
 	))
 
@@ -460,6 +460,8 @@
 				desired_conviction 5
 				use_regional_model_residuals (false)
 				continue_series (true)
+				series_id_features ["stock"]
+				series_id_values [["stk_A"]]
 			))
 	))
 

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -342,6 +342,7 @@
 				output_new_series_ids (false)
 				series_id_features (list "stock")
 				series_id_values (list (list "stk_A") (list "stk_A") (list "stkB") (list "stkB") (list "stoC"))
+				leave_series_out (true)
 			))
 	))
 	(call keep_result_payload)


### PR DESCRIPTION
- initial_features and initial_values are removed and mostly replaced/renamed to "series_id_features" and "series_id_values". These allow the user to specify the ID feature values that uniquely identify a trained series they want to react to or forecast.
- leave_series_out is added. Allowing users to hold out the cases of a series (cases matching *any* the specified ID feature values) from queries during the execution of a react_series call.
- the ability to use the continue_series flag without continue_series_value or initial_values (now series_id_values) has been removed. Previously it would have selected a random trained series to forecast, this is no longer possible or supported.