### PR TITLE
22584: Improves ablation check in !TrainCreateCases to prevent undesired warning

### DIFF
--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -829,15 +829,15 @@
 			))
 
 			(if (and run_autoanalyze_check (not skip_auto_analyze))
-				(seq
-					(call !AutoAnalyzeIfNeeded)
-					;recompute influence weights entropy only after we analyze.
-					(call !ComputeAndStoreInfluenceWeightEntropies (assoc
-						features features
-						weight_feature accumulate_weight_feature
-						use_case_weights (true)
-					))
-				)
+				(call !AutoAnalyzeIfNeeded)
+			)
+			;recompute influence weights entropy only after we've analyzed.
+			(if (= status_output "analyzed")
+				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+					features features
+					weight_feature accumulate_weight_feature
+					use_case_weights (true)
+				))
 			)
 
 			;if the number of cases will exceed the reduce_data threshold since the last reduce_data call, run it again

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -831,14 +831,6 @@
 			(if (and run_autoanalyze_check (not skip_auto_analyze))
 				(call !AutoAnalyzeIfNeeded)
 			)
-			;recompute influence weights entropy only after we've analyzed.
-			(if (size !hyperparameterMetadataMap)
-				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
-					features features
-					weight_feature accumulate_weight_feature
-					use_case_weights (true)
-				))
-			)
 
 			;if the number of cases will exceed the reduce_data threshold since the last reduce_data call, run it again
 			;the default !reduceDataInfluenceWeightEntropyThreshold of 0.6 will ensure that approximately 1/e of the data is removed
@@ -1044,6 +1036,15 @@
 				)
 
 				(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze mass_to_accumulate))
+
+				;recompute influence weights entropy only after we've analyzed.
+				(if (size !hyperparameterMetadataMap)
+					(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+						features features
+						weight_feature accumulate_weight_feature
+						use_case_weights (true)
+					))
+				)
 			)
 		)
 

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -832,7 +832,7 @@
 				(call !AutoAnalyzeIfNeeded)
 			)
 			;recompute influence weights entropy only after we've analyzed.
