### PR TITLE
22756: Improves default context feature selection behavior for `react_series_stationary`

### DIFF
--- a/howso/react_series_stationary.amlg
+++ b/howso/react_series_stationary.amlg
@@ -68,6 +68,9 @@
 					(if (size series_id_features)
 						series_id_features
 
+						(size series_context_features)
+						series_context_features
+
 						!trainedFeatures
 					)
 			))

--- a/howso/react_series_stationary.amlg
+++ b/howso/react_series_stationary.amlg
@@ -61,14 +61,11 @@
 			(call !Return (assoc errors ["Either \"series_id_values\" or \"series_context_values\" must be specified, but not both."]))
 		)
 
-		;if no context features, use those given or all features
+		;if no context features, use those given as series_context_features or all features
 		(if (= 0 (size context_features))
 			(assign (assoc
 				context_features
-					(if (size series_id_features)
-						series_id_features
-
-						(size series_context_features)
+					(if (size series_context_features)
 						series_context_features
 
 						!trainedFeatures


### PR DESCRIPTION
When specifying series_context_features/values, react_series_stationary previously would not automatically use these features as context features if no context features were specified.