### PR TITLE
22697:  Adds support for the conditioning parameters when computing feature influences with `react_aggregate`, MINOR 

### DIFF
--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -491,7 +491,6 @@
 								weight_feature distribute_weight_feature
 								use_case_weights (true)
 								compute_all_statistics (true)
-								store_values (false)
 							)) "prediction_stats")
 					)
 					(assign (assoc

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -19,6 +19,7 @@
 	; num_robust_influence_samples_per_case: optional, Specifies the number of robust samples to use for each case for robust contribution computations.
 	;				  Defaults to 300 + 2 * (number of features).
 	; run_on_local_model: optional, if true will use all the provided cases and not store results to model
+	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	#!CalculateFeatureContributions
 	(declare
 		(assoc
@@ -32,6 +33,7 @@
 			num_robust_influence_samples (null)
 			num_samples (null)
 			run_on_local_model (false)
+			context_condition_filter_query (list)
 		)
 
 		(declare (assoc
@@ -239,6 +241,7 @@
 													ignore_case case_id
 													details (assoc "categorical_action_probabilities" action_is_nominal)
 													hyperparam_map hyperparam_map
+													filtering_queries context_condition_filter_query
 												))
 											with_features_set (zip filtered_context_features)
 										))
@@ -452,6 +455,7 @@
 													ignore_case case_id
 													details (assoc "categorical_action_probabilities" action_is_nominal)
 													hyperparam_map hyperparam_map
+													filtering_queries context_condition_filter_query
 												))
 											reaction_without
 												(call !ReactDiscriminative (assoc
@@ -464,6 +468,7 @@
 													ignore_case case_id
 													details (assoc "categorical_action_probabilities" action_is_nominal)
 													hyperparam_map hyperparam_map
+													filtering_queries context_condition_filter_query
 												))
 											correct_value
 												(if action_is_nominal

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -257,24 +257,6 @@
 												)
 										))
 
-										(if (< react_value 1.0)
-											(seq
-												(print "alert!!")
-												(call !ReactDiscriminative (assoc
-													context_features filtered_context_features
-													context_values (unzip case_values_map filtered_context_features)
-													action_features (list action_feature)
-													skip_decoding (true)
-													skip_encoding (true)
-													;ignore the local case
-													ignore_case case_id
-													details (assoc "categorical_action_probabilities" action_is_nominal)
-													hyperparam_map hyperparam_map
-													filtering_queries context_condition_filter_query
-												))
-											)
-										)
-
 										;output a pair of two lists, each of the two list is the length of context_features
 										; (list (list react_values_with_feature_as_context) (list react_values_without_feature_as_context))
 										(list

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -257,6 +257,24 @@
 												)
 										))
 
