### PR TITLE
22716: Fixes issues in forecasting that could give an incorrect warning or malformed results

### DIFF
--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -675,6 +675,7 @@
 			features series_data_features
 			session "temp"
 			input_is_substituted input_is_substituted
+			allow_training_reserved_features (true)
 			skip_auto_analyze (true)
 			skip_reduce_data (true)
 		))

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1192,7 +1192,7 @@
 						warnings
 							(associate (concat
 								"There is no series trained with the set of IDs:\n"
-								(apply "concat" (map (lambda (concat ": "  (current_value) "\n")) id_values_map))
+								(apply "concat" (map (lambda (concat (current_value) ", ")) (indices id_values_map)))
 							))
 					))
 				)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1192,7 +1192,7 @@
 						warnings
 							(associate (concat
 								"There is no series trained with the set of IDs:\n"
-								(apply "concat" (map (lambda (concat (current_value) ", ")) (indices id_values_map)))
+								(apply "concat" (values (map (lambda (concat (current_index) ": " (current_value) "\n")) id_values_map)))
 							))
 					))
 				)


### PR DESCRIPTION
Fixes two issues in react_series.
1. If attempting to continue a series using an ID that no trained series possesses, then the warning issues was not being formed properly.
2. Forecasting with untrained data using a reserved feature name (precedes with a ".") was not functional.