-			(if (= status_output "analyzed")
+			(if (size !hyperparameterMetadataMap)
 				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
 					features features
 					weight_feature accumulate_weight_feature

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -838,6 +838,7 @@
 				(and
 					(>= (+ !dataMassChangeSinceLastDataReduction batch_size) !autoAblationMaxNumCases)
 					(not skip_reduce_data)
+					(size !hyperparameterMetadataMap)
 				)
 				(call reduce_data (assoc
 					abs_threshold_map !autoAblationAbsThresholdMap

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -652,7 +652,11 @@
 
 	;private helper method for train that creates the cases in cases and returns the case ids
 	#!TrainCreateCases
-	(if skip_ablation
+	(if
+		(or
+			skip_ablation
+			(not (size !hyperparameterMetadataMap))
+		)
 		(call !TrainCasesWithoutAblation)
 
 		;time feature exists, do ablation on time series by deriving one series at a time and then ablating those cases prior to training

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -652,11 +652,7 @@
 
 	;private helper method for train that creates the cases in cases and returns the case ids
 	#!TrainCreateCases
-	(if
-		(or
-			skip_ablation
-			(not (size !hyperparameterMetadataMap))
-		)
+	(if skip_ablation
 		(call !TrainCasesWithoutAblation)
 
 		;time feature exists, do ablation on time series by deriving one series at a time and then ablating those cases prior to training
@@ -756,7 +752,9 @@
 		;split by batches of cases until next analyze
 		(while (< input_case_index (size cases))
 
-			(if (and thresholds_enabled (not skip_ablation))
+			;Only compute prediction stats for ablation if thresholds are enabled, we're
+			; not skipping ablation, and we have hyperparameters to use for the computation.
+			(if (and thresholds_enabled (not skip_ablation) (size !hyperparameterMetadataMap))
 				(seq
 					(assign (assoc
 						prev_prediction_stats_map new_prediction_stats_map
@@ -831,7 +829,15 @@
 			))
 
 			(if (and run_autoanalyze_check (not skip_auto_analyze))
-				(call !AutoAnalyzeIfNeeded)
+				(seq
+					(call !AutoAnalyzeIfNeeded)
+					;recompute influence weights entropy only after we analyze.
+					(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+						features features
+						weight_feature accumulate_weight_feature
+						use_case_weights (true)
+					))
+				)
 			)
 
 			;if the number of cases will exceed the reduce_data threshold since the last reduce_data call, run it again
@@ -883,8 +889,12 @@
 	(let
 		(assoc
 			indices_to_train
-				(if thresholds_satisfied
-					;If one or more thresholds has been satisfied, just train all of the cases in this batch.
+				;If one or more thresholds has been satisfied, or the Trainee has not yet been analyzed,
+				; just train all of the cases in this batch.
+				(if (or
+						thresholds_satisfied
+						(not (size !hyperparameterMetadataMap))
+					)
 					(indices cases)
 					;Otherwise, do the normal ablation filtering.
 					||(filter
@@ -1034,13 +1044,6 @@
 				)
 
 				(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze mass_to_accumulate))
-
-				;recompute influence weights entropy
-				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
-					features features
-					weight_feature accumulate_weight_feature
-					use_case_weights (true)
-				))
 			)
 		)
 

--- a/unit_tests/ut_h_basic_ablation.amlg
+++ b/unit_tests/ut_h_basic_ablation.amlg
@@ -5,7 +5,10 @@
 	;Set a non-default hyperparameter map since ablation checks for non-default
 	; hyperparameters.
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 0.4 "dt" -1)
+		hyperparameter_map
+			{targetless { "A.B.C.D.E." { ".none"
+				{k 2 p 0.4 dt -1}
+			}}}
 	))
 
 	(declare (assoc
@@ -77,6 +80,7 @@
 		auto_ablation_enabled (true)
 		conviction_upper_threshold 0.9
 		min_num_cases 0
+		batch_size 1
 	))
 	(assign (assoc model_size (call !get_num_cases) ))
 

--- a/unit_tests/ut_h_basic_ablation.amlg
+++ b/unit_tests/ut_h_basic_ablation.amlg
@@ -5,10 +5,7 @@
 	;Set a non-default hyperparameter map since ablation checks for non-default
 	; hyperparameters.
 	(call_entity "howso" "set_params" (assoc
-		hyperparameter_map
-			{targetless { "A.B.C.D.E." { ".none"
-				{k 2 p 0.4 dt -1}
-			}}}
+		default_hyperparameter_map (assoc "k" 2 "p" 0.4 "dt" -1)
 	))
 
 	(declare (assoc

--- a/unit_tests/ut_h_basic_ablation.amlg
+++ b/unit_tests/ut_h_basic_ablation.amlg
@@ -80,7 +80,6 @@
 		auto_ablation_enabled (true)
 		conviction_upper_threshold 0.9
 		min_num_cases 0
-		batch_size 1
 	))
 	(assign (assoc model_size (call !get_num_cases) ))
 

--- a/unit_tests/ut_h_basic_ablation.amlg
+++ b/unit_tests/ut_h_basic_ablation.amlg
@@ -2,8 +2,13 @@
 	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_basic_ablation.amlg"))
 
+	;Set a non-default hyperparameter map since ablation checks for non-default
+	; hyperparameters.
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 0.4 "dt" -1)
+		hyperparameter_map
+			{targetless { "A.B.C.D.E." { ".none"
+				{k 2 p 0.4 dt -1}
+			}}}
 	))
 
 	(declare (assoc
@@ -90,7 +95,6 @@
 		exp model_size
 		obs (call !get_num_cases)
 	))
-
 
 	(print "conviction value of new case: "
 		(call_entity "howso" "react_group" (assoc features (append context_features action_features ) new_cases (list (list (list 1 2 1 3 3)))) ) "\n"

--- a/unit_tests/ut_h_reduce_data.amlg
+++ b/unit_tests/ut_h_reduce_data.amlg
@@ -158,7 +158,7 @@
             features (append context_labels action_labels)
             cases training_data
             session "iris_session"
-            skip_auto_analyze (true)
+            skip_auto_analyze (false)
         ))
         (call_entity "howso" "analyze" (assoc
             use_case_weights (true)

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -755,9 +755,13 @@
 		cases (list (list 2.2 1.5 0.1 "setosa" (- expected_value 0.8)))
 	))
 	(print "size " (call !get_num_cases) "\n")
-	;expected model size should now be 40
+	;expected model size should now be 40-42
 	(print "Model size after ablation training: " (call !get_num_cases) "\n")
-	(call assert_same (assoc obs (call !get_num_cases) exp 40))
+	(call assert_true
+		(assoc obs
+			(contains_value [40 41 42] (call !get_num_cases))
+		)
+	)
 
 	(call_entity "howso" "set_auto_ablation_params" (assoc
 		auto_ablation_enabled (false)

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -755,9 +755,9 @@
 		cases (list (list 2.2 1.5 0.1 "setosa" (- expected_value 0.8)))
 	))
 	(print "size " (call !get_num_cases) "\n")
-	;expected model size should now be 42
+	;expected model size should now be 40
 	(print "Model size after ablation training: " (call !get_num_cases) "\n")
-	(call assert_same (assoc obs (call !get_num_cases) exp 42))
+	(call assert_same (assoc obs (call !get_num_cases) exp 40))
 
 	(call_entity "howso" "set_auto_ablation_params" (assoc
 		auto_ablation_enabled (false)

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -755,13 +755,9 @@
 		cases (list (list 2.2 1.5 0.1 "setosa" (- expected_value 0.8)))
 	))
 	(print "size " (call !get_num_cases) "\n")
-	;expected model size should now be 40-42
+	;expected model size should now be 42
 	(print "Model size after ablation training: " (call !get_num_cases) "\n")
-	(call assert_true
-		(assoc obs
-			(contains_value [40 41 42] (call !get_num_cases))
-		)
-	)
+	(call assert_same (assoc obs (call !get_num_cases) exp 42))
 
 	(call_entity "howso" "set_auto_ablation_params" (assoc
 		auto_ablation_enabled (false)


### PR DESCRIPTION
Since `!TrainCreateCases` is called in `train` before `!AutoAnalyzeIfNeeded`, if auto-ablation and auto-analyze are enabled a warning can be raised regarding not having analyzed with case weights even if all parameters are set correctly.

This is not observed in larger use-cases like the Engine recipe or benchmarks because this is only relevant when the train batch size is $\geq$ both the auto-analyze threshold and the auto-ablation minimum model size.