+										(if (< react_value 1.0)
+											(seq
+												(print "alert!!")
+												(call !ReactDiscriminative (assoc
+													context_features filtered_context_features
+													context_values (unzip case_values_map filtered_context_features)
+													action_features (list action_feature)
+													skip_decoding (true)
+													skip_encoding (true)
+													;ignore the local case
+													ignore_case case_id
+													details (assoc "categorical_action_probabilities" action_is_nominal)
+													hyperparam_map hyperparam_map
+													filtering_queries context_condition_filter_query
+												))
+											)
+										)
+
 										;output a pair of two lists, each of the two list is the length of context_features
 										; (list (list react_values_with_feature_as_context) (list react_values_without_feature_as_context))
 										(list

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -19,7 +19,6 @@
 	; num_robust_influence_samples_per_case: optional, Specifies the number of robust samples to use for each case for robust contribution computations.
 	;				  Defaults to 300 + 2 * (number of features).
 	; run_on_local_model: optional, if true will use all the provided cases and not store results to model
-	; store_values: flag, optional. if set to true will store the statistics in trainee-level caches, if set to false will return the set of values
 	#!CalculateFeatureContributions
 	(declare
 		(assoc
@@ -33,7 +32,6 @@
 			num_robust_influence_samples (null)
 			num_samples (null)
 			run_on_local_model (false)
-			store_values (true)
 		)
 
 		(declare (assoc
@@ -139,7 +137,7 @@
 		)
 
 		;outputs the pair of assocs
-		(if (or run_on_local_model (not store_values) )
+		(if run_on_local_model
 			(conclude (list feature_contributions_map directional_contributions_map))
 		)
 

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -333,8 +333,7 @@
 
 		(if (or (get details "prediction_stats") (get details "feature_residuals_full"))
 			; if computing all statistics, default is to store values. Turns off
-			; storing values for local metrics. For residuals only, the code doesn't
-			; use the store_values parameter.
+			; storing values for local metrics.
 			(call !ComputeReactFeatureResiduals (assoc
 				compute_all_statistics compute_all_statistics
 				robust_residuals (false)
@@ -343,8 +342,7 @@
 
 		(if (get details "feature_residuals_robust")
 			; if computing all statistics, default is to store values. Turns off
-			; storing values for local metrics. For residuals only, the code doesn't
-			; use the store_values parameter.
+			; storing values for local metrics.
 			(call !ComputeReactFeatureResiduals (assoc
 					compute_all_statistics (false)
 					robust_residuals (true)

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -41,7 +41,6 @@
 								regional_model_only (true)
 								robust_residuals robust_residuals
 								compute_all_statistics compute_all_statistics
-								store_values store_values
 								;use the same hyperparameters that were used to make the original prediction
 								custom_hyperparam_map hyperparam_map
 								compute_null_uncertainties (false)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -210,7 +210,6 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; custom_hyperparam_map: optional, hyperparameters to use for residuals computation
 	; compute_all_statistics: flag, optional. if set to true will compute other statistics (precision, recall, r^2, rmse, etc.) in addition to MAE
-	; store_values: flag, optional. if set to true will store the statistics in trainee-level caches, if set to false will return the set of values
 	; confusion_matrix_min_count: number, optional, default is 10. Applicable only to confusion matrices, the number of predictions a class should have
 	;		(value of a cell in the matrix) for it to remain in the confusion matrix. If the count is less than this value, it will be accumulated
 	;		into a single value of all insignificant predictions for the class and removed from the confusion matrix.

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -197,14 +197,9 @@
 	; context_features: list of features to be used as the context. If not specified, will use the value of features.
 	; target_residual_feature: optional feature for which to calculate the (MAE) residual. If not specified, will compute for all features.
 	; case_ids: optional list of case ids to compute residuals for the action set, will ignore 'action_condition_filter_query' and 'num_samples' if specified
-	; action_condition_filter_query: optional list of filtering queries for the action set. If both 'action_condition_filter_query' and 'context_condition_filter_query' are specified,
-	;		then all of the action cases selected by the 'action_condition_filter_query' will be excluded from the context set, effectively holding them out.
-	;		If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
-	; num_samples: optional, limit on the number of cases for the action set to use in calculating conditional residuals. Works with or without 'action_condition_filter_query'. If
-	; 		'action_condition_filter_query' is not provided, will be ignored if 'case_ids' is provided.
-	; context_condition_filter_query: optional list of filtering queries for the context set. Ignored if 'action_condition_filter_query' is not specified.
-	;		If both 'action_condition_filter_query' and 'context_condition_filter_query' are specified, then all of the cases selected by the 'action_condition_filter_query'
-	;		will be excluded from the context set, effectively holding them out. If only 'action_condition_filter_query' is specified, then only the single predicted case will be left out.
+	; num_samples: optional, limit on the number of cases for the action set to use in calculating conditional residuals.
+	; context_condition_filter_query: optional list of filtering queries for the context set.
+	; strict_case_ids: flag, default to false. If true, then any augmentations to case ids is prohibited (selecting additional non-null cases, more null cases, etc.)
 	; focal_case: optional case id of case for which to compute residuals for  is to be ignored during computation
 	; regional_model_only: flag, default to false. when set to true will only explicitly use the specified case_ids for computation.
 	; robust_residuals: string, default to (null). when "deviations" calculates accurate local residuals, otherwise computes residuals robust with respect to the set of contexts used
@@ -234,10 +229,10 @@
 			regional_model_only (false)
 			focal_case (null)
 			robust_residuals (false)
+			strict_case_ids (false)
 
 			;ordered by priority for the action set, with the 'case_ids' parameters having the top priority.
 			case_ids (list)
-			action_condition_filter_query (list)
 			context_condition_filter_query (list)
  			num_samples (null)
 
@@ -288,8 +283,6 @@
 			null_accuracies_map (assoc)
 			;list of unique features to populate output at the end
 			unique_features_for_populating_output (null)
-
-			provided_case_id_flag (true)
 
 			;store an assoc of lag/rate/delta feature -> lag/order amount for time series flows
 			ts_feature_lag_amount_map (null)

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -9,11 +9,13 @@
 			num (null)
 			start_offset 0
 			rand_seed (null)
+			query_conditions (list)
 		)
 		(if (!= (null) num)
 			(if (!= (null) rand_seed)
-				(contained_entities (list
+				(contained_entities (append
 					(query_exists !internalLabelSession)
+					query_conditions
 					(query_select num start_offset rand_seed)
 				))
 
@@ -25,8 +27,9 @@
 
 
 			;else return all
-			(contained_entities (list
+			(contained_entities (append
 				(query_exists !internalLabelSession)
+				query_conditions
 			))
 		)
 	)

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -42,17 +42,20 @@
 			num (null)
 			rand_seed (null)
 			case_weight_feature (null)
+			query_conditions (list)
 		)
 		(if (!= (null) num)
-			(contained_entities (list
+			(contained_entities (append
 				(query_exists !internalLabelSession)
+				query_conditions
 				(query_sample num case_weight_feature
 					(if (!= (null) rand_seed) rand_seed (rand)))
 			))
 
 			;else return samples with replacement on all cases
-			(contained_entities (list
+			(contained_entities (append
 				(query_exists !internalLabelSession)
+				query_conditions
 				(query_sample (call !GetNumTrainingCases) case_weight_feature (rand))
 			))
 		)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -82,6 +82,7 @@
 					custom_hyperparam_map hyperparam_map
 					use_case_weights use_case_weights
 					weight_feature weight_feature
+					context_condition_filter_query context_condition_filter_query
 				))
 		))
 
@@ -117,6 +118,7 @@
 											custom_hyperparam_map hyperparam_map
 											use_case_weights use_case_weights
 											weight_feature weight_feature
+											context_condition_filter_query context_condition_filter_query
 
 											;the scramble feature index will be null if doing feature knockout
 											scramble_feature_index

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -20,6 +20,7 @@
 	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
+	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	#!DecreaseInAccuracy
 	(declare
 		(assoc
@@ -34,6 +35,7 @@
 			weight_feature ".case_weight"
 			use_case_weights (null)
 			hyperparam_map (null)
+			context_condition_filter_query (list)
 		)
 
 		(if (= (null) hyperparam_map)
@@ -173,6 +175,7 @@
 	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
+	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	#!CalculateModelMAE
 	(declare
 		(assoc
@@ -191,6 +194,7 @@
 			custom_hyperparam_map (null)
 			use_case_weights (null)
 			weight_feature ".case_weight"
+			context_condition_filter_query (list)
 		)
 
 		;if a corresponding feature list for each case was provided, only consider action features from that list
@@ -360,6 +364,7 @@
 									use_case_weights use_case_weights
 									;disable usage of dependent features for resdiual computation to prevent recursive behaviour in reacts
 									has_dependent_features (false)
+									filtering_queries context_condition_filter_query
 								))
 							expected_values (retrieve_from_entity (if cases_already_removed (list "_temp_" case_id ) case_id) react_action_features)
 						))

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1279,7 +1279,10 @@
 							(list)
 						)
 						dependent_queries_list
-						custom_extra_filtering_queries
+						(if (size custom_extra_filtering_queries)
+							custom_extra_filtering_queries
+							(list)
+						)
 						(if ignore_case
 							(if focal_case
 								(query_not_in_entity_list (list ignore_case focal_case))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -129,7 +129,7 @@
 			;				If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
 			;			If 'action_condition' is not set:
 			;				If null, will be set to the Howso default limit of 2000. default is null
-			;		context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the collection of cases available in queries while computing the requested metrics.
+			;		context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the collection of cases available in queries made to compute metrics.
 			;			no value = must have feature
 			;			- for continuous or numeric ordinal features:
 			;				one value = must equal exactly the value or be close to it for fuzzy match

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -341,7 +341,7 @@
 				;if there is 1000 or less cases and no other parametrization of the sample
 				(if (and
 						(not (size action_condition_filter_query))
-						(not num_cases)
+						(not num_samples)
 						(not sample_model_fraction)
 						(<= num_training_cases 1000)
 					)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -116,10 +116,7 @@
 			;							values for a specified feature.
 			;						"all": All of the available prediction stats including the confusion_matrix
 			;				If empty, will return all of the available prediction stats not including the confusion matrices.
-			;		action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the dataset for which the prediction stats are for.
-			;			If both 'action_condition' and 'context_condition' are provided, then all of the action cases selected by the 'action_condition'
-			;			will be excluded from the context set, which is the set being queried to make to make predictions on the action set, effectively holding them out.
-			;			If only 'action_condition' is specified, then only the single predicted case will be left out.
+			;		action_condition: assoc of feature->value(s), optional. If specified, will condition the action set, which is the collection of cases that metrics will be computed upon.
 			;			no value = must have feature
 			;			- for continuous or numeric ordinal features:
 			;				one value = must equal exactly the value or be close to it for fuzzy match
@@ -132,9 +129,7 @@
 			;				If null, will be set to k if precision is "similar" or no limit if precision is "exact". default is null
 			;			If 'action_condition' is not set:
 			;				If null, will be set to the Howso default limit of 2000. default is null
-			;		context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the set being queried to make to make predictions on the action set.
-			;			If both 'action_condition' and 'context_condition' are provided, then all of the cases from the action set, which is the dataset for which the prediction stats are for,
-			;			will be excluded from the context set,  effectively holding them out. If only 'action_condition' is specified, then only the single predicted case will be left out.
+			;		context_condition: assoc of feature->value(s), optional. If specified, will condition the context set, which is the collection of cases available in queries while computing the requested metrics.
 			;			no value = must have feature
 			;			- for continuous or numeric ordinal features:
 			;				one value = must equal exactly the value or be close to it for fuzzy match
@@ -311,72 +306,6 @@
 			(assign (assoc action_features context_features ))
 		)
 
-
-		;if num_samples was explicitly specified, use that many, even if it means
-		;it should super-sample the model to match the exact number of samples specified
-		;and by default sample 1000 out of the full model if num_samples wasn't specified
-		(declare (assoc
-			case_ids
-				(if num_samples
-					(call !SampleCases (assoc
-						num num_samples
-						case_weight_feature (if valid_weight_feature weight_feature)
-					))
-
-					(> sample_model_fraction 0)
-					(call !AllCases (assoc
-						num (* sample_model_fraction num_training_cases)
-					))
-
-					;else just sample 1000 cases
-					(or
-						(get details "feature_residuals_full")
-						(get details "feature_mda_full")
-						(get details "feature_mda_permutation_full")
-						(get details "feature_contributions_full")
-					)
-					(if (> (call !GetNumTrainingCases) 1000)
-						;if more than 1000 cases, sample 1000
-						(call !SampleCases (assoc
-							num 1000
-							case_weight_feature (if valid_weight_feature weight_feature)
-						))
-
-						;otherwise just use all the cases
-						(call !AllCases)
-					)
-				)
-			robust_residual_case_ids
-				(if num_robust_residual_samples
-					(call !SampleCases (assoc
-						num num_robust_residual_samples
-						case_weight_feature (if valid_weight_feature weight_feature)
-					))
-
-					;for robust residual flows, scale the number of cases relative to the log of context_features
-					;TODO: remove feature_mda_full from this logic
-					(or robust_residuals (get details "feature_mda_robust") (get details "feature_mda_permutation_full"))
-					(call !SampleCases (assoc
-						num (* 1000 (+ 1 (log (size context_features))))
-						case_weight_feature (if valid_weight_feature weight_feature)
-					))
-				)
-			robust_influence_case_ids
-				(if	num_robust_influence_samples
-					(call !SampleCases (assoc
-						num num_robust_influence_samples
-						case_weight_feature (if valid_weight_feature weight_feature)
-					))
-
-					;TODO: add feature_mda_full to this logic
-					(get details "feature_contributions_robust")
-					(call !SampleCases (assoc
-						num 300
-						case_weight_feature (if valid_weight_feature weight_feature)
-					))
-				)
-		))
-
 		(declare (assoc
 			;set the custom hp map if specified a hyperparameter_param_path
 			custom_hyperparam_map
@@ -404,6 +333,62 @@
 				)
 		))
 
+		;if num_samples was explicitly specified, use that many, even if it means
+		;it should super-sample the model to match the exact number of samples specified
+		;and by default sample 1000 out of the full model if num_samples wasn't specified
+		(declare (assoc
+			case_ids
+				;if there is 1000 or less cases and no other parametrization of the sample
+				(if (and
+						(not (size action_condition_filter_query))
+						(not num_cases)
+						(not sample_model_fraction)
+						(<= num_training_cases 1000)
+					)
+					(call !AllCases)
+
+					;otherwise sample based on other parameters
+					(call !SampleCases (assoc
+						case_weight_feature (if (and use_case_weights valid_weight_feature) weight_feature)
+						num
+							(if num_samples
+								num_samples
+
+								(> sample_model_fraction 0)
+								(floor (* sample_model_fraction num_training_cases))
+
+								;otherwise default to 1000 (or model size if less than 1000)
+								(min num_training_cases 1000)
+							)
+						query_conditions action_condition_filter_query
+					))
+				)
+			robust_residual_case_ids
+				(call !SampleCases (assoc
+					num
+						(if num_robust_residual_samples
+							num_robust_residual_samples
+
+							(* 1000 (+ 1 (log (size context_features))))
+						)
+					case_weight_feature (if valid_weight_feature weight_feature)
+					query_conditions action_condition_filter_query
+				))
+			robust_influence_case_ids
+				(call !SampleCases (assoc
+					num
+						(if num_robust_influence_samples
+							num_robust_influence_samples
+
+							;Ideally this would be larger, but performance is of significant concern here.
+							300
+						)
+					case_weight_feature (if valid_weight_feature weight_feature)
+					query_conditions action_condition_filter_query
+				))
+		))
+
+
 		;calculates and stores the full residuals unless its conditioned prediction stats
 		(if (get details "prediction_stats")
 			(let
@@ -419,14 +404,9 @@
 							custom_hyperparam_map custom_hyperparam_map
 							compute_all_statistics (true)
 							confusion_matrix_min_count confusion_matrix_min_count
-							action_condition_filter_query action_condition_filter_query
 							context_condition_filter_query context_condition_filter_query
-							case_ids
-								;if there is an action condition, case ids matching the condition will be selected internally
-								(if (size action_condition_filter_query)
-									(null)
-									case_ids
-								)
+							case_ids case_ids
+							strict_case_ids (!= 0 (size action_condition_filter_query))
 						))
 					selected_prediction_stats
 						(call !ProcessSelectedPredictionStats (assoc selected_prediction_stats (or (get details "selected_prediction_stats") [])))
@@ -472,6 +452,8 @@
 									custom_hyperparam_map custom_hyperparam_map
 									compute_all_statistics (false)
 									confusion_matrix_min_count confusion_matrix_min_count
+									context_condition_filter_query context_condition_filter_query
+									strict_case_ids (!= 0 (size action_condition_filter_query))
 								))
 								"residual_map"
 							)
@@ -590,8 +572,7 @@
 										action_features [feature_influences_action_feature]
 										sensitivity_to_randomization (false)
 										robust (true)
-										;TODO: replace with robust_influence_case_ids
-										case_ids robust_residual_case_ids
+										case_ids robust_influence_case_ids
 										use_case_weights use_case_weights
 										weight_feature weight_feature
 										hyperparam_map custom_hyperparam_map
@@ -629,8 +610,7 @@
 										action_features [feature_influences_action_feature]
 										sensitivity_to_randomization (true)
 										robust (true)
-										;TODO: replace with robust_influence_case_ids
-										case_ids robust_residual_case_ids
+										case_ids robust_influence_case_ids
 										use_case_weights use_case_weights
 										weight_feature weight_feature
 										hyperparam_map custom_hyperparam_map

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -345,7 +345,30 @@
 						(not sample_model_fraction)
 						(<= num_training_cases 1000)
 					)
-					(call !AllCases)
+					(call !AllCases (assoc
+						query_conditions action_condition_filter_query
+					))
+
+					;sample_model_fraction indicates to sample without replacement
+					(and
+						;num_samples should be prioritzed over sample_model_fraction
+						(not num_samples)
+						(> sample_model_fraction 0)
+					)
+					(call !AllCases (assoc
+						num (floor (* sample_model_fraction num_training_cases))
+						query_conditions action_condition_filter_query
+						rand_seed (rand)
+					))
+
+					;if specified less samples than training cases or less than 1000 cases
+					(or
+						(< num_samples num_training_cases)
+						(< num_training_cases 1000)
+					)
+					(call !AllCases (assoc
+						query_conditions action_condition_filter_query
+					))
 
 					;otherwise sample based on other parameters
 					(call !SampleCases (assoc
@@ -353,9 +376,6 @@
 						num
 							(if num_samples
 								num_samples
-
-								(> sample_model_fraction 0)
-								(floor (* sample_model_fraction num_training_cases))
 
 								;otherwise default to 1000 (or model size if less than 1000)
 								(min num_training_cases 1000)
@@ -479,6 +499,7 @@
 									custom_hyperparam_map custom_hyperparam_map
 									compute_all_statistics (false)
 									confusion_matrix_min_count confusion_matrix_min_count
+									context_condition_filter_query context_condition_filter_query
 								))
 								"residual_map"
 							)
@@ -507,6 +528,7 @@
 								case_ids case_ids
 								weight_feature weight_feature
 								custom_hyperparam_map custom_hyperparam_map
+								context_condition_filter_query context_condition_filter_query
 								num_samples num_samples
 							))
 					))
@@ -524,6 +546,7 @@
 								custom_hyperparam_map custom_hyperparam_map
 								num_robust_influence_samples num_robust_influence_samples
 								num_robust_influence_samples_per_case num_robust_influence_samples_per_case
+								context_condition_filter_query context_condition_filter_query
 							))
 					))
 				)
