### PR TITLE
22735: Update types for new FA keys, MINOR

### DIFF
--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -18,8 +18,8 @@
 			;		'allow_null': flag, allow nulls to be output, per their distribution in the data. Defaults to true
 			;		'constraint': code, whose logic has to evaluate to true for value to be considered valid.
 			;			Same format as 'derived_feature_code. Example: "(> #f1 0 #f2 0)"
-			;       'observed_min': number, string or date string, the minimum value observed
-			;       'observed_max': number, string or date string, the maximum value observed
+			;       'observed_min': number, string, or date string, the minimum value observed in the data
+			;       'observed_max': number, string, or date string, the maximum value observed in the data
 			;
 			;	'cycle_length': integer, specifies cycle length of cyclic feature, default is no cycle length
 			;

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -18,8 +18,8 @@
 			;		'allow_null': flag, allow nulls to be output, per their distribution in the data. Defaults to true
 			;		'constraint': code, whose logic has to evaluate to true for value to be considered valid.
 			;			Same format as 'derived_feature_code. Example: "(> #f1 0 #f2 0)"
-			;       'observed_min': number or date string, the minimum value observed
-			;       'observed_max': number or date string, the maximum value observed
+			;       'observed_min': number, string or date string, the minimum value observed
+			;       'observed_max': number, string or date string, the maximum value observed
 			;
 			;	'cycle_length': integer, specifies cycle length of cyclic feature, default is no cycle length
 			;

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -18,6 +18,8 @@
 			;		'allow_null': flag, allow nulls to be output, per their distribution in the data. Defaults to true
 			;		'constraint': code, whose logic has to evaluate to true for value to be considered valid.
 			;			Same format as 'derived_feature_code. Example: "(> #f1 0 #f2 0)"
+			;       'observed_min': number or date string, the minimum value observed
+			;       'observed_max': number or date string, the maximum value observed
 			;
 			;	'cycle_length': integer, specifies cycle length of cyclic feature, default is no cycle length
 			;

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -634,12 +634,12 @@
 						observed_min
 							(assoc
 								type ["number" "string"]
-								description "The observed minimum value. May be a number or date string."
+								description "The observed minimum value in the data. May be a number, string, or date string."
 							)
 						observed_max
 							(assoc
 								type ["number" "string"]
-								description "The observed maximum value. May be a number or date string."
+								description "The observed maximum value in the data. May be a number, string, or date string."
 							)
 					)
 				description "A map defining any feature bounds, allowed values, and constraints."

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -631,6 +631,16 @@
 										"than feature 'f2' value from current (offset 0) data."
 									)
 							)
+						observed_min
+							(assoc
+								type ["number" "string"]
+								description "The observed minimum value. May be a number or date string."
+							)
+						observed_max
+							(assoc
+								type ["number" "string"]
+								description "The observed maximum value. May be a number or date string."
+							)
 					)
 				description "A map defining any feature bounds, allowed values, and constraints."
 			)


### PR DESCRIPTION
- Adds `observed_min` and `observed_max` to `types.amlg`.
- Adds documentation for `observed_min` and `observed_max` to `attributes.amlg`.