### PR TITLE
22790: Updates Linux/ARM runner to use GitHub instead of emulator

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -94,7 +94,7 @@ jobs:
   test-linux-arm64:
     if: inputs.build-type != 'PR'
     needs: ['get-dependency-details', 'build']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
 
     - name: Collect Workflow Telemetry
@@ -120,19 +120,14 @@ jobs:
         cd target && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
 
     - name: Test
-      uses: pguyot/arm-runner-action@v2
-      with:
-        base_image: raspios_lite_arm64:latest
-        cpu: cortex-a8
-        image_additional_mb: 1000
-        commands: |
-          set -e
+      run: |
+        set -e
 
-          sudo apt-get install --no-install-recommends -y git jq
-          sudo sed -i "s/en_GB.UTF-8/es_ES.UTF-8/g" /etc/locale.gen
-          sudo locale-gen es_ES.UTF-8 UTF-8
+        sudo apt-get install --no-install-recommends -y git jq
+        sudo sed -i "s/en_GB.UTF-8/es_ES.UTF-8/g" /etc/locale.gen
+        sudo locale-gen es_ES.UTF-8 UTF-8
 
-          ./build/build.sh test ${{ inputs.version }}
+        ./build/build.sh test ${{ inputs.version }}
 
   test-linux-arm64_8a:
     if: inputs.build-type != 'PR'


### PR DESCRIPTION
This will improve the reliability of the workflow.