### PR TITLE
22591: Removes continue_series_features/values, allows forecasting from series_context_features/values

### DIFF
--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -404,14 +404,27 @@
 						)
 				))
 
+				(declare (assoc
+					all_id_values_defined
+						;true if all series_id_features are in series_context_features
+						(=
+							(size series_id_features)
+							(size (keep (zip series_context_features) series_id_features))
+						)
+				))
+
 				;ID features may be in one of the context lists
 				;(series_context or context features). It's possible that no IDs actually need to be set as initial.
 				(if (size series_id_features)
 					(let
 						(assoc
 							initial_values_list
-								;if continuing an untrained series, use the id values from the specified data
-								(if (size series_context_values)
+								;if continuing an untrained series where all id values are specified, use the id values from the specified data
+								(if (and
+										(size series_context_values)
+										;TODO: support partial ID specification
+										all_id_values_defined
+									)
 									(map
 										(lambda
 											;only keep the series id values
@@ -462,7 +475,7 @@
 						(assign (assoc
 							initial_values_list
 								;when explicitly provided a list of untrained series to continue, keep that list
-								(if (size series_context_values)
+								(if (and all_id_values_defined (size series_context_values))
 									initial_values_list
 
 									;keeping n_samples worth of ids, sample randomly with replacement

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -660,7 +660,8 @@
 		))
 
 		;Ensure that the user specified context features are not being derived but still being output
-		(if (size all_contexts)
+		;when forecasting, these features still need be derived
+		(if (and (size all_contexts) (not continue_series))
 			(seq
 				(assign (assoc
 					;This line ensures that some features aren't double-added to action_features later.

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -348,10 +348,6 @@
 	 ;	If "fixed", tracks the particular relevant series ID.
 	 ;	If "dynamic", tracks the particular series ID, but is allowed to change the series ID that it tracks based on its current context.
 	 ;	If "no", does not track any particular series ID.
-	 ; continue_series_values: optional, list of lists of values, when specified will continue this specific untrained series as defined by these values.
-	 ; 		continue_series flag will be ignored and treated as true if this value is specified.
-	 ; continue_series_features: optional, list of features corresponding to the values in each row of continue_series_values.
-	 ; 		This value is ignored if continue_series_values is not specified.
 	#!PrepTimeSeriesFeatures
 	(declare
 		(assoc single_series (false) )
@@ -415,18 +411,18 @@
 						(assoc
 							initial_values_list
 								;if continuing an untrained series, use the id values from the specified data
-								(if (size continue_series_values)
+								(if (size series_context_values)
 									(map
 										(lambda
 											;only keep the series id values
 											(unzip
 												;create an assoc of features -> values from first row of series
-												(zip continue_series_features (first (current_value)))
+												(zip series_context_features (first (current_value)))
 												series_id_features
 											)
 										)
 										;list of lists of values
-										continue_series_values
+										series_context_values
 									)
 
 									;else pull all unique id feature combos from dataset and sample n_samples worth
@@ -466,7 +462,7 @@
 						(assign (assoc
 							initial_values_list
 								;when explicitly provided a list of untrained series to continue, keep that list
-								(if (size continue_series_values)
+								(if (size series_context_values)
 									initial_values_list
 
 									;keeping n_samples worth of ids, sample randomly with replacement

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -34,16 +34,8 @@
 			series_id_tracking "fixed"
 			;{type "boolean"}
 			;flag, default is false.  When true, react_series will do a forecast of a series.
-			;	When true, either series_id_values or continue_series_values must be specified.
+			;	When true, either series_id_values or series_context_values must be specified.
 			continue_series (false)
-			;{type "list" values "string"}
-			;list of features corresponding to the values in each row of continue_series_values.
-			;	This value is ignored if continue_series_values is not specified.
-			continue_series_features (null)
-			;{type "list" values {type "list"} }
-			;list of lists of values, when specified will continue this specific untrained series as defined by these values.
-			;	continue_series flag will be ignored and treated as true if this value is specified.
-			continue_series_values (null)
 			;{type "list" values "string"}
 			;list of feature names corresponding to values in each row of action_values
 			action_features (list)
@@ -61,7 +53,8 @@
 			;list of features corresponding to series_context_values
 			series_context_features (list)
 			;{type "list" values {type "list"} }
-			;2d-list of values, context value for each feature for each row of the series.
+			;2d-list of values, context value for each feature for each row of the series. series_context_features must be specified if this parameter
+			;is specified.
 			;	If specified, max_series_length is ignored.
 			series_context_values (list)
 			;{type "list" values "string"}
@@ -171,16 +164,27 @@
 				continue_series
 				(not (xor
 					(size series_id_values)
-					(size continue_series_values)
+					(size series_context_values)
 				))
 			)
 			(conclude
 				(call !Return (assoc
 					errors
 						(list (concat
-							"When using the continue_series flag, either series_id_values or continue_series_values "
+							"When using the continue_series flag, either series_id_values or series_context_values "
 							"must be specified, but not both."
 						))
+				))
+			)
+		)
+
+		(if (and
+				(size series_context_values)
+				(not (size series_context_features))
+			)
+			(conclude
+				(call !Return (assoc
+					errors (list "series_context_values is provided without series_context_features, please specify series_context_features.")
 				))
 			)
 		)
@@ -217,17 +221,9 @@
 		)
 
 		;if user passed in a series for continuing, create a temporary trainee to derive all the necessary values (lags, deltas, etc.)
-		;and then overwrite the passed continue_series_values with the additional derived feature values
-		(if (size continue_series_values)
+		;and then overwrite the passed series_context_values with the additional derived feature values
+		(if (and continue_series (size series_context_values))
 			(seq
-				(if (= 0 (size continue_series_features))
-					(conclude (conclude
-						(call !Return (assoc
-							errors (list "continue_series_values is provided without continue_series_features, please specify continue_series_features")
-						))
-					))
-				)
-
 				(declare (assoc trainee_clone (first (create_entities (null))) ))
 
 				;create a shollow copy (no contained entities, just the trainee data)
@@ -235,22 +231,20 @@
 
 				;train and derive all the lags and other features as necessary
 				(call_entity trainee_clone "train" (assoc
-					cases continue_series_values
-					features continue_series_features
+					cases series_context_values
+					features series_context_features
 					session "temp"
 					input_is_substituted input_is_substituted
 				))
 
 				;use all the features including all the derived ones
-				(assign (assoc continue_series_features !trainedFeatures ))
+				(assign (assoc series_context_features !trainedFeatures ))
 
 				(assign (assoc
-					;explicitly set the continue_series flag to true since values are provided
-					continue_series (true)
-					continue_series_values
+					series_context_values
 						(get
 							(call_entity trainee_clone "get_cases" (assoc
-								features continue_series_features
+								features series_context_features
 								session "temp"
 							))
 							(list 1 "payload" "cases")
@@ -260,16 +254,16 @@
 				(declare (assoc
 					time_feature_index
 						(get
-							(zip continue_series_features (indices continue_series_features))
+							(zip series_context_features (indices series_context_features))
 							!tsTimeFeature
 						)
 				))
 
 				;sort the passed in data by the time feature to ensure its order
 				(assign (assoc
-					continue_series_values
+					series_context_values
 						(call !MultiSortList (assoc
-							data continue_series_values
+							data series_context_values
 							column_order_indices (list time_feature_index)
 						))
 				))
@@ -287,8 +281,6 @@
 				output_new_series_ids output_new_series_ids
 				output_features output_features
 				continue_series continue_series
-				continue_series_features continue_series_features
-				continue_series_values continue_series_values
 
 				initial_features initial_features
 				initial_values initial_values
@@ -356,16 +348,8 @@
 			series_id_tracking "fixed"
 			;{type "boolean"}
 			;flag, default is false.  When true, react_series will do a forecast of a series.
-			;	When true, either series_id_values or continue_series_values must be specified.
+			;	When true, either series_id_values or series_context_values must be specified.
 			continue_series (false)
-			;{type "list" values "string"}
-			;list of features corresponding to the values in each row of continue_series_values.
-			;	This value is ignored if continue_series_values is not specified.
-			continue_series_features (null)
-			;{type "list" values {type "list"}}
-			;3d-list of values, when specified will continue this specific untrained series as defined by these values.
-			;	continue_series flag will be ignored and treated as true if this value is specified.
-			continue_series_values (null)
 			;{type "list" values ["number" "string"]}
 			;time step values at which to begin synthesis for each series, applicable only for time series.
 			init_time_steps (null)
@@ -389,7 +373,8 @@
 			;list of features corresponding to series_context_values
 			series_context_features (list)
 			;{type "list" values {type "list" values {type "list"}}}
-			;3d-list of values, context value for each feature for each row of a series.
+			;3d-list of values, context value for each feature for each row of each series. series_context_features must be specified if this parameter
+			;is specified.
 			;	If specified max_series_lengths are ignored.
 			series_context_values (null)
 			;{type "list" values "string"}
@@ -481,9 +466,6 @@
 
 						(!= (null) series_id_values)
 						(size series_id_values)
-
-						(!= (null) continue_series_values)
-						(size continue_series_values)
 					)
 				)
 		))
@@ -551,14 +533,14 @@
 				continue_series
 				(not (xor
 					(size series_id_values)
-					(size continue_series_values)
+					(size series_context_values)
 				))
 			)
 			(conclude
 				(call !Return (assoc
 					errors
 						(list (concat
-							"When using the continue_series flag, either series_id_values or continue_series_values "
+							"When using the continue_series flag, either series_id_values or series_context_values "
 							"must be specified, but not both."
 						))
 				))
@@ -567,6 +549,17 @@
 
 		(if !hasDateTimeFeatures
 			(call !ValidateDateTimeInputs (assoc single_series (false)))
+		)
+
+		(if (and
+				(size series_context_values)
+				(not (size series_context_features))
+			)
+			(conclude
+				(call !Return (assoc
+					errors (list "series_context_values is provided without series_context_features, please specify series_context_features.")
+				))
+			)
 		)
 
 		(call !ValidateDerivedActionFeaturesIsSubset)
@@ -592,33 +585,23 @@
 		)
 
 		;if user passed in a series for continuing, create a temporary trainee to derive all the necessary values (lags, deltas, etc.)
-		;and then overwrite the passed continue_series_values with the additional derived feature values
-		(if (size continue_series_values)
+		;and then overwrite the passed series_context_values with the additional derived feature values
+		(if (and continue_series (size series_context_values))
 			(let
 				(assoc
-					original_continue_series_features continue_series_features
+					original_series_context_features series_context_features
 					time_feature_index 0
 					time_feature (retrieve_from_entity "!tsTimeFeature")
 				)
 
-				(if (= 0 (size continue_series_features))
-					(conclude (conclude
-						(call !Return (assoc
-							errors (list "continue_series_values is provided without continue_series_features, please specify continue_series_features")
-						))
-					))
-				)
-
 				;use all the features including all the derived ones
-				(assign (assoc continue_series_features !trainedFeatures ))
+				(assign (assoc series_context_features !trainedFeatures ))
 
 				(assign (assoc
-					;explicitly set the continue_series flag to true since values are provided
-					continue_series (true)
-					continue_series_values
+					series_context_values
 						(map
 							(lambda (let
-								(assoc continue_values (current_value 1) )
+								(assoc context_values (current_value 1) )
 								(declare (assoc trainee_clone (first (create_entities (null))) ))
 
 								;create a shallow copy (no contained entities, just the trainee data)
@@ -626,42 +609,42 @@
 
 								;train and derive all the lags and other features as necessary
 								(call_entity trainee_clone "train" (assoc
-									cases continue_values
-									features original_continue_series_features
+									cases context_values
+									features original_series_context_features
 									session "temp"
 									input_is_substituted input_is_substituted
 								))
 
 								(assign (assoc
-									continue_values
+									context_values
 										(get
 											(call_entity trainee_clone "get_cases" (assoc
-												features continue_series_features
+												features series_context_features
 												session "temp"
 											))
 											(list 1 "payload" "cases")
 										)
 									time_feature_index
 										(get
-											(zip continue_series_features (indices continue_series_features))
+											(zip series_context_features (indices series_context_features))
 											time_feature
 										)
 								))
 
 								;sort the passed in data by the time feature to ensure its order
 								(assign (assoc
-									continue_values
+									context_values
 										(call !MultiSortList (assoc
-											data continue_values
+											data context_values
 											column_order_indices (list time_feature_index)
 										))
 								))
 
 								(destroy_entities trainee_clone)
 
-								continue_values
+								context_values
 							))
-							continue_series_values
+							series_context_values
 						)
 				))
 			)
@@ -677,8 +660,6 @@
 				series_id_tracking series_id_tracking
 				output_features output_features
 				continue_series continue_series
-				continue_series_features continue_series_features
-				continue_series_values continue_series_values
 
 				initial_features initial_features
 				initial_values initial_values

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -18,7 +18,6 @@
 	;  context_values - list of lists.  see #single_react for description.
 	;  action_values - list of lists.  see #single_react for description.
 	;  case_indices - list of lists.  see #single_react for description.
-	;  continue_series_values - list of lists. see #single_react_series for description.
 	#!BatchReactSeries
     (declare
         (assoc
@@ -27,7 +26,7 @@
 			single_initial (= 1 (size initial_values))
             single_stop_map (= 1 (size series_stop_maps))
             single_max_length (= 1 (size max_series_lengths))
-			single_continue_series (= 1 (size continue_series_values))
+			single_series_context (= 1 (size series_context_values))
             num_reacts 1
 
             has_series_context_values (false)
@@ -37,13 +36,6 @@
         (if (= (list) series_id_values) (assign (assoc series_id_values (null))) )
 		(if (= (list) initial_values) (assign (assoc initial_values (null))) )
         (if (= (list) series_stop_maps) (assign (assoc series_stop_maps (null))) )
-
-        (if (size series_context_values)
-            (assign (assoc
-                num_reacts (size series_context_values)
-                has_series_context_values (true)
-            ))
-        )
 
         (if (= 0 (size output_features))
             ;TODO: 15300 feed into single_react_group() and output results if details are provided
@@ -82,11 +74,10 @@
 							initial_index (if single_initial 0 (current_index 1))
 							stop_map_index (if single_stop_map 0 (current_index 1))
 							max_length_index (if single_max_length 0 (current_index 1))
+							series_context_index (if single_series_context 0 (current_index 1))
 							react_rand_seed (if rand_seed (get rand_seed (current_index 1)))
-							continue_index (if single_continue_series 0 (current_index 1))
 							react_session (null)
 							react_session_training_index (null)
-							react_series_context_values (if has_series_context_values (get series_context_values (current_index 1)) (list))
 						)
 
  						;get the corresponding parameters by the index, values will be null if not specified, but must be defaulted to an empty list/assoc
@@ -94,7 +85,7 @@
 							react_series_ids (if series_id_values (get series_id_values ids_index) (list))
 							react_initial_values (if initial_values (get initial_values initial_index) (list))
 							react_series_stop_map (if series_stop_maps (get series_stop_maps stop_map_index) (assoc))
-							react_continue_values (if continue_series_values (get continue_series_values continue_index) (null))
+							react_series_context_values (if (size series_context_values) (get series_context_values series_context_index) (list))
 
 							;max series is allowed to be null
 							react_max_series_length (get max_series_lengths max_length_index)
@@ -113,8 +104,6 @@
 								output_new_series_ids output_new_series_ids
 								output_features output_features
 								continue_series continue_series
-								continue_series_features continue_series_features
-								continue_series_values react_continue_values
 
 								initial_features initial_features
 								initial_values react_initial_values
@@ -210,7 +199,8 @@
 					(zip derived_context_features)
 					(zip derived_action_features)
 					(zip action_features)
-					(if (size series_context_values)
+					;only use first row of series_context_values if not forecasting it
+					(if (and (not continue_series) (size series_context_values))
 						(zip series_context_features (first series_context_values))
 						(assoc)
 					)
@@ -254,8 +244,8 @@
 			initial_series_ids_map (null)
 			;flag to use initial features as contexts for the series ract when doing the initial react
 			use_initial_context_features (false)
-			;flag if there are values to condition each row of the series
-			has_series_context_values (size series_context_values)
+			;flag if there are values to condition each row of the series, this uses series_context_values if they're not being forecasted
+			has_series_context_values (and (size series_context_values) (not continue_series))
 			user_specified_context_features series_context_features
 
 			;features used for uniqueness validation should not include id features
@@ -1090,7 +1080,7 @@
 				series_has_terminators
 				(not (contains_index initial_features_map !tsTimeFeature))
 				;don't terminate a provided untrained continuing series
-				(= 0 (size continue_series_values))
+				(= 0 (size series_context_values))
 			)
 			(seq
 				(accum (assoc warnings (assoc "Can't continue terminated series.") ))
@@ -1109,12 +1099,12 @@
 		)
 
 		;if user has provided series data to continue, populate series_data with the provided values
-		(if (size continue_series_values)
+		(if (size series_context_values)
 			(let
 				(assoc
 					feature_order
 						(unzip
-							(zip continue_series_features (indices continue_series_features))
+							(zip series_context_features (indices series_context_features))
 							features
 						)
 				)
@@ -1123,7 +1113,7 @@
 					series_data
 						(map
 							(lambda (unzip (current_value) feature_order))
-							continue_series_values
+							series_context_values
 						)
 				))
 

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -250,7 +250,7 @@
 			initial_features_map (null)
 			;map of initial condition series id feature -> id value that are not conditioned on in context_features
 			initial_series_ids_map (null)
-			;flag to use initial features as contexts for the series ract when doing the initial react
+			;flag to use initial features as contexts for the series react when doing the initial react
 			use_initial_context_features (false)
 			;flag if there are values to condition each row of the series, this uses series_context_values if they're not being forecasted
 			has_series_context_values (and (size series_context_values) (not continue_series))

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -226,8 +226,16 @@
 			;assoc of of all features -> feature values for the current series case
 			current_case_map (null)
 			;all features that are used as contexts
-			all_context_features (append derived_context_features series_context_features)
-			;context features used for each series ract, usually same as all_context_features except for the initial react
+			all_context_features
+				(append
+					derived_context_features
+					;if series_contexts are used in the generated rows and not forecasting
+					(if (and (size series_context_features) (not continue_series))
+						series_context_features
+						(list)
+					)
+				)
+			;context features used for each series react, usually same as all_context_features except for the initial react
 			react_context_features (list)
 			;store output of react
 			react_output (null)

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -365,7 +365,7 @@
 	(print "Error given when continue_series is set but no data is given: ")
 	(call assert_same (assoc
 		obs result
-		exp "When using the continue_series flag, either series_id_values or continue_series_values must be specified, but not both."
+		exp "When using the continue_series flag, either series_id_values or series_context_values must be specified, but not both."
 	))
 
 	(assign (assoc
@@ -380,8 +380,8 @@
 				output_new_series_ids (false)
 				series_id_features (list "stock")
 				series_id_values (list (list "fake_stock"))
-				continue_series_features (list "stock" "time" "value")
-				continue_series_values [ [ ["stk_A" 1 3] ] ]
+				series_context_features (list "stock" "time" "value")
+				series_context_values [ [ ["stk_A" 1 3] ] ]
 			))
 	))
 	(call keep_result_errors)
@@ -389,7 +389,7 @@
 	(print "Error given when continue_series is set but both data are given: ")
 	(call assert_same (assoc
 		obs result
-		exp "When using the continue_series flag, either series_id_values or continue_series_values must be specified, but not both."
+		exp "When using the continue_series flag, either series_id_values or series_context_values must be specified, but not both."
 	))
 
 	;set attributes to verify that continue doesn't work on terminated series
@@ -490,7 +490,8 @@
 				action_features (list "stock" "time" "value")
 				desired_conviction 5
 				use_regional_model_residuals (false)
-				continue_series_values
+				continue_series (true)
+				series_context_values
 					(list
 						(list
 							(list "stoX"	3	85)
@@ -502,10 +503,10 @@
 	))
 	(call keep_result_errors)
 
-	(print "Errors out when continue_series_features isn't specified: ")
+	(print "Errors out when series_context_features isn't specified: ")
 	(call assert_same (assoc
 		obs result
-		exp "continue_series_values is provided without continue_series_features, please specify continue_series_features"
+		exp "series_context_values is provided without series_context_features, please specify series_context_features."
 	))
 
 	(assign (assoc
@@ -517,14 +518,14 @@
 					desired_conviction 5
 					use_regional_model_residuals (false)
 					output_new_series_ids (false)
-					continue_series_features features
 					continue_series (true)
-					continue_series_values
+					series_context_features features
+					series_context_values
 						(list
 							;validate that the time series will be sorted correctly
 							(list
-								(list "stoX"	4	86)
 								(list "stoX"	3	85)
+								(list "stoX"	4	86)
 							)
 							(list
 								(list "stoY"	24	64)


### PR DESCRIPTION
Removing the continue_series_features/values parameters. Alters the code to allow users to instead forecast data provided with the series_context_features/values parameters.