@@ -557,6 +580,7 @@
 										use_case_weights use_case_weights
 										weight_feature weight_feature
 										hyperparam_map custom_hyperparam_map
+										context_condition_filter_query context_condition_filter_query
 									))
 							)
 					))
@@ -576,6 +600,7 @@
 										use_case_weights use_case_weights
 										weight_feature weight_feature
 										hyperparam_map custom_hyperparam_map
+										context_condition_filter_query context_condition_filter_query
 									))
 							)
 					))
@@ -595,6 +620,7 @@
 										use_case_weights use_case_weights
 										weight_feature weight_feature
 										hyperparam_map custom_hyperparam_map
+										context_condition_filter_query context_condition_filter_query
 									))
 							)
 					))
@@ -614,6 +640,7 @@
 										use_case_weights use_case_weights
 										weight_feature weight_feature
 										hyperparam_map custom_hyperparam_map
+										context_condition_filter_query context_condition_filter_query
 									))
 							)
 					))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -485,6 +485,7 @@
 									compute_all_statistics (false)
 									confusion_matrix_min_count confusion_matrix_min_count
 									context_condition_filter_query context_condition_filter_query
+									strict_case_ids (!= 0 (size action_condition_filter_query))
 								))
 								"residual_map"
 							)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -338,50 +338,35 @@
 		;and by default sample 1000 out of the full model if num_samples wasn't specified
 		(declare (assoc
 			case_ids
-				;if there is 1000 or less cases and no other parametrization of the sample
-				(if (and
-						(not (size action_condition_filter_query))
-						(not num_samples)
-						(not sample_model_fraction)
-						(<= num_training_cases 1000)
-					)
-					(call !AllCases (assoc
+				(if num_samples
+					(call !SampleCases (assoc
+						num num_samples
+						case_weight_feature (if valid_weight_feature weight_feature)
 						query_conditions action_condition_filter_query
 					))
 
-					;sample_model_fraction indicates to sample without replacement
-					(and
-						;num_samples should be prioritzed over sample_model_fraction
-						(not num_samples)
-						(> sample_model_fraction 0)
-					)
+					(> sample_model_fraction 0)
 					(call !AllCases (assoc
-						num (floor (* sample_model_fraction num_training_cases))
+						num (* sample_model_fraction num_training_cases)
 						query_conditions action_condition_filter_query
 						rand_seed (rand)
 					))
 
-					;if specified less samples than training cases or less than 1000 cases
-					(or
-						(< num_samples num_training_cases)
-						(< num_training_cases 1000)
+					;otherwise sample 1000 or the whole model
+					(if (> num_training_cases 1000)
+						;if more than 1000 cases, sample 1000
+						(call !SampleCases (assoc
+							num 1000
+							case_weight_feature (if valid_weight_feature weight_feature)
+							query_conditions action_condition_filter_query
+						))
+
+						;otherwise just use all the cases
+						(call !AllCases (assoc
+							query_conditions action_condition_filter_query
+							rand_seed (rand)
+						))
 					)
-					(call !AllCases (assoc
-						query_conditions action_condition_filter_query
-					))
-
-					;otherwise sample based on other parameters
-					(call !SampleCases (assoc
-						case_weight_feature (if (and use_case_weights valid_weight_feature) weight_feature)
-						num
-							(if num_samples
-								num_samples
-
-								;otherwise default to 1000 (or model size if less than 1000)
-								(min num_training_cases 1000)
-							)
-						query_conditions action_condition_filter_query
-					))
 				)
 			robust_residual_case_ids
 				(call !SampleCases (assoc

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -289,7 +289,13 @@
 				;action feature is not also a context feature
 				;output as a list
 				(assign (assoc
-					react_action_values (list (call !GenerateReaction (assoc allow_nulls allow_nulls)) )
+					react_action_values
+						(list
+							(call !GenerateReaction (assoc
+								allow_nulls allow_nulls
+								custom_extra_filtering_queries filtering_queries
+							))
+						)
 				))
 			)
 
@@ -363,6 +369,7 @@
 								context_features context_features_param
 								context_values context_values_param
 								action_features (list action_feature)
+								custom_extra_filtering_queries filtering_queries
 							))
 					))
 

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -451,48 +451,33 @@
 			(assign (assoc max_lag_index_value (apply "max" (values ts_feature_lag_amount_map)) ))
 		)
 
-		;flag that 'case_ids' were not provided so 'action_condition_filter_query' is used.
-		(if (and (= (size case_ids) 0) (size action_condition_filter_query))
-			(assign (assoc
-				provided_case_id_flag (false)
-			))
-		)
-
-		;if 'case_id' and 'action_condition_filter_query' are not specified either, use a random 'num_samples' sampling of cases from the whole model
+		;if 'case_id' are not specified, use a random 'num_samples' sampling of cases from the whole model
 		(if (= 0 (size case_ids))
 			(assign (assoc
 				case_ids
-					(if (size action_condition_filter_query)
-						;if action condition, get the matching case ids
-						(call !GetCasesByCondition (assoc
-							condition_filter_query action_condition_filter_query
-							num_cases num_samples
-						))
+					;sample from the model
+					;if there are more cases than the sample size, randomly select that many cases, by default cases are in random order
+					(if (and (> num_training_cases num_samples) (> num_training_cases 1000))
+						(if robust_residuals
+							(call !SampleCases (assoc
+								num num_samples
+								rand_seed (rand)
+								case_weight_feature (if valid_weight_feature weight_feature)
+							))
+							;grab samples from the model
+							(call !AllCases (assoc num num_samples rand_seed (rand)))
+						)
 
-						;otherwise sample from the model
-						;if there are more cases than the sample size, randomly select that many cases, by default cases are in random order
-						(if (and (> num_training_cases num_samples) (> num_training_cases 1000))
-							(if robust_residuals
-								(call !SampleCases (assoc
-									num num_samples
-									rand_seed (rand)
-									case_weight_feature (if valid_weight_feature weight_feature)
-								))
-								;grab samples from the model
-								(call !AllCases (assoc num num_samples rand_seed (rand)))
-							)
-
-							;else the model is small, use the smaller of num_samples or (num_cases * 2^f) because that's the amount of all possible combinations
-							(if robust_residuals
-								(call !SampleCases (assoc
-									num (min num_samples (* num_training_cases (pow 2 (size features))))
-									case_weight_feature (if valid_weight_feature weight_feature)
-								))
-								;else just use all the case ids because the model size is <= num_samples or the model is small
-								(seq
-									(declare (assoc using_full_model (true) ))
-									(call !AllCases)
-								)
+						;else the model is small, use the smaller of num_samples or (num_cases * 2^f) because that's the amount of all possible combinations
+						(if robust_residuals
+							(call !SampleCases (assoc
+								num (min num_samples (* num_training_cases (pow 2 (size features))))
+								case_weight_feature (if valid_weight_feature weight_feature)
+							))
+							;else just use all the case ids because the model size is <= num_samples or the model is small
+							(seq
+								(declare (assoc using_full_model (true) ))
+								(call !AllCases)
 							)
 						)
 					)
@@ -503,7 +488,7 @@
 		(if (and
 				(not using_full_model)
 				(not robust_residuals)
-				(= 0 (size action_condition_filter_query))
+				(not strict_case_ids)
 			)
 			(let
 				(assoc not_null_feature_output_map (call !SelectNonNullCases) )
@@ -716,22 +701,7 @@
 											(query_not_in_entity_list (list (replace case_id) (replace focal_case)))
 											(query_not_in_entity_list (list (replace case_id)))
 										)
-										;Only query the cases filtered by the 'context_condition_filter_query' if both action and context filter queries are provided and 'case_ids'
-										;were not provided at the beginning of the function, or if only the 'context_condition_filter_query' is provided. Otherwise query everything.
-										;This is due to the performance issues when using 'query_not_in_entity_list' from a large list of 'case_ids'.
-										(if
-											(or
-												(and
-													(not provided_case_id_flag)
-													(!= (size action_condition_filter_query) 0)
-													(!= (size context_condition_filter_query) 0)
-												)
-												(and
-													(not provided_case_id_flag)
-													(!= (size context_condition_filter_query) 0)
-													(= (size action_condition_filter_query) 0)
-												)
-											)
+										(if (size context_condition_filter_query)
 											context_condition_filter_query
 											(list)
 										)
@@ -1025,22 +995,7 @@
 													(query_not_equals feature (null))
 													(list)
 												)
-												;Only query the cases filtered by the 'context_condition_filter_query' if both action and context filter queries are provided and 'case_ids'
-												;were not provided at the beginning of the function, or if only the 'context_condition_filter_query' is provided. Otherwise query everything.
-												;This is due to the performance issues when using 'query_not_in_entity_list' from a large list of 'case_ids'.
-												(if
-													(or
-														(and
-															(not provided_case_id_flag)
-															(!= (size action_condition_filter_query) 0)
-															(!= (size context_condition_filter_query) 0)
-														)
-														(and
-															(not provided_case_id_flag)
-															(!= (size context_condition_filter_query) 0)
-															(= (size action_condition_filter_query) 0)
-														)
-													)
+												(if (size context_condition_filter_query)
 													context_condition_filter_query
 													(list)
 												)

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -767,7 +767,6 @@
 									weight_feature !autoAblationWeightFeature
 									use_case_weights (true)
 									compute_all_statistics (true)
-									store_values (false)
 								))
 								"prediction_stats"
 							)

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -422,6 +422,7 @@
 			)
 		thresh 0.39
 	))
+	(call exit_if_failures (assoc msg "Global prediction stats"))
 
 	(call_entity "howso" "train" (assoc
 		features features
@@ -516,7 +517,7 @@
 	; holding out all of one fruit type should result in not being able to predict that fruit correctly
 	(print "Output conditioned prediction stats for fruits with disjoint datasets correctly: ")
 	(call assert_same (assoc
-		obs 
+		obs
 			[
 				(get result ["accuracy" "fruit"])
 				(get result ["precision" "fruit"])
@@ -662,6 +663,29 @@
 			)
 		)
 	)
+
+	;computing feature contributions where only allowed to use one class for context/action should
+	;return a contribution of 0 for all features
+	(assign (assoc
+		result
+			(call_entity "howso" "react_aggregate" (assoc
+				action_feature "fruit"
+				details (assoc
+					feature_contributions_robust (true)
+					action_condition (assoc "fruit" (list "strawberry"))
+					context_condition (assoc "weight" (list "strawberry"))
+				)
+			))
+	))
+	(call keep_result_payload)
+	(print "Contributions are zero as expected: ")
+	(call assert_true (assoc
+		obs (apply "=" (append [0] (values (get result "directional_feature_contributions_robust"))))
+	))
+	(call assert_true (assoc
+		obs (apply "=" (append [0] (values (get result "feature_contributions_robust"))))
+	))
+	(call exit_if_failures (assoc msg "Heavily influenced feature influences"))
 
 	(call exit_if_failures (assoc msg unit_test_name ))
 )

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -654,13 +654,9 @@
 	; with 'features' returns prediction stats. Also tests whether having
 	; an 'action_feature' that overlaps with 'features' returns correct
 	; stats. Accuracy should be one since should only predict one case correctly.
-	(call assert_exact
-		(assoc
+	(call assert_same (assoc
 			obs result
-			exp (assoc
-				fruit (assoc accuracy 1)
-				size (assoc accuracy 1)
-			)
+			exp {accuracy {fruit 1 size 1}}
 		)
 	)
 
@@ -670,6 +666,8 @@
 		result
 			(call_entity "howso" "react_aggregate" (assoc
 				action_feature "fruit"
+				;this is truly a trivial operation, so low samples is ok
+				num_robust_influence_samples 10
 				details (assoc
 					feature_contributions_robust (true)
 					action_condition (assoc "fruit" (list "strawberry"))

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -660,7 +660,7 @@
 		)
 	)
 
-	;computing feature contributions where only allowed to use one class for context/action should
+	;computing feature influences where only allowed to use one class for context/action should
 	;return a contribution of 0 for all features
 	(assign (assoc
 		result
@@ -670,18 +670,22 @@
 				num_robust_influence_samples 10
 				details (assoc
 					feature_contributions_robust (true)
+					feature_mda_full (true)
 					action_condition (assoc "fruit" (list "strawberry"))
 					context_condition (assoc "weight" (list "strawberry"))
 				)
 			))
 	))
 	(call keep_result_payload)
-	(print "Contributions are zero as expected: ")
+	(print "Influences are zero as expected: ")
 	(call assert_true (assoc
 		obs (apply "=" (append [0] (values (get result "directional_feature_contributions_robust"))))
 	))
 	(call assert_true (assoc
 		obs (apply "=" (append [0] (values (get result "feature_contributions_robust"))))
+	))
+	(call assert_true (assoc
+		obs (apply "=" (append [0] (values (get result "feature_mda_robust"))))
 	))
 	(call exit_if_failures (assoc msg "Heavily influenced feature influences"))
 

--- a/unit_tests/ut_h_synthetic_dataset1.amlg
+++ b/unit_tests/ut_h_synthetic_dataset1.amlg
@@ -139,8 +139,8 @@
 	(print "Recalculating residuals on smaller sample size: ")
 	(call assert_approximate (assoc
 		obs (get result "feature_residuals_full")
-		exp (assoc "z" 21 "y" 0.0 "w" 3.1 "x" 28)
-		thresh (assoc "z" 2 "y" 0.001 "w" 0.4 "x" 3)
+		exp (assoc "z" 20 "y" 0.0 "w" 2.8 "x" 37)
+		thresh (assoc "z" 5 "y" 0.14 "w" 1.4 "x" 9)
 	))
 
 	(assign (assoc


### PR DESCRIPTION
Updates `react_aggregate` to use the context/action condition parameters for more than just prediction stats. Updated the docstrings and added all the necessary passthroughs to get this working. Also did my best to cleanup and simplify code where I could along the way.