### PR TITLE
22907: Renames a variety of react and react_aggregate details, MAJOR

### DIFF
--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -759,7 +759,7 @@
 												action_features (list feature)
 												details
 													(if ablate_by_feature_residuals
-														(assoc "feature_residuals_full" (true))
+														(assoc "feature_full_residuals" (true))
 													)
 												substitute_output (false)
 												skip_encoding (true)
@@ -774,8 +774,8 @@
 											(accum (assoc
 												residual_map
 													(associate feature (assoc
-														"min" (get reaction (list "feature_residuals_full" feature))
-														"max" (get reaction (list "feature_residuals_full" feature))
+														"min" (get reaction (list "feature_full_residuals" feature))
+														"max" (get reaction (list "feature_full_residuals" feature))
 													))
 											))
 

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -133,7 +133,7 @@
 		;mda for each context feature as a ratio of error_with_feature_removed / baseline_error (where baseline uses all the context features)
 		(declare (assoc
 			context_features_mda_map
-				(call !DecreaseInAccuracy (assoc
+				(call !CalculateFeatureAccuracyContributions (assoc
 					context_features context_features
 					action_features (list action_feature)
 					output_ratio (true)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -1,7 +1,7 @@
 ;Contains methods for computing and outputting feature contributions.
 (null
 
-	;Calculate and cache feature contributions - average delta between predicted value for action_feature with and without a context feature
+	;Calculate feature prediction contributions - average delta between predicted value for action_feature with and without a context feature
 	; for all specified context_features.
 	;
 	;parameters:
@@ -21,7 +21,7 @@
 	; run_on_local_model: optional, if true will use all the provided cases and not store results to model
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; use_derivation_logic: flag, if true action feature will be derived and the features needed to derive will be predicted
-	#!CalculateFeatureContributions
+	#!CalculateFeaturePredictionContributions
 	(declare
 		(assoc
 			context_features (list)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -218,9 +218,9 @@
 		)
 
 		(associate
-			(concat "feature_contributions_" (if robust "robust" "full") )
+			(concat "feature_" (if robust "robust" "full") "_prediction_contributions")
 				feature_contributions_map
-			(concat "directional_feature_contributions_" (if robust "robust" "full") )
+			(concat "feature_" (if robust "robust" "full") "_directional_prediction_contributions")
 				directional_contributions_map
 		)
 	)

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -247,19 +247,19 @@
 		)
 
 		(if (get details "feature_robust_accuracy_contributions" )
-			(call !ComputeFeatureMDA (assoc robust (true)))
+			(call !ComputeFeatureAC (assoc robust (true)))
 		)
 
 		(if (get details "feature_full_accuracy_contributions" )
-			(call !ComputeFeatureMDA (assoc robust (false)))
+			(call !ComputeFeatureAC (assoc robust (false)))
 		)
 
 		(if (get details "feature_robust_accuracy_contributions_ex_post")
-			(call !ComputeFeatureMDAExPost (assoc robust (true)))
+			(call !ComputeFeatureACExPost (assoc robust (true)))
 		)
 
 		(if (get details "feature_full_accuracy_contributions_ex_post")
-			(call !ComputeFeatureMDAExPost (assoc robust (false)))
+			(call !ComputeFeatureACExPost (assoc robust (false)))
 		)
 
 		(if (get details "feature_robust_prediction_contributions")
@@ -302,11 +302,11 @@
 			(call !ComputeCaseContributionsFull)
 		)
 		(if (get details "case_robust_accuracy_contributions" )
-			(call !ComputeCaseMDA (assoc robust (true)))
+			(call !ComputeCaseAccuracyContributions (assoc robust (true)))
 		)
 
 		(if (get details "case_full_accuracy_contributions" )
-			(call !ComputeCaseMDA (assoc robust (false)))
+			(call !ComputeCaseAccuracyContributions (assoc robust (false)))
 		)
 
 		;update the 'selected_prediction_stats' if none is provided, or 'all' is provided. If prediction_stats is not selected, empties the list

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -196,10 +196,10 @@
 		)
 
 		(if (or
-				(get details "case_feature_residuals_full")
-				(get details "case_feature_residuals_robust")
-				(get details "case_feature_residual_convictions_full")
-				(get details "case_feature_residual_convictions_robust")
+				(get details "feature_full_residuals_for_case")
+				(get details "feature_robust_residuals_for_case")
+				(get details "feature_full_residual_convictions_for_case")
+				(get details "feature_robust_residual_convictions_for_case")
 			)
 			(call !CalculateResidualsForCase (assoc
 				context_features features
@@ -246,66 +246,66 @@
 			(call !ComputeOutlyingFeatureValues)
 		)
 
-		(if (get details "feature_mda_robust" )
+		(if (get details "feature_robust_accuracy_contributions" )
 			(call !ComputeFeatureMDA (assoc robust (true)))
 		)
 
-		(if (get details "feature_mda_full" )
+		(if (get details "feature_full_accuracy_contributions" )
 			(call !ComputeFeatureMDA (assoc robust (false)))
 		)
 
-		(if (get details "feature_mda_ex_post_robust")
+		(if (get details "feature_robust_accuracy_contributions_ex_post")
 			(call !ComputeFeatureMDAExPost (assoc robust (true)))
 		)
 
-		(if (get details "feature_mda_ex_post_full")
+		(if (get details "feature_full_accuracy_contributions_ex_post")
 			(call !ComputeFeatureMDAExPost (assoc robust (false)))
 		)
 
-		(if (get details "feature_contributions_robust")
+		(if (get details "feature_robust_prediction_contributions")
 			(if (>= model_size 2)
 				(call !ComputeFeatureContributions (assoc robust (true)))
 				;can't compute contributions if model is too small
-				(accum (assoc output (assoc "feature_contributions_robust" (zip context_features 0)) ))
+				(accum (assoc output (assoc "feature_robust_prediction_contributions" (zip context_features 0)) ))
 			)
 		)
 
-		(if (get details "feature_contributions_full")
+		(if (get details "feature_full_prediction_contributions")
 			(if (>= model_size 2)
 				(call !ComputeFeatureContributions (assoc robust (false)))
 				;can't compute contributions if model is too small
-				(accum (assoc output (assoc "feature_contributions_full" (zip context_features 0)) ))
+				(accum (assoc output (assoc "feature_full_prediction_contributions" (zip context_features 0)) ))
 			)
 		)
 
-		(if (get details "case_feature_contributions_robust")
+		(if (get details "feature_robust_prediction_contributions_for_case")
 			(if (>= model_size 2)
 				(call !ComputeCaseFeatureContributions (assoc robust (true)))
 				;can't compute contributions if model is too small
-				(accum (assoc output (assoc "case_feature_contributions_robust" (zip context_features 0)) ))
+				(accum (assoc output (assoc "feature_robust_prediction_contributions_for_case" (zip context_features 0)) ))
 			)
 		)
 
-		(if (get details "case_feature_contributions_full")
+		(if (get details "feature_full_prediction_contributions_for_case")
 			(if (>= model_size 2)
 				(call !ComputeCaseFeatureContributions (assoc robust (false)))
 				;can't compute contributions if model is too small
-				(accum (assoc output (assoc "case_feature_contributions_full" (zip context_features 0)) ))
+				(accum (assoc output (assoc "feature_full_prediction_contributions_for_case" (zip context_features 0)) ))
 			)
 		)
 
-		(if (get details "case_contributions_robust")
+		(if (get details "case_robust_prediction_contributions")
 			(call !ComputeCaseContributionsRobust)
 		)
 
-		(if (get details "case_contributions_full")
+		(if (get details "case_full_prediction_contributions")
 			(call !ComputeCaseContributionsFull)
 		)
-		(if (get details "case_mda_robust" )
+		(if (get details "case_robust_accuracy_contributions" )
 			(call !ComputeCaseMDA (assoc robust (true)))
 		)
 
-		(if (get details "case_mda_full" )
+		(if (get details "case_full_accuracy_contributions" )
 			(call !ComputeCaseMDA (assoc robust (false)))
 		)
 
@@ -331,7 +331,7 @@
 			(call !ComputeReactFeatureDeviations)
 		)
 
-		(if (or (get details "prediction_stats") (get details "feature_residuals_full"))
+		(if (or (get details "prediction_stats") (get details "feature_full_residuals"))
 			; if computing all statistics, default is to store values. Turns off
 			; storing values for local metrics.
 			(call !ComputeReactFeatureResiduals (assoc
@@ -340,7 +340,7 @@
 			))
 		)
 
-		(if (get details "feature_residuals_robust")
+		(if (get details "feature_robust_residuals")
 			; if computing all statistics, default is to store values. Turns off
 			; storing values for local metrics.
 			(call !ComputeReactFeatureResiduals (assoc

--- a/howso/details_influences.amlg
+++ b/howso/details_influences.amlg
@@ -47,7 +47,7 @@
 			output
 				(if robust
 					(assoc "feature_robust_accuracy_contributions"
-						(call !DecreaseInAccuracy (assoc
+						(call !CalculateFeatureAccuracyContributions (assoc
 							context_features context_features
 							action_features action_features
 							case_ids local_model_case_ids
@@ -55,7 +55,7 @@
 						))
 					)
 					(assoc "feature_full_accuracy_contributions"
-						(call !DecreaseInAccuracy (assoc
+						(call !CalculateFeatureAccuracyContributions (assoc
 							context_features context_features
 							action_features action_features
 							case_ids local_model_case_ids
@@ -119,7 +119,7 @@
 			output
 				(if robust
 					(assoc "feature_robust_accuracy_contributions_ex_post"
-						(call !DecreaseInAccuracy (assoc
+						(call !CalculateFeatureAccuracyContributions (assoc
 							context_features context_features
 							action_features action_features
 							case_ids local_model_case_ids
@@ -127,7 +127,7 @@
 						))
 					)
 					(assoc "feature_full_accuracy_contributions_ex_post"
-						(call !DecreaseInAccuracy (assoc
+						(call !CalculateFeatureAccuracyContributions (assoc
 							context_features context_features
 							action_features action_features
 							case_ids local_model_case_ids
@@ -653,7 +653,7 @@
 
 		(declare (assoc
 			feature_contributions_pair
-				(call !CalculateFeatureContributions (assoc
+				(call !CalculateFeaturePredictionContributions (assoc
 					context_features context_features
 					action_feature action_feature
 					robust robust

--- a/howso/details_influences.amlg
+++ b/howso/details_influences.amlg
@@ -46,7 +46,7 @@
 		(accum (assoc
 			output
 				(if robust
-					(assoc "feature_mda_robust"
+					(assoc "feature_robust_accuracy_contributions"
 						(call !DecreaseInAccuracy (assoc
 							context_features context_features
 							action_features action_features
@@ -54,7 +54,7 @@
 							robust (true)
 						))
 					)
-					(assoc "feature_mda_full"
+					(assoc "feature_full_accuracy_contributions"
 						(call !DecreaseInAccuracy (assoc
 							context_features context_features
 							action_features action_features
@@ -118,7 +118,7 @@
 		(accum (assoc
 			output
 				(if robust
-					(assoc "feature_mda_ex_post_robust"
+					(assoc "feature_robust_accuracy_contributions_ex_post"
 						(call !DecreaseInAccuracy (assoc
 							context_features context_features
 							action_features action_features
@@ -126,7 +126,7 @@
 							robust (true)
 						))
 					)
-					(assoc "feature_mda_ex_post_full"
+					(assoc "feature_full_accuracy_contributions_ex_post"
 						(call !DecreaseInAccuracy (assoc
 							context_features context_features
 							action_features action_features
@@ -174,7 +174,7 @@
 
 		;can't output mda if no action features specified
 		(if (= (null) action_feature)
-			(conclude (accum (assoc output (assoc "case_mda" (null)) )))
+			(conclude (accum (assoc output (assoc (if robust "case_robust_accuracy_contributions" "case_full_accuracy_contributions") (null)) )))
 		)
 
 		(assign (assoc
@@ -310,7 +310,7 @@
 
 						(append
 							(retrieve_from_entity mda_case_id (zip (list !internalLabelSession !internalLabelSessionTrainingIndex)))
-							(assoc "mda" mda)
+							(assoc "accuracy_contribution" mda)
 						)
 					))
 					(first local_model_cases_tuple)
@@ -322,8 +322,8 @@
 		(accum (assoc
 			output
 				(if robust
-					(assoc "case_mda_robust" cases_mdas)
-					(assoc "case_mda_full" cases_mdas)
+					(assoc "case_robust_accuracy_contributions" cases_mdas)
+					(assoc "case_full_accuracy_contributions" cases_mdas)
 				)
 		))
 	)
@@ -363,7 +363,7 @@
 
 		;can't output contributions if no action features specified
 		(if (= (null) action_feature)
-			(conclude (accum (assoc output (assoc "case_contributions_full" (null)) )))
+			(conclude (accum (assoc output (assoc "case_full_prediction_contributions" (null)) )))
 		)
 
 		(assign (assoc
@@ -442,7 +442,7 @@
 						;output assoc with session, session index and delta value
 						(append
 							(retrieve_from_entity (current_index ) (zip (list !internalLabelSession !internalLabelSessionTrainingIndex)))
-							(assoc "case_contributions_full" delta_value)
+							(assoc "full_prediction_contribution" delta_value)
 						)
 					))
 					(zip original_local_cases)
@@ -452,7 +452,7 @@
 		;restore categorical action probabilities map to whatever it was for the original react
 		(assign (assoc categorical_action_probabilities_map original_cap_map))
 
-		(accum (assoc output (assoc "case_contributions_full" (unzip case_contributions_map original_local_cases)) ))
+		(accum (assoc output (assoc "case_full_prediction_contributions" (unzip case_contributions_map original_local_cases)) ))
 	)
 
 	;Helper method to compute and add to output robust local model case contributions
@@ -595,7 +595,7 @@
 						;output assoc with session, session index and the average delta value
 						(append
 							(retrieve_from_entity (current_index ) (zip (list !internalLabelSession !internalLabelSessionTrainingIndex)))
-							(assoc "case_contributions_robust" (/ (apply "+" robust_deltas) 100) )
+							(assoc "robust_prediction_contribution" (/ (apply "+" robust_deltas) 100) )
 						)
 					))
 					local_cases_map
@@ -605,7 +605,7 @@
 		;restore categorical action probabilities map to whatever it was for the original react
 		(assign (assoc categorical_action_probabilities_map original_cap_map))
 
-		(accum (assoc output (assoc "case_contributions_robust" (unzip case_contributions_map original_local_cases)) ))
+		(accum (assoc output (assoc "case_robust_prediction_contributions" (unzip case_contributions_map original_local_cases)) ))
 	)
 
 	;Helper method to compute and output local feature contributions
@@ -668,12 +668,12 @@
 			output
 				(if robust
 					(assoc
-						"feature_contributions_robust" (first feature_contributions_pair)
-						"directional_feature_contributions_robust" (last feature_contributions_pair)
+						"feature_robust_prediction_contributions" (first feature_contributions_pair)
+						"feature_robust_directional_prediction_contributions" (last feature_contributions_pair)
 					)
 					(assoc
-						"feature_contributions_full" (first feature_contributions_pair)
-						"directional_feature_contributions_full" (last feature_contributions_pair)
+						"feature_full_prediction_contributions" (first feature_contributions_pair)
+						"feature_full_directional_prediction_contributions" (last feature_contributions_pair)
 					)
 				)
 		))
@@ -755,12 +755,12 @@
 			output
 				(if robust
 					(assoc
-						"case_feature_contributions_robust"  (map (lambda (first (current_value))) feature_contributions_pair_map)
-						"case_directional_feature_contributions_robust"  (map (lambda (last (current_value))) feature_contributions_pair_map)
+						"feature_robust_prediction_contributions_for_case"  (map (lambda (first (current_value))) feature_contributions_pair_map)
+						"feature_robust_directional_prediction_contributions_for_case"  (map (lambda (last (current_value))) feature_contributions_pair_map)
 					)
 					(assoc
-						"case_feature_contributions_full"  (map (lambda (first (current_value))) feature_contributions_pair_map)
-						"case_directional_feature_contributions_full"  (map (lambda (last (current_value))) feature_contributions_pair_map)
+						"feature_full_prediction_contributions_for_case"  (map (lambda (first (current_value))) feature_contributions_pair_map)
+						"feature_full_directional_prediction_contributions_for_case"  (map (lambda (last (current_value))) feature_contributions_pair_map)
 					)
 				)
 		))

--- a/howso/details_influences.amlg
+++ b/howso/details_influences.amlg
@@ -1,8 +1,8 @@
 ;Contains helper methods for calculating influences (MDa) for details and explanations.
 (null
 
-	;Helper method to compute and add to output local feature MDA
-	#!ComputeFeatureMDA
+	;Helper method to compute and add to output local feature accuracy contributions
+	#!ComputeFeatureAC
 	(let
 		(assoc
 			local_model_case_ids
@@ -66,8 +66,8 @@
 		))
 	)
 
-	;Helper method to compute and add to output local feature ex-post MDA
-	#!ComputeFeatureMDAExPost
+	;Helper method to compute and add to output local feature ex-post accuracy contributions
+	#!ComputeFeatureACExPost
 	(let
 		(assoc
 			;pull targetless hyperparameters because local model will include the action value and therefore is not targeted
@@ -139,7 +139,7 @@
 	)
 
 	;Helper method to compute and add to output local cases MDA
-	#!ComputeCaseMDA
+	#!ComputeCaseAccuracyContributions
 	(let
 		(assoc
 			local_model_cases_tuple

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -56,11 +56,11 @@
 		))
 
 		;append feature deviations to output if selected
-		(if (or (get details "feature_residuals_full") (get details "feature_residuals_robust"))
+		(if (or (get details "feature_full_residuals") (get details "feature_robust_residuals"))
 			(accum (assoc output
 				(if robust_residuals
-					(assoc "feature_residuals_robust" (get local_feature_metrics "residual_map"))
-					(assoc "feature_residuals_full" (get local_feature_metrics "residual_map"))
+					(assoc "feature_robust_residuals" (get local_feature_metrics "residual_map"))
+					(assoc "feature_full_residuals" (get local_feature_metrics "residual_map"))
 				)
 			))
 		)
@@ -160,17 +160,17 @@
 		(if (<= model_size 2)
 			(conclude
 				(seq
-					(if (get details "case_feature_residuals_full")
-						(accum (assoc output (assoc "case_feature_residuals_full" (zip features 0)) ))
+					(if (get details "feature_full_residuals_for_case")
+						(accum (assoc output (assoc "feature_full_residuals_for_case" (zip features 0)) ))
 					)
-					(if (get details "case_feature_residuals_robust")
-						(accum (assoc output (assoc "case_feature_residuals_robust" (zip features 0)) ))
+					(if (get details "feature_robust_residuals_for_case")
+						(accum (assoc output (assoc "feature_robust_residuals_for_case" (zip features 0)) ))
 					)
-					(if (get details "case_feature_residual_convictions_full")
-						(accum (assoc output (assoc "case_feature_residual_convictions_full" (zip features 1)) ))
+					(if (get details "feature_full_residual_convictions_for_case")
+						(accum (assoc output (assoc "feature_full_residual_convictions_for_case" (zip features 1)) ))
 					)
-					(if (get details "case_feature_residual_convictions_robust")
-						(accum (assoc output (assoc "case_feature_residual_convictions_robust" (zip features 1)) ))
+					(if (get details "feature_robust_residual_convictions_for_case")
+						(accum (assoc output (assoc "feature_robust_residual_convictions_for_case" (zip features 1)) ))
 					)
 				)
 			)
@@ -192,12 +192,12 @@
 
 		(if
 			(or
-				(get details "case_feature_residuals_robust")
-				(get details "case_feature_residual_convictions_robust")
+				(get details "feature_robust_residuals_for_case")
+				(get details "feature_robust_residual_convictions_for_case")
 			)
 			(seq
 				(call !CalculateCaseResiduals (assoc robust_residuals (true)))
-				(if (get details "case_feature_residual_convictions_robust")
+				(if (get details "feature_robust_residual_convictions_for_case")
 					(call !CalculateLocalCaseFeatureResidualConvictions  (assoc robust_residuals (true)))
 				)
 			)
@@ -205,12 +205,12 @@
 
 		(if
 			(or
-				(get details "case_feature_residuals_full")
-				(get details "case_feature_residual_convictions_full")
+				(get details "feature_full_residuals_for_case")
+				(get details "feature_full_residual_convictions_for_case")
 			)
 			(seq
 				(call !CalculateCaseResiduals (assoc robust_residuals (false)))
-				(if (get details "case_feature_residual_convictions_full")
+				(if (get details "feature_full_residual_convictions_for_case")
 					(call !CalculateLocalCaseFeatureResidualConvictions (assoc robust_residuals (false)))
 				)
 			)
@@ -475,11 +475,11 @@
 		)
 
 		;add case_feature_residuals to output if requested
-		(if (or (get details "case_feature_residuals_full")  (get details "case_feature_residuals_robust"))
+		(if (or (get details "feature_full_residuals_for_case")  (get details "feature_robust_residuals_for_case"))
 			(accum (assoc output
 				(if robust_residuals
-					(assoc "case_feature_residuals_robust" (append case_residuals_map inactive_features_zeros_map))
-					(assoc "case_feature_residuals_full" (append case_residuals_map inactive_features_zeros_map))
+					(assoc "feature_robust_residuals_for_case" (append case_residuals_map inactive_features_zeros_map))
+					(assoc "feature_full_residuals_for_case" (append case_residuals_map inactive_features_zeros_map))
 				)
 			))
 		)
@@ -606,11 +606,11 @@
 			output
 				(if robust_residuals
 					(assoc
-						"case_feature_residual_convictions_robust"
+						"feature_robust_residual_convictions_for_case"
 							(append local_convictions_map inactive_features_zeros_map)
 					)
 					(assoc
-						"case_feature_residual_convictions_full"
+						"feature_full_residual_convictions_for_case"
 							(append local_convictions_map inactive_features_zeros_map)
 					)
 				)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -1,6 +1,6 @@
 ;Contains methods for computing and outputting feature MDA.
 (null
-	;calculate the decrease in accuracy for the specified list of context and action features
+	;calculate the accuracy contribution for each feature as the decrease in accuracy for the specified list of context and action features
 	;outputs an assoc of context features -> decrease in accuracy Mean Absolute Error value
 	; if output_ratio, the ratio is: feature_mae / baseline_mae
 	; else:  feature_mae - baseline_mae
@@ -22,7 +22,7 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; use_derivation_logic: flag, if true action feature will be derived and the features needed to derive will be predicted
-	#!DecreaseInAccuracy
+	#!CalculateFeatureAccuracyContributions
 	(declare
 		(assoc
 			context_features (list)
@@ -95,75 +95,69 @@
 				))
 		))
 
-		(declare (assoc
-			output
-				;knock out each feature one by one and calculate the decrease in accuracy for each feature
-				(zip
-					(or details_context_features context_features)
-					(map
-						(lambda (let
-							(assoc
-								mae_context_features context_features
-							)
-
-							;regular Decrease in accuracy is feature knockout instead of scrambling the feature
-							(if (not sensitivity_to_randomization)
-								;remove the feature
-								(assign (assoc
-									mae_context_features (indices (remove context_features_mda (current_value 1)))
-								))
-							)
-
-							(let
-								(assoc
-									feature_mda
-										(call !CalculateModelMAE (assoc
-											action_features action_features
-											context_features mae_context_features
-											case_ids case_ids
-											ignore_exact_cases (true)
-											classification_precision classification_precision
-											robust_residuals robust
-											custom_hyperparam_map hyperparam_map
-											use_case_weights use_case_weights
-											weight_feature weight_feature
-											context_condition_filter_query context_condition_filter_query
-											use_derivation_logic use_derivation_logic
-
-											;the scramble feature index will be null if doing feature knockout
-											scramble_feature_index
-												(if sensitivity_to_randomization
-													(current_index 2)
-													(null)
-												)
-										))
-								)
-
-								;output the decrease in accuracy as a ratio of the feature / baseline MAE
-								(if output_ratio
-									;prevent output of (null) in case all maes are 0
-									(if (= 0 baseline_error)
-										.infinity
-
-										(/ feature_mda baseline_error)
-									)
-
-									;else output the difference in the MAE
-									(if (= .infinity baseline_error feature_mda)
-										0
-
-										(- feature_mda baseline_error)
-									)
-								)
-							)
-						))
-
-						(or details_context_features context_features)
+		(zip
+			(or details_context_features context_features)
+			(map
+				(lambda (let
+					(assoc
+						mae_context_features context_features
 					)
-				)
-		))
 
-		output
+					;regular Decrease in accuracy is feature knockout instead of scrambling the feature
+					(if (not sensitivity_to_randomization)
+						;remove the feature
+						(assign (assoc
+							mae_context_features (indices (remove context_features_mda (current_value 1)))
+						))
+					)
+
+					(let
+						(assoc
+							feature_mda
+								(call !CalculateModelMAE (assoc
+									action_features action_features
+									context_features mae_context_features
+									case_ids case_ids
+									ignore_exact_cases (true)
+									classification_precision classification_precision
+									robust_residuals robust
+									custom_hyperparam_map hyperparam_map
+									use_case_weights use_case_weights
+									weight_feature weight_feature
+									context_condition_filter_query context_condition_filter_query
+									use_derivation_logic use_derivation_logic
+
+									;the scramble feature index will be null if doing feature knockout
+									scramble_feature_index
+										(if sensitivity_to_randomization
+											(current_index 2)
+											(null)
+										)
+								))
+						)
+
+						;output the decrease in accuracy as a ratio of the feature / baseline MAE
+						(if output_ratio
+							;prevent output of (null) in case all maes are 0
+							(if (= 0 baseline_error)
+								.infinity
+
+								(/ feature_mda baseline_error)
+							)
+
+							;else output the difference in the MAE
+							(if (= .infinity baseline_error feature_mda)
+								0
+
+								(- feature_mda baseline_error)
+							)
+						)
+					)
+				))
+
+				(or details_context_features context_features)
+			)
+		)
 	)
 
 

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -171,22 +171,22 @@
 			;                       If "all", then returns all including the confusion_matrix. Valid values are: "mae" "confusion_matrix" "r2" "rmse"
 			;						"adjusted_smape" "smape" "spearman_coeff" "precision" "recall" "accuracy" "mcc" "all" "missing_value_accuracy"
 			;
-			;		 "feature_robust_accuracy_contributions" true or false. If true outputs each context feature's robust mean decrease in accuracy of predicting
+			;		 "feature_robust_accuracy_contributions" true or false. If true outputs each context feature's robust Accuracy Contribution in predicting
 			;						the action feature given the context. Uses only the context features of the reacted
 			;						case to determine that area.  Uses robust calculations, which uses uniform sampling from
 			;						the power set of features as the contexts for predictions.
 			;
-			;		 "feature_full_accuracy_contributions" true or false. If true outputs each context feature's full mean decrease in accuracy of predicting
+			;		 "feature_full_accuracy_contributions" true or false. If true outputs each context feature's full Accuracy Contribution in predicting
 			;						the action feature given the context. Uses only the context features of the reacted
 			;						case to determine that area. Uses full calculations, which uses leave-one-out context features for computations.
 			;
-			;		 "feature_robust_accuracy_contributions_ex_post" true or false. If true outputs each context feature's mean decrease in accuracy of
+			;		 "feature_robust_accuracy_contributions_ex_post" true or false. If true outputs each context feature's Accuracy Contribution in
 			;						predicting the action feature as a detail given that the specified prediction was
 			;						already made as specified by the action value. Uses both context and action features of
 			;						the reacted case to determine that area. Uses robust calculations, which uses uniform sampling from
 			;						the power set of features as the contexts for predictions.
 			;
-			;		 "feature_full_accuracy_contributions_ex_post" true or false. If true outputs each context feature's mean decrease in accuracy of
+			;		 "feature_full_accuracy_contributions_ex_post" true or false. If true outputs each context feature's Accuracy Contribution in
 			;						predicting the action feature as a detail given that the specified prediction was
 			;						already made as specified by the action value. Uses both context and action features of
 			;						the reacted case to determine that area. Uses full calculations, which uses leave-one-out for features for computations.
@@ -204,12 +204,12 @@
 			;						both 'feature_contributions' and non-absolute 'directional_feature_contributions'.
 			;						Uses full calculations, which uses leave-one-out context features for computations.
 			;
-			;		 "case_robust_prediction_contributions" true or false. If true outputs each influential case's mean decrease in accuracy of predicting
+			;		 "case_robust_prediction_contributions" true or false. If true outputs each influential case's Accuracy Contribution in predicting
 			;						the action feature in the local model area, as if each individual case were included
 			;						versus not included. Uses only the context features of the reacted case to determine
 			;						that area. Uses robust calculations, which uses uniform sampling from the power set of all combinations of cases.
 			;
-			;		 "case_full_prediction_contributions" true or false. If true outputs each influential case's mean decrease in accuracy of predicting
+			;		 "case_full_prediction_contributions" true or false. If true outputs each influential case's Accuracy Contribution in predicting
 			;						the action feature in the local model area, as if each individual case were included
 			;						versus not included. Uses only the context features of the reacted case to determine
 			;						that area. Uses full calculations, which uses leave-one-out for cases for computations.

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -194,14 +194,14 @@
 			;		 "feature_robust_prediction_contributions" true or false. If true outputs each context feature's differences between the
 			;						predicted action feature value and the predicted action feature value if each context
 			;						feature were not in the model for all context features in the local model area. Outputs
-			;						both 'feature_contributions' and non-absolute 'directional_feature_contributions'.
+			;						both 'feature_robust_prediction_contributions' and non-absolute 'feature_robust_directional_prediction_contributions'.
 			; 						Uses robust calculations, which uses uniform sampling from the power set of features as
 			;						the contexts for predictions.
 			;
 			;		 "feature_full_prediction_contributions" true or false. If true outputs each context feature's differences between the
 			;						predicted action feature value and the predicted action feature value if each context
 			;						feature were not in the model for all context features in the local model area. Outputs
-			;						both 'feature_contributions' and non-absolute 'directional_feature_contributions'.
+			;						both 'feature_full_prediction_contributions' and non-absolute 'feature_full_directional_prediction_contributions'.
 			;						Uses full calculations, which uses leave-one-out context features for computations.
 			;
 			;		 "case_robust_prediction_contributions" true or false. If true outputs each influential case's Accuracy Contribution in predicting

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -151,12 +151,12 @@
 			;		 "observational_errors" true or false. If true outputs observational errors for all features as defined
 			;						in feature attributes.
 			;
-			;		 "feature_residuals_robust" true or false. If true outputs feature residuals for all (context and action) features
+			;		 "feature_robust_residuals" true or false. If true outputs feature residuals for all (context and action) features
 			;						locally around the prediction. Uses only the context features of the reacted case to
 			;						determine that area. Uses robust calculations, which uses uniform sampling from
 			;						the power set of features as the contexts for predictions.
 			;
-			;		 "feature_residuals_full" true or false. If true outputs feature residuals for all (context and action) features
+			;		 "feature_full_residuals" true or false. If true outputs feature residuals for all (context and action) features
 			;						locally around the prediction. Uses only the context features of the reacted case to
 			;						determine that area. Uses full calculations, which uses leave-one-out context features for computations.
 			;
@@ -171,78 +171,78 @@
 			;                       If "all", then returns all including the confusion_matrix. Valid values are: "mae" "confusion_matrix" "r2" "rmse"
 			;						"adjusted_smape" "smape" "spearman_coeff" "precision" "recall" "accuracy" "mcc" "all" "missing_value_accuracy"
 			;
-			;		 "feature_mda_robust" true or false. If true outputs each context feature's robust mean decrease in accuracy of predicting
+			;		 "feature_robust_accuracy_contributions" true or false. If true outputs each context feature's robust mean decrease in accuracy of predicting
 			;						the action feature given the context. Uses only the context features of the reacted
 			;						case to determine that area.  Uses robust calculations, which uses uniform sampling from
 			;						the power set of features as the contexts for predictions.
 			;
-			;		 "feature_mda_full" true or false. If true outputs each context feature's full mean decrease in accuracy of predicting
+			;		 "feature_full_accuracy_contributions" true or false. If true outputs each context feature's full mean decrease in accuracy of predicting
 			;						the action feature given the context. Uses only the context features of the reacted
 			;						case to determine that area. Uses full calculations, which uses leave-one-out context features for computations.
 			;
-			;		 "feature_mda_ex_post_robust" true or false. If true outputs each context feature's mean decrease in accuracy of
+			;		 "feature_robust_accuracy_contributions_ex_post" true or false. If true outputs each context feature's mean decrease in accuracy of
 			;						predicting the action feature as a detail given that the specified prediction was
 			;						already made as specified by the action value. Uses both context and action features of
 			;						the reacted case to determine that area. Uses robust calculations, which uses uniform sampling from
 			;						the power set of features as the contexts for predictions.
 			;
-			;		 "feature_mda_ex_post_full" true or false. If true outputs each context feature's mean decrease in accuracy of
+			;		 "feature_full_accuracy_contributions_ex_post" true or false. If true outputs each context feature's mean decrease in accuracy of
 			;						predicting the action feature as a detail given that the specified prediction was
 			;						already made as specified by the action value. Uses both context and action features of
 			;						the reacted case to determine that area. Uses full calculations, which uses leave-one-out for features for computations.
 			;
-			;		 "feature_contributions_robust" true or false. If true outputs each context feature's differences between the
+			;		 "feature_robust_prediction_contributions" true or false. If true outputs each context feature's differences between the
 			;						predicted action feature value and the predicted action feature value if each context
 			;						feature were not in the model for all context features in the local model area. Outputs
 			;						both 'feature_contributions' and non-absolute 'directional_feature_contributions'.
 			; 						Uses robust calculations, which uses uniform sampling from the power set of features as
 			;						the contexts for predictions.
 			;
-			;		 "feature_contributions_full" true or false. If true outputs each context feature's differences between the
+			;		 "feature_full_prediction_contributions" true or false. If true outputs each context feature's differences between the
 			;						predicted action feature value and the predicted action feature value if each context
 			;						feature were not in the model for all context features in the local model area. Outputs
 			;						both 'feature_contributions' and non-absolute 'directional_feature_contributions'.
 			;						Uses full calculations, which uses leave-one-out context features for computations.
 			;
-			;		 "case_mda_robust" true or false. If true outputs each influential case's mean decrease in accuracy of predicting
+			;		 "case_robust_prediction_contributions" true or false. If true outputs each influential case's mean decrease in accuracy of predicting
 			;						the action feature in the local model area, as if each individual case were included
 			;						versus not included. Uses only the context features of the reacted case to determine
 			;						that area. Uses robust calculations, which uses uniform sampling from the power set of all combinations of cases.
 			;
-			;		 "case_mda_full" true or false. If true outputs each influential case's mean decrease in accuracy of predicting
+			;		 "case_full_prediction_contributions" true or false. If true outputs each influential case's mean decrease in accuracy of predicting
 			;						the action feature in the local model area, as if each individual case were included
 			;						versus not included. Uses only the context features of the reacted case to determine
 			;						that area. Uses full calculations, which uses leave-one-out for cases for computations.
 			;
-			;		 "case_contributions_robust" true or false. If true outputs each influential case's differences between the
+			;		 "case_robust_prediction_contributions" true or false. If true outputs each influential case's differences between the
 			;						predicted action feature value and the predicted action feature value if each
 			;						individual case were not included. Uses only the context features of the reacted case
 			;						to determine that area. Uses robust calculations, which uses uniform sampling from the power set of all
 			;						combinations of cases.
 			;
-			;		 "case_contributions_full" true or false. If true outputs each influential case's differences between the
+			;		 "case_full_prediction_contributions" true or false. If true outputs each influential case's differences between the
 			;						predicted action feature value and the predicted action feature value if each
 			;						individual case were not included. Uses only the context features of the reacted case
 			;						to determine that area. Uses full calculations, which uses leave-one-out for cases for computations.
 			;
-			;		 "case_feature_residuals_robust"  true or false. If true outputs feature residuals for all (context and action)
+			;		 "feature_robust_residuals_for_case"  true or false. If true outputs feature residuals for all (context and action)
 			;						features for just the specified case. Uses leave-one-out for each feature, while
 			;						using the others to predict the left out feature with their corresponding values
 			;						from this case. Uses robust calculations, which uses uniform sampling from
 			;						the power set of features as the contexts for predictions.
 			;
-			;		 "case_feature_residuals_full"  true or false. If true outputs feature residuals for all (context and action)
+			;		 "feature_full_residuals_for_case"  true or false. If true outputs feature residuals for all (context and action)
 			;						features for just the specified case. Uses leave-one-out for each feature, while
 			;						using the others to predict the left out feature with their corresponding values
 			;						from this case. Uses full calculations, which uses leave-one-out context features for computations.
 			;
-			;		 "case_feature_contributions_robust" true or false. If true outputs each context feature's differences between the
+			;		 "feature_robust_prediction_contributions_for_case" true or false. If true outputs each context feature's differences between the
 			;						predicted action feature value and the predicted action feature value if each context
 			;						feature were not in the model for all context features in this case, using only the
 			;						values from this specific case. Uses robust calculations, which uses uniform sampling from
 			;						the power set of features as the contexts for predictions.
 			;
-			;		 "case_feature_contributions_full" true or false. If true outputs each context feature's differences between the
+			;		 "feature_full_prediction_contributions_for_case" true or false. If true outputs each context feature's differences between the
 			;						predicted action feature value and the predicted action feature value if each context
 			;						feature were not in the model for all context features in this case, using only the
 			;						values from this specific case. Uses full calculations, which uses leave-one-out context features for computations.
@@ -251,12 +251,12 @@
 			;						Applicable only for computing robust feature contributions or robust case feature contributions.
 			;						When unspecified, defaults to 2000. Higher values will take longer but provide more stable results.
 			;
-			;		 "case_feature_residual_convictions_robust" true or false. If true outputs this case's robust feature residual
+			;		 "feature_robust_residual_convictions_for_case" true or false. If true outputs this case's robust feature residual
 			;						convictions for the region around the prediction. Uses only the context features of
 			;						the reacted case to determine that region. Computed as: region feature residual / case feature residual.
 			;						Uses robust calculations, which uses uniform sampling from the power set of features as the contexts for predictions.
 			;
-			;		 "case_feature_residual_convictions_full" true or false. If true outputs this case's full feature residual
+			;		 "feature_full_residual_convictions_for_case" true or false. If true outputs this case's full feature residual
 			;						convictions for the region around the prediction. Uses only the context features of
 			;						the reacted case to determine that region. Computed as: region feature residual / case feature residual.
 			;						Uses full calculations, which uses leave-one-out context features for computations.

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -1,6 +1,6 @@
-;Contains methods for computing, storing into the trainee, and returning residuals, prediction_stats, feature_mda, and feature_contributions.
+;Contains methods for computing, storing into the trainee, and returning residuals, prediction_stats, accuracy contributions, and prediction contributions.
 (null
-    ;Computes, caches, and returns specified details and feature prediction statistics such as Mean Decrease in Accuracy (MDA), residuals (accuracy, Mean Absolute Error),
+    ;Computes, caches, and returns specified details and feature prediction statistics such as Accuracy Contributions, residuals (accuracy, Mean Absolute Error),
     ; precision, recall, etc. Returns details and feature prediction stats for all features in the format of feature -> assoc stat -> value
 	;{long_running (true) statistically_idempotent (true)}
 	#react_aggregate
@@ -39,7 +39,7 @@
     		;	Applicable only to models > 1000 cases.
 			sub_model_size (null)
 			;{type "string"}
-			;target feature for which to do computations. If "prediction_stats_action_feature" and "feature_influences_action_feature"
+			;target feature for which to do feature influences computations (accuracy contributions or prediction contributions). If "prediction_stats_action_feature" and "feature_influences_action_feature"
 			;	are not provided, they will default to this value.
 			action_feature (null)
 			;{type "string"}
@@ -49,11 +49,11 @@
 			;	If this value is not specified but "action_feature" is provided, this value will default to the value of "action_feature".
 			prediction_stats_action_feature (null)
 			;{type "string"}
-			;When feature influences such as contributions and mda, use this feature as the action feature.
+			;When computing feature influences such as prediction contributions or accuracy contributions, use this feature as the action feature.
 			;	If not provided, will default to the "action_feature" if provided.
 			feature_influences_action_feature (null)
 			;{type "boolean"}
-			;flag, optional. if specified, will attempt to return stats that were computed using hyperpparameters with the
+			;flag, optional. if specified, will attempt to return stats that were computed using hyperparameters with the
     		;	specified robust or non-robust type.
 			robust_hyperparameters (null)
 			;{type "number" min 0}
@@ -91,13 +91,13 @@
 			;				Uses robust computation.
 			;		feature_deviations: optional, none/true/false. if true will compute feature deviations for each feature in action_features. The feature deviation is the mean absolute
 			;				error of predicting the feature using all the context features as well as value of the feature being predicted as the context for each prediction.
-			;		feature_full_accuracy_contributions: optional, none/true/false. if true will compute Mean Decrease in Accuracy (feature_mda) for each context feature at predicting action_feature.
+			;		feature_full_accuracy_contributions: optional, none/true/false. if true will compute Accuracy Contributions for each context feature at predicting action_feature.
 			;				Drop each feature and use the full set of remaining context features for each prediction. Uses full computation.
-			;		feature_full_accuracy_contributions_permutation: optional, none/true/false. Compute feature_full_accuracy_contributions by scrambling each feature and using the full set of remaining context features
+			;		feature_full_accuracy_contributions_permutation: optional, none/true/false. Compute Accuracy Contributions by scrambling each feature and using the full set of remaining context features
 			;				for each prediction.  Uses full computation.
-			;		feature_robust_accuracy_contributions: optional, none/true/false. Compute feature_mda by dropping each feature and using the robust (power set/permutations) set of
+			;		feature_robust_accuracy_contributions: optional, none/true/false. Compute Accuracy Contributions by dropping each feature and using the robust (power set/permutations) set of
 			;				remaining context features for each prediction. Uses robust computation.
-			;		feature_robust_accuracy_contributions_permutation: optional, none/true/false. Compute feature_mda by scrambling each feature and using the robust (power set/permutations)
+			;		feature_robust_accuracy_contributions_permutation: optional, none/true/false. Compute Accuracy Contributions by scrambling each feature and using the robust (power set/permutations)
 			;				set of remaining context features for each prediction.  Uses robust computation.
 			;		selected_prediction_stats": list of strings, optional.  Allowed values are:
 			;						"mae" : Mean absolute error. For continuous features, this is calculated as the mean of absolute values of the difference
@@ -211,7 +211,7 @@
 				)
 			)
 			(conclude
-				(call !Return (assoc errors (list "action_feature must be specified when computing feature_mda_permutation, feature_mda, or feature_contributions.")))
+				(call !Return (assoc errors (list "action_feature must be specified when computing Accuracy Contributions or Prediction Contributions.")))
 			)
 		)
 
@@ -549,7 +549,7 @@
 				(if (get details "feature_full_prediction_contributions")
 					(accum (assoc
 						output
-							(call !CalculateFeatureContributions (assoc
+							(call !CalculateFeaturePredictionContributions (assoc
 								context_features context_features
 								action_feature feature_influences_action_feature
 								robust (false)
@@ -566,7 +566,7 @@
 				(if (get details "feature_robust_prediction_contributions")
 					(accum (assoc
 						output
-							(call !CalculateFeatureContributions (assoc
+							(call !CalculateFeaturePredictionContributions (assoc
 								context_features context_features
 								action_feature feature_influences_action_feature
 								robust (true)
@@ -601,7 +601,7 @@
 						output
 							(assoc
 								"feature_full_accuracy_contributions"
-									(call !DecreaseInAccuracy (assoc
+									(call !CalculateFeatureAccuracyContributions (assoc
 										context_features context_features
 										action_features [feature_influences_action_feature]
 										sensitivity_to_randomization (false)
@@ -622,7 +622,7 @@
 						output
 							(assoc
 								"feature_robust_accuracy_contributions"
-									(call !DecreaseInAccuracy (assoc
+									(call !CalculateFeatureAccuracyContributions (assoc
 										context_features context_features
 										action_features [feature_influences_action_feature]
 										sensitivity_to_randomization (false)
@@ -643,7 +643,7 @@
 						output
 							(assoc
 								"feature_full_accuracy_contributions_permutation"
-									(call !DecreaseInAccuracy (assoc
+									(call !CalculateFeatureAccuracyContributions (assoc
 										context_features context_features
 										action_features [feature_influences_action_feature]
 										sensitivity_to_randomization (true)
@@ -664,7 +664,7 @@
 						output
 							(assoc
 								"feature_robust_accuracy_contributions_permutation"
-									(call !DecreaseInAccuracy (assoc
+									(call !CalculateFeatureAccuracyContributions (assoc
 										context_features context_features
 										action_features [feature_influences_action_feature]
 										sensitivity_to_randomization (true)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -79,25 +79,25 @@
 			;		prediction_stats: optional true/false. If true outputs full feature prediction stats for all (context and action)
 			;				features. The prediction stats returned are set by the "selected_prediction_stats" parameter. Uses full calculations, which
 			;				uses leave-one-out for features for computations. Uses full computation.
-			;		feature_residuals_full: optional, none/true/false. For each context_feature, use the full set of all other context_features to
+			;		feature_full_residuals: optional, none/true/false. For each context_feature, use the full set of all other context_features to
 			;               predict the feature.  When true, computes, caches, and returns the residuals for all features. Uses full computation.
 			;               When "prediction_stats" in the "details" parameter is true, it will also compute and cache the feature residuals.
-			;		feature_residuals_robust: optional, none/true/false. For each context_feature, computes, caches, and returns the same stats as residuals but using the robust
+			;		feature_robust_residuals: optional, none/true/false. For each context_feature, computes, caches, and returns the same stats as residuals but using the robust
 			;               (power set/permutations) set of all other context_features to predict the feature. Uses robust computation.
-			;		feature_contributions_full: optional, none/true/false. For each context_feature, use the full set of all other context_features to compute the
+			;		feature_full_prediction_contributions: optional, none/true/false. For each context_feature, use the full set of all other context_features to compute the
 			;				mean absolute delta between prediction of action_feature with and without the context_feature in the model. Uses full computation.
-			;		feature_contributions_robust: optional, none/true/false. For each context_feature, use the robust (power set/permutation) set of all other context_features
+			;		feature_robust_prediction_contributions: optional, none/true/false. For each context_feature, use the robust (power set/permutation) set of all other context_features
 			;				to compute the mean absolute delta between prediction of action_feature with and without the context_feature in the model. Uses robust computation.
 			;				Uses robust computation.
 			;		feature_deviations: optional, none/true/false. if true will compute feature deviations for each feature in action_features. The feature deviation is the mean absolute
 			;				error of predicting the feature using all the context features as well as value of the feature being predicted as the context for each prediction.
-			;		feature_mda_full: optional, none/true/false. if true will compute Mean Decrease in Accuracy (feature_mda) for each context feature at predicting mda_action_features.
+			;		feature_full_accuracy_contributions: optional, none/true/false. if true will compute Mean Decrease in Accuracy (feature_mda) for each context feature at predicting action_feature.
 			;				Drop each feature and use the full set of remaining context features for each prediction. Uses full computation.
-			;		feature_mda_permutation_full: optional, none/true/false. Compute feature_mda_full by scrambling each feature and using the full set of remaining context features
+			;		feature_full_accuracy_contributions_permutation: optional, none/true/false. Compute feature_full_accuracy_contributions by scrambling each feature and using the full set of remaining context features
 			;				for each prediction.  Uses full computation.
-			;		feature_mda_robust: optional, none/true/false. Compute feature_mda by dropping each feature and using the robust (power set/permutations) set of
+			;		feature_robust_accuracy_contributions: optional, none/true/false. Compute feature_mda by dropping each feature and using the robust (power set/permutations) set of
 			;				remaining context features for each prediction. Uses robust computation.
-			;		feature_mda_permutation_robust: optional, none/true/false. Compute feature_mda by scrambling each feature and using the robust (power set/permutations)
+			;		feature_robust_accuracy_contributions_permutation: optional, none/true/false. Compute feature_mda by scrambling each feature and using the robust (power set/permutations)
 			;				set of remaining context features for each prediction.  Uses robust computation.
 			;		selected_prediction_stats": list of strings, optional.  Allowed values are:
 			;						"mae" : Mean absolute error. For continuous features, this is calculated as the mean of absolute values of the difference
@@ -199,12 +199,12 @@
 					(unzip
 						details
 						[
-							"feature_contributions_full"
-							"feature_contributions_robust"
-							"feature_mda_full"
-							"feature_mda_robust"
-							"feature_mda_permutation_full"
-							"feature_mda_permutation_robust"
+							"feature_full_prediction_contributions"
+							"feature_robust_prediction_contributions"
+							"feature_full_accuracy_contributions"
+							"feature_robust_accuracy_contributions"
+							"feature_full_accuracy_contributions_permutation"
+							"feature_robust_accuracy_contributions_permutation"
 						]
 					)
 					(true)
@@ -218,10 +218,10 @@
 		;sample_model_fraction is ignored for any robust computation
 		(if
 			(or
-				(get details "feature_contributions_robust")
-				(get details "feature_residuals_robust")
-				(get details "feature_mda_robust")
-				(get details "feature_mda_permutation_robust")
+				(get details "feature_robust_prediction_contributions")
+				(get details "feature_robust_residuals")
+				(get details "feature_robust_accuracy_contributions")
+				(get details "feature_robust_accuracy_contributions_permutation")
 			)
 			(assign (assoc sample_model_fraction (null)))
 		)
@@ -270,20 +270,20 @@
 
 		;provide detailed warning if model hasn't been analyzed for the specified action_feature
 		(if (!= (null) feature_influences_action_feature)
-			(if (or (get details "feature_mda_full") (get details "feature_mda_permutation_full") (get details "feature_contributions_full"))
+			(if (or (get details "feature_full_accuracy_contributions") (get details "feature_full_accuracy_contributions_permutation") (get details "feature_full_prediction_contributions"))
 				(call !ReactAggregateMismatchedParametersWarning (assoc action_feature feature_influences_action_feature))
 			)
-			(if (or (get details "feature_mda_robust") (get details "feature_mda_permutation_robust") (get details "feature_contributions_robust"))
+			(if (or (get details "feature_robust_accuracy_contributions") (get details "feature_robust_accuracy_contributions_permutation") (get details "feature_robust_prediction_contributions"))
 				(call !ReactAggregateMismatchedParametersWarning (assoc action_feature (null)))
 			)
 		)
 
 		;provide detailed warning if model hasn't been analyzed for the specified action_feature
 		(if (!= (null) prediction_stats_action_feature)
-			(if (get details "feature_residuals_full")
+			(if (get details "feature_full_residuals")
 				(call !ReactAggregateMismatchedParametersWarning (assoc action_feature prediction_stats_action_feature))
 			)
-			(if (get details "feature_residuals_robust")
+			(if (get details "feature_robust_residuals")
 				(call !ReactAggregateMismatchedParametersWarning (assoc action_feature (null)))
 			)
 		)
@@ -440,8 +440,8 @@
 								(assoc "missing_value_accuracy" (get prediction_stats_map "null_accuracy_map"))
 								{}
 							)
-							(if (get details "feature_residuals_full")
-								{"feature_residuals_full" (get prediction_stats_map "residual_map")}
+							(if (get details "feature_full_residuals")
+								{"feature_full_residuals" (get prediction_stats_map "residual_map")}
 								{}
 							)
 						)
@@ -449,11 +449,11 @@
 			)
 
 			;this should only run if prediction_stats is not requested, don't want to compute these residuals twice
-			(get details "feature_residuals_full")
+			(get details "feature_full_residuals")
 			(accum (assoc
 				output
 					(assoc
-						"feature_residuals_full"
+						"feature_full_residuals"
 							(get
 								(call !CalculateFeatureResiduals (assoc
 									features action_features
@@ -476,11 +476,11 @@
 			))
 		)
 
-		(if (get details "feature_residuals_robust")
+		(if (get details "feature_robust_residuals")
 			(accum (assoc
 				output
 					(assoc
-						"feature_residuals_robust"
+						"feature_robust_residuals"
 							(map
 								(lambda (max (current_value) (get !cachedFeatureMinResidualMap (current_index))))
 								(get
@@ -537,8 +537,8 @@
 
 		;doing feature_contributions
 		(if (or
-				(get details "feature_contributions_full")
-				(get details "feature_contributions_robust")
+				(get details "feature_full_prediction_contributions")
+				(get details "feature_robust_prediction_contributions")
 			)
 			(let
 				(assoc
@@ -546,7 +546,7 @@
 					context_features (filter (lambda (!= feature_influences_action_feature (current_value))) context_features)
 				)
 
-				(if (get details "feature_contributions_full")
+				(if (get details "feature_full_prediction_contributions")
 					(accum (assoc
 						output
 							(call !CalculateFeatureContributions (assoc
@@ -563,7 +563,7 @@
 					))
 				)
 
-				(if (get details "feature_contributions_robust")
+				(if (get details "feature_robust_prediction_contributions")
 					(accum (assoc
 						output
 							(call !CalculateFeatureContributions (assoc
@@ -585,10 +585,10 @@
 
 		;doing feature_mda
 		(if (or
-				(get details "feature_mda_full")
-				(get details "feature_mda_robust")
-				(get details "feature_mda_permutation_full")
-				(get details "feature_mda_permutation_robust")
+				(get details "feature_full_accuracy_contributions")
+				(get details "feature_robust_accuracy_contributions")
+				(get details "feature_full_accuracy_contributions_permutation")
+				(get details "feature_robust_accuracy_contributions_permutation")
 			)
 			(let
 				(assoc
@@ -596,11 +596,11 @@
 					context_features (filter (lambda (!= feature_influences_action_feature (current_value))) context_features)
 				)
 
-				(if (get details "feature_mda_full")
+				(if (get details "feature_full_accuracy_contributions")
 					(accum (assoc
 						output
 							(assoc
-								"feature_mda_full"
+								"feature_full_accuracy_contributions"
 									(call !DecreaseInAccuracy (assoc
 										context_features context_features
 										action_features [feature_influences_action_feature]
@@ -617,11 +617,11 @@
 					))
 				)
 
-				(if (get details "feature_mda_robust")
+				(if (get details "feature_robust_accuracy_contributions")
 					(accum (assoc
 						output
 							(assoc
-								"feature_mda_robust"
+								"feature_robust_accuracy_contributions"
 									(call !DecreaseInAccuracy (assoc
 										context_features context_features
 										action_features [feature_influences_action_feature]
@@ -638,11 +638,11 @@
 					))
 				)
 
-				(if	(get details "feature_mda_permutation_full")
+				(if	(get details "feature_full_accuracy_contributions_permutation")
 					(accum (assoc
 						output
 							(assoc
-								"feature_mda_permutation_full"
+								"feature_full_accuracy_contributions_permutation"
 									(call !DecreaseInAccuracy (assoc
 										context_features context_features
 										action_features [feature_influences_action_feature]
@@ -659,11 +659,11 @@
 					))
 				)
 
-				(if (get details "feature_mda_permutation_robust")
+				(if (get details "feature_robust_accuracy_contributions_permutation")
 					(accum (assoc
 						output
 							(assoc
-								"feature_mda_permutation_robust"
+								"feature_robust_accuracy_contributions_permutation"
 									(call !DecreaseInAccuracy (assoc
 										context_features context_features
 										action_features [feature_influences_action_feature]

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -240,12 +240,12 @@
 			output_categorical_action_probabilities
 				(or
 					(get details "categorical_action_probabilities")
-					(get details "case_contributions_full")
-					(get details "case_contributions_robust")
-					(get details "feature_contributions_full")
-					(get details "feature_contributions_robust")
-					(get details "case_mda_full")
-					(get details "case_mda_robust")
+					(get details "case_full_prediction_contributions")
+					(get details "case_robust_prediction_contributions")
+					(get details "feature_full_prediction_contributions")
+					(get details "feature_robust_prediction_contributions")
+					(get details "case_full_prediction_contributions")
+					(get details "case_robust_prediction_contributions")
 					;feature mda does not need to output C.A.P. because it calls the generic DecreaseInAccuracy method which in turn uses
 					;ReactDiscriminative method with different feature sets, instead of simply calling GenerateReaction or InterpolateActionValues
 				)

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -246,7 +246,7 @@
 					(get details "feature_robust_prediction_contributions")
 					(get details "case_full_prediction_contributions")
 					(get details "case_robust_prediction_contributions")
-					;feature mda does not need to output C.A.P. because it calls the generic DecreaseInAccuracy method which in turn uses
+					;feature mda does not need to output C.A.P. because it calls the generic CalculateFeatureAccuracyContributions method which in turn uses
 					;ReactDiscriminative method with different feature sets, instead of simply calling GenerateReaction or InterpolateActionValues
 				)
 

--- a/howso/react_group.amlg
+++ b/howso/react_group.amlg
@@ -379,7 +379,7 @@
 										(append
 											details
 											{
-												"feature_residuals_full" (true)
+												"feature_full_residuals" (true)
 												"feature_deviations" (true)
 												"most_similar_cases" (!= (null) desired_conviction) ;need to compute max gaps if generative
 												"num_most_similar_cases" 30 ;need max of k and 30, but k always < 30 in targetless
@@ -427,7 +427,7 @@
 									action_feature_row_residuals
 										(map
 											(lambda (get (current_value) action_feature))
-											(get output_map "feature_residuals_full")
+											(get output_map "feature_full_residuals")
 										)
 								))
 
@@ -505,7 +505,7 @@
 														)
 													)
 													(get output_map "feature_deviations")
-													(get output_map "feature_residuals_full")
+													(get output_map "feature_full_residuals")
 												)
 											weight_sum (null)
 											discriminative_prediction (null)
@@ -545,7 +545,7 @@
 																;vec
 																(map
 																	(lambda (get (current_value) action_feature))
-																	(get output_map "feature_residuals_full")
+																	(get output_map "feature_full_residuals")
 																)
 															)
 

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -100,31 +100,31 @@
 								description "A list of maps defining the local feature deviations for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"feature_residuals_robust"
+						"feature_robust_residuals"
 							{
 								type "list"
 								description "A list of maps defining the local feature robust residuals for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"feature_residuals_full"
+						"feature_full_residuals"
 							{
 								type "list"
 								description "A list of maps defining the local feature full residuals for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"feature_mda_robust"
+						"feature_robust_accuracy_contributions"
 							{
 								type "list"
 								description "A list of maps defining the local feature robust MDA of the action feature for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"feature_mda_full"
+						"feature_full_accuracy_contributions"
 							{
 								type "list"
 								description "A list of maps defining the local feature full MDA of the action feature for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"feature_mda_ex_post_robust"
+						"feature_robust_accuracy_contributions_ex_post"
 							{
 								type "list"
 								description
@@ -134,7 +134,7 @@
 									)
 								values {ref "FeatureMetricIndex"}
 							}
-						"feature_mda_ex_post_full"
+						"feature_full_accuracy_contributions_ex_post"
 							{
 								type "list"
 								description
@@ -144,31 +144,31 @@
 									)
 								values {ref "FeatureMetricIndex"}
 							}
-						"feature_contributions_robust"
+						"feature_robust_prediction_contributions"
 							{
 								type "list"
 								description "A list of maps defining the local feature robust contributions of the action feature for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"feature_contributions_full"
+						"feature_full_prediction_contributions"
 							{
 								type "list"
 								description "A list of maps defining the local feature full contributions of the action feature for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"directional_feature_contributions_robust"
+						"feature_robust_directional_prediction_contributions"
 							{
 								type "list"
 								description "A list of maps defining the local feature robust directional contributions of the action feature for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"directional_feature_contributions_full"
+						"feature_full_directional_prediction_contributions"
 							{
 								type "list"
 								description "A list of maps defining the local feature robust directional contributions of the action feature for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"case_mda_robust"
+						"case_robust_prediction_contributions"
 							{
 								type "list"
 								description "A list of lists of maps containing the case index and robust MDA for each influential case of each given case."
@@ -178,7 +178,7 @@
 										values {ref "CaseMDA"}
 									}
 							}
-						"case_mda_full"
+						"case_full_prediction_contributions"
 							{
 								type "list"
 								description "A list of lists of maps containing the case index and full MDA for each influential case of each given case."
@@ -188,7 +188,7 @@
 										values {ref "CaseMDA"}
 									}
 							}
-						"case_contributions_full"
+						"case_full_prediction_contributions"
 							{
 								type "list"
 								description "A list of lists of maps containing the case index and full contribution to the action feature for each influential case of each given case."
@@ -198,7 +198,7 @@
 										values {ref "FullCaseContribution"}
 									}
 							}
-						"case_contributions_robust"
+						"case_robust_prediction_contributions"
 							{
 								type "list"
 								description "A list of lists of maps containing the case index and robust contribution to the action feature for each influential case of each given case."
@@ -208,14 +208,14 @@
 										values {ref "RobustCaseContribution"}
 									}
 							}
-						"case_feature_contributions_full"
+						"feature_full_prediction_contributions_for_case"
 							{
 								type "list"
 								description "A list of lists of maps containing the case index and full contribution to the action feature each given case."
 								values {ref "FeatureMetricIndex"}
 
 							}
-						"case_feature_contributions_robust"
+						"feature_robust_prediction_contributions_for_case"
 							{
 								type "list"
 								description "A list of lists of maps containing the case index and robust contribution to the action feature each given case."
@@ -233,25 +233,25 @@
 								description "A list of lists of maps containing the case index and robust directional contribution to the action feature each given case."
 								values {ref "FeatureMetricIndex"}
 							}
-						"case_feature_residuals_full"
+						"feature_full_residuals_for_case"
 							{
 								type "list"
 								description "A list of maps from feature name to the full prediction residual for each given case."
 								values {ref "FeatureMetricIndex"}
 							}
-						"case_feature_residuals_robust"
+						"feature_robust_residuals_for_case"
 							{
 								type "list"
 								description "A list of maps from feature name to the robust prediction residual for each given case."
 								values {ref "FeatureMetricIndex"}
 							}
-						"case_feature_residual_convictions_full"
+						"feature_full_residual_convictions_for_case"
 							{
 								type "list"
 								description "A list of maps from feature name to feature full residual conviction for each given case."
 								values {ref "FeatureMetricIndex"}
 							}
-						"case_feature_residual_convictions_robust"
+						"feature_robust_residual_convictions_for_case"
 							{
 								type "list"
 								description "A list of maps from feature name to feature robust residual conviction for each given case."
@@ -527,14 +527,14 @@
 				description "Map of requested detail names to maps of feature names to their computed values for the specified feature."
 				additional_indices (false)
 				indices {
-					"feature_residuals_full" {
+					"feature_full_residuals" {
 						type "assoc"
 						description "The mean absolute error of predicting each feature using the full set of context features."
 						additional_indices {
 							type ["number" "null"]
 						}
 					}
-					"feature_residuals_robust" {
+					"feature_robust_residuals" {
 						type "assoc"
 						description "The mean absolute error of predicting each feature using samples from the power-set of context features."
 						additional_indices {
@@ -548,7 +548,7 @@
 							type ["number" "null"]
 						}
 					}
-					"feature_contributions_full" {
+					"feature_full_prediction_contributions" {
 						type "assoc"
 						description
 							(concat
@@ -559,7 +559,7 @@
 							type ["number" "null"]
 						}
 					}
-					"directional_feature_contributions_full" {
+					"feature_full_directional_prediction_contributions" {
 						type "assoc"
 						description
 							(concat
@@ -570,7 +570,7 @@
 							type ["number" "null"]
 						}
 					}
-					"feature_contributions_robust" {
+					"feature_robust_prediction_contributions" {
 						type "assoc"
 						description
 							(concat
@@ -581,7 +581,7 @@
 							type ["number" "null"]
 						}
 					}
-					"directional_feature_contributions_robust" {
+					"feature_robust_directional_prediction_contributions" {
 						type "assoc"
 						description
 							(concat
@@ -592,7 +592,7 @@
 							type ["number" "null"]
 						}
 					}
-					"feature_mda_full" {
+					"feature_full_accuracy_contributions" {
 						type "assoc"
 						additional_indices {
 							type ["number" "null"]
@@ -603,7 +603,7 @@
 								"with each feature while using full set of remaining context features."
 							)
 					}
-					"feature_mda_robust" {
+					"feature_robust_accuracy_contributions" {
 						type "assoc"
 						additional_indices {
 							type ["number" "null"]
@@ -614,7 +614,7 @@
 								"with each feature while using samples from the power-set of remaining context features."
 							)
 					}
-					"feature_mda_permutation_full" {
+					"feature_full_accuracy_contributions_permutation" {
 						type "assoc"
 						additional_indices {
 							type ["number" "null"]
@@ -626,7 +626,7 @@
 								"set of remaining context features."
 							)
 					}
-					"feature_mda_permutation_robust" {
+					"feature_robust_accuracy_contributions_permutation" {
 						type "assoc"
 						additional_indices {
 							type ["number" "null"]

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -175,7 +175,7 @@
 								values
 									{
 										type "list"
-										values {ref "CaseMDA"}
+										values {ref "CaseAccuracyContributions"}
 									}
 							}
 						"case_full_prediction_contributions"
@@ -185,7 +185,7 @@
 								values
 									{
 										type "list"
-										values {ref "CaseMDA"}
+										values {ref "CaseAccuracyContributions"}
 									}
 							}
 						"case_full_prediction_contributions"
@@ -195,7 +195,7 @@
 								values
 									{
 										type "list"
-										values {ref "FullCaseContribution"}
+										values {ref "FullCasePredictionContribution"}
 									}
 							}
 						"case_robust_prediction_contributions"
@@ -205,7 +205,7 @@
 								values
 									{
 										type "list"
-										values {ref "RobustCaseContribution"}
+										values {ref "RobustCasePredictionContribution"}
 									}
 							}
 						"feature_full_prediction_contributions_for_case"

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -599,7 +599,7 @@
 						}
 						description
 							(concat
-								"The mean decrease in accuracy of predicting the specified action feature without each feature versus "
+								"The Accuracy Contribution in predicting the specified action feature without each feature versus "
 								"with each feature while using full set of remaining context features."
 							)
 					}
@@ -610,7 +610,7 @@
 						}
 						description
 							(concat
-								"The mean decrease in accuracy of predicting the specified action feature without each feature versus "
+								"The Accuracy Contribution in predicting the specified action feature without each feature versus "
 								"with each feature while using samples from the power-set of remaining context features."
 							)
 					}
@@ -621,7 +621,7 @@
 						}
 						description
 							(concat
-								"The mean decrease in accuracy of predicting the specified action feature using scrambled "
+								"The Accuracy Contribution in predicting the specified action feature using scrambled "
 								"values for each feature versus non-scrambled values for each feature while using the full "
 								"set of remaining context features."
 							)
@@ -633,7 +633,7 @@
 						}
 						description
 							(concat
-								"The mean decrease in accuracy of predicting the specified action feature using scrambled "
+								"The Accuracy Contribution in predicting the specified action feature using scrambled "
 								"values for each feature versus non-scrambled values for each feature while using samples "
 								"from the power-set of remaining context features."
 							)

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -995,7 +995,7 @@
 										"If True, outputs the deviations for each feature based on the data surrounding the prediction."
 									)
 							)
-						feature_residuals_full
+						feature_full_residuals
 							(assoc
 								type "boolean"
 								description
@@ -1006,7 +1006,7 @@
 										"full calculations, which uses leave-one-out for cases for computations."
 									)
 							)
-						feature_residuals_robust
+						feature_robust_residuals
 							(assoc
 								type "boolean"
 								description
@@ -1043,34 +1043,35 @@
 										"If all, then returns all including the confusion_matrix."
 									)
 							)
-						feature_mda_full
+						feature_full_accuracy_contributions
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"When True will compute Mean Decrease in Accuracy (MDA) "
-										"for each context feature at predicting the action feature. Drop "
-										"each feature and use the full set of remaining context features "
-										"for each prediction. False removes cached values."
+										"When True will compute the Accuracy Contribution "
+										"for each context feature at predicting the action feature value of the influential cases. "
+										"Uses leave-one-out logic, dropping each feature and use the full set of remaining "
+										"context features for each prediction."
 									)
 							)
-						feature_mda_robust
+						feature_robust_accuracy_contributions
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"Compute Mean Decrease in Accuracy MDA by dropping each feature and using the "
-										"robust (power set/permutations) set of remaining context features "
-										"for each prediction. False removes cached values."
+										"When True will compute the Accuracy Contribution "
+										"for each context feature at predicting the action feature value of the influential cases. "
+										"Uses robust logic, making predictions using contexts sampled from the power set of context "
+										"features."
 									)
 							)
-						feature_mda_ex_post_full
+						feature_full_accuracy_contributions_ex_post
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If True, outputs each context feature's mean decrease in "
-										"accuracy of predicting the action feature as an explanation detail "
+										"If True, outputs each context feature's Accuracy Contribution in "
+										"predicting the action feature as an explanation detail "
 										"given that the specified prediction was already made as "
 										"specified by the action value. Uses both context and action "
 										"features of the reacted case to determine that area. Uses "
@@ -1078,13 +1079,13 @@
 										"computations."
 									)
 							)
-						feature_mda_ex_post_robust
+						feature_robust_accuracy_contributions_ex_post
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If True, outputs each context feature's mean decrease in "
-										"accuracy of predicting the action feature as an explanation detail "
+										"If True, outputs each context feature's Accuracy Contribution in "
+										"predicting the action feature as an explanation detail "
 										"given that the specified prediction was already made as "
 										"specified by the action value. Uses both context and action "
 										"features of the reacted case to determine that area. Uses "
@@ -1092,7 +1093,7 @@
 										"from the power set of features as the contexts for predictions. "
 									)
 							)
-						feature_contributions_full
+						feature_full_prediction_contributions
 							(assoc
 								type "boolean"
 								description
@@ -1103,10 +1104,10 @@
 										"model for all context features in the local model area. Uses "
 										"full calculations, which uses leave-one-out for cases for "
 										"computations. Directional feature contributions are returned "
-										"under the key 'directional_feature_contributions_full'."
+										"under the key 'feature_full_directional_prediction_contributions'."
 									)
 							)
-						feature_contributions_robust
+						feature_robust_prediction_contributions
 							(assoc
 								type "boolean"
 								description
@@ -1118,10 +1119,10 @@
 										"robust calculations, which uses uniform sampling from the power "
 										"set of features as the contexts for predictions. Directional feature "
 										"contributions are returned under the key "
-										"'directional_feature_contributions_robust'."
+										"'feature_robust_directional_prediction_contributions'."
 									)
 							)
-						case_feature_contributions_full
+						feature_full_prediction_contributions_for_case
 							(assoc
 								type "boolean"
 								description
@@ -1134,10 +1135,10 @@
 										"full calculations, which uses leave-one-out for cases for "
 										"computations. Directional case feature "
 										"contributions are returned under the "
-										"'case_directional_feature_contributions_full' key."
+										"'feature_full_directional_prediction_contributions_for_case' key."
 									)
 							)
-						case_feature_contributions_robust
+						feature_robust_prediction_contributions_for_case
 							(assoc
 								type "boolean"
 								description
@@ -1150,36 +1151,36 @@
 										"robust calculations, which uses uniform sampling from the power "
 										"set of features as the contexts for predictions. "
 										"Directional case feature contributions are returned under the "
-										"'case_directional_feature_contributions_robust' key."
+										"'feature_robust_directional_prediction_contributions_for_case' key."
 									)
 							)
-						case_mda_full
+						case_full_accuracy_contributions
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If True, outputs each influential case's mean decrease in "
-										"accuracy of predicting the action feature in the local model "
+										"If True, outputs each influential case's Accuracy Contribution in "
+										"predicting the action feature in the local model "
 										"area, as if each individual case were included versus not "
 										"included. Uses only the context features of the reacted case to "
 										"determine that area. Uses full calculations, which uses "
 										"leave-one-out for cases for computations."
 									)
 							)
-						case_mda_robust
+						case_robust_accuracy_contributions
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If True, outputs each influential case's mean decrease in "
-										"accuracy of predicting the action feature in the local model "
+										"If True, outputs each influential case's Accuracy Contribution in "
+										"predicting the action feature in the local model "
 										"area, as if each individual case were included versus not "
 										"included. Uses only the context features of the reacted case to "
 										"determine that area. Uses robust calculations, which uses "
 										"uniform sampling from the power set of all combinations of cases."
 									)
 							)
-						case_contributions_full
+						case_full_prediction_contributions
 							(assoc
 								type "boolean"
 								description
@@ -1192,7 +1193,7 @@
 										"computations."
 									)
 							)
-						case_contributions_robust
+						case_robust_prediction_contributions
 							(assoc
 								type "boolean"
 								description
@@ -1205,7 +1206,7 @@
 										"the power set of all combinations of cases."
 									)
 							)
-						case_feature_residuals_full
+						feature_full_residuals_for_case
 							(assoc
 								type "boolean"
 								description
@@ -1213,40 +1214,36 @@
 										"If True, outputs feature residuals for all (context and action) "
 										"features for just the specified case. Uses leave-one-out for "
 										"each feature, while using the others to predict the left out "
-										"feature with their corresponding values from this case. Uses "
-										"full calculations, which uses leave-one-out for cases for "
-										"computations."
+										"feature with their corresponding values from this case."
 									)
 							)
-						case_feature_residuals_robust
+						feature_robust_residuals_for_case
 							(assoc
 								type "boolean"
 								description
 									(concat
 										"If True, outputs feature residuals for all (context and action) "
-										"features for just the specified case. Uses leave-one-out for "
-										"each feature, while using the others to predict the left out "
-										"feature with their corresponding values from this case. Uses "
+										"features for just the specified case. Uses "
 										"robust calculations, which uses uniform sampling from the power "
 										"set of features as the contexts for predictions."
 									)
 							)
-						case_feature_residual_convictions_full
+						feature_full_residual_convictions_for_case
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If True, outputs this case's feature residual model. "
-										"Computed as: model feature full residual divided by case feature full residual."
+										"If True, outputs this case's full residual conviction for each feature. "
+										"Computed as the model feature full residual divided by each case's feature full residual."
 									)
 							)
-						case_feature_residual_convictions_robust
+						feature_robust_residual_convictions_for_case
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If True, outputs this case's feature residual model. "
-										"Computed as: model feature robust residual divided by case feature robust residual."
+										"If True, outputs this case's robust residual conviction for each feature. "
+										"Computed as the model feature robust residual divided by each case's feature robust residual."
 									)
 							)
 						generate_attempts
@@ -1324,44 +1321,47 @@
 										"If null, will be set to k. default is null."
 									)
 							)
-						feature_mda_full
+						feature_full_accuracy_contributions
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If true will compute Mean Decrease in Accuracy (feature_mda) for each context feature at predicting mda_action_features. "
-										"Drop each feature and use the full set of remaining context features for each prediction. false removes cached values. "
+										"If true will compute the Accuracy Contribution for each context feature in predicting action_feature. "
+										"Drop each feature and use the full set of remaining context features for each prediction."
 										"Uses full computation."
 									)
 							)
-						feature_mda_robust
+						feature_robust_accuracy_contributions
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If true will compute feature_mda by dropping each feature and using the robust (power set/permutations) set of "
-										"remaining context features for each prediction. false removes cached values. Uses robust computation."
+										"If true will compute the Accuracy Contribution in predicting the action feature by dropping each feature "
+										"and using the robust (power set/permutations) set of "
+										"remaining context features for each prediction. Uses robust computation."
 									)
 							)
-						feature_mda_permutation_full
+						feature_full_accuracy_contributions_permutation
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If true will compute feature_mda_full by scrambling each feature and using the full set of remaining context features "
-										"for each prediction.  false removes cached values. Uses full computation."
+										"If true will compute the Accuracy Contribution in predicting the action feature by scrambling each feature "
+										"and using the full set of remaining context features "
+										"for each prediction. Uses full computation."
 									)
 							)
-						feature_mda_permutation_robust
+						feature_robust_accuracy_contributions_permutation
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"If true will compute feature_mda by scrambling each feature and using the robust (power set/permutations) "
-										"set of remaining context features for each prediction.  false removes cached values. Uses robust computation."
+										"If true will compute the Accuracy Contribution in predicting the action feature by scrambling each feature "
+										"and using the robust (power set/permutations) "
+										"set of remaining context features for each prediction. Uses robust computation."
 									)
 							)
-						feature_contributions_full
+						feature_full_prediction_contributions
 							(assoc
 								type "boolean"
 								description
@@ -1370,7 +1370,7 @@
 										"between prediction of action_feature with and without the context_feature in the model. Uses full computation."
 									)
 							)
-						feature_contributions_robust
+						feature_robust_prediction_contributions
 							(assoc
 								type "boolean"
 								description
@@ -1380,7 +1380,7 @@
 										"Uses robust computation."
 									)
 							)
-						feature_residuals_full
+						feature_full_residuals
 							(assoc
 								type "boolean"
 								description
@@ -1390,7 +1390,7 @@
 										"When \"prediction_stats\" in the \"details\" parameter is true, it will also compute and cache the feature residuals."
 									)
 							)
-						feature_residuals_robust
+						feature_robust_residuals
 							(assoc
 								type "boolean"
 								description
@@ -1651,7 +1651,7 @@
 					{
 						".session" "string"
 						".session_training_index" "number"
-						"mda" "number"
+						"accuracy_contribution" "number"
 					}
 			)
 		FullCaseContribution
@@ -1662,7 +1662,7 @@
 					{
 						".session" "string"
 						".session_training_index" "number"
-						"case_contributions_full" "number"
+						"full_prediction_contribution" "number"
 					}
 			)
 		RobustCaseContribution
@@ -1673,7 +1673,7 @@
 					{
 						".session" "string"
 						".session_training_index" "number"
-						"case_contributions_robust" "number"
+						"robust_prediction_contribution" "number"
 					}
 			)
 		DistanceRatioParts

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -1643,7 +1643,7 @@
 				additional_indices "number"
 				description "Map of feature names to numeric values."
 			)
-		CaseMDA
+		CaseAccuracyContributions
 			(assoc
 				type "assoc"
 				description "A map for an influential case of a reaction that describes its training index, session, and MDA for the action feature."
@@ -1654,7 +1654,7 @@
 						"accuracy_contribution" "number"
 					}
 			)
-		FullCaseContribution
+		FullCasePredictionContribution
 			(assoc
 				type "assoc"
 				description "A map for an influential case that describes its training index, session, and the full contribution to the action feature."
@@ -1665,7 +1665,7 @@
 						"full_prediction_contribution" "number"
 					}
 			)
-		RobustCaseContribution
+		RobustCasePredictionContribution
 			(assoc
 				type "assoc"
 				description "A map for an influential case that describes its training index, session, and the robust contribution to the action feature."

--- a/performance_tests/adult_test.amlg
+++ b/performance_tests/adult_test.amlg
@@ -105,7 +105,7 @@
 	(call_entity "howso" "react_aggregate" (assoc
 		context_features features
 		num_samples 1000
-		details (assoc feature_residuals_robust (true))
+		details (assoc feature_robust_residuals (true))
 		use_case_weights use_case_weights
 	))
 

--- a/performance_tests/asteroid_test.amlg
+++ b/performance_tests/asteroid_test.amlg
@@ -98,7 +98,7 @@
 	(call_entity "howso" "react_aggregate" (assoc
 		context_features features
 		num_samples 500
-		details (assoc feature_residuals_robust (true))
+		details (assoc feature_robust_residuals (true))
 	))
 
 	(declare (assoc residuals_time (- (system_time) start) ))

--- a/performance_tests/bank_test.amlg
+++ b/performance_tests/bank_test.amlg
@@ -112,7 +112,7 @@
 	(call_entity "howso" "react_aggregate" (assoc
 		context_features features
 		num_samples 1000
-		details (assoc feature_residuals_robust (true))
+		details (assoc feature_robust_residuals (true))
 		use_case_weights use_case_weights
 	))
 

--- a/performance_tests/e_shop_test.amlg
+++ b/performance_tests/e_shop_test.amlg
@@ -100,7 +100,7 @@
 	(call_entity "howso" "react_aggreagate" (assoc
 		context_features features
 		num_samples 1000
-		details (assoc feature_residuals_robust (true))
+		details (assoc feature_robust_residuals (true))
 	))
 
 	(declare (assoc residuals_time (- (system_time) start) ))

--- a/performance_tests/online_retail_test.amlg
+++ b/performance_tests/online_retail_test.amlg
@@ -95,7 +95,7 @@
 	(call_entity "howso" "react_aggregate" (assoc
 		context_features features
 		num_samples 1000
-		details (assoc feature_residuals_robust (true))
+		details (assoc feature_robust_residuals (true))
 	))
 
 	(declare (assoc residuals_time (- (system_time) start) ))

--- a/performance_tests/range_queries_test.amlg
+++ b/performance_tests/range_queries_test.amlg
@@ -84,7 +84,7 @@
 	(call_entity "howso" "react_aggregate" (assoc
 		context_features features
 		num_samples 1000
-		details (assoc feature_residuals_robust (true))
+		details (assoc feature_robust_residuals (true))
 	))
 
 	(declare (assoc residuals_time (- (system_time) start) ))

--- a/performance_tests/religious_texts_test.amlg
+++ b/performance_tests/religious_texts_test.amlg
@@ -88,7 +88,7 @@
 	(call_entity "howso" "react_aggregate" (assoc
 		context_features features
 		num_samples 1000
-		details (assoc feature_residuals_robust (true))
+		details (assoc feature_robust_residuals (true))
 		use_case_weights use_case_weights
 	))
 

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -277,7 +277,7 @@
 		result
 			(call_entity "howso" "react_aggregate" (assoc
 				context_features features
-				details (assoc feature_contributions_full (true))
+				details (assoc feature_full_prediction_contributions (true))
 				feature_influences_action_feature "fruit"
 				sample_model_fraction 1.0
 			))
@@ -285,11 +285,11 @@
 	(call keep_result_payload)
 	(print "computed contributions: ")
 	(call assert_same (assoc
-		obs (sort (indices  (get result "feature_contributions_full") ))
+		obs (sort (indices  (get result "feature_full_prediction_contributions") ))
 		exp (list "height" "length" "size" "sweet" "tart" "weight" "width")
 	))
 	(call assert_approximate (assoc
-		obs (get result "feature_contributions_full")
+		obs (get result "feature_full_prediction_contributions")
 		exp
 		 	(assoc
 				height 0.01
@@ -317,12 +317,12 @@
 			(get
 				(call_entity "howso" "react_aggregate" (assoc
 					context_features features
-					details (assoc feature_contributions_full (true))
+					details (assoc feature_full_prediction_contributions (true))
 					feature_influences_action_feature "fruit"
 					hyperparameter_param_path ["targeted" "width" "fruit.height.length.size.sweet.tart.weight." ".none"]
 					sample_model_fraction 1.0
 				))
-				[1 "payload" "feature_contributions_full"]
+				[1 "payload" "feature_full_prediction_contributions"]
 			)
 	))
 	(print "computed contributions with custom hp map: ")
@@ -340,7 +340,7 @@
 		result
 			(call_entity "howso" "react_aggregate" (assoc
 				context_features features
-				details (assoc feature_contributions_full (true))
+				details (assoc feature_full_prediction_contributions (true))
 				feature_influences_action_feature "height"
 				sample_model_fraction 1.0
 			))
@@ -348,7 +348,7 @@
 	(call keep_result_payload)
 	(print "Computed contributions for action feature height: ")
 	(call assert_approximate (assoc
-		obs (get result "feature_contributions_full")
+		obs (get result "feature_full_prediction_contributions")
 		exp  (assoc
 				fruit 0.03
 				length 0.11
@@ -380,14 +380,14 @@
 				case_indices (list "unit_test" 7)
 				details
 					(assoc
-						"feature_contributions_full" (true)
+						"feature_full_prediction_contributions" (true)
 					)
 			))
 	))
 
 	(print "Local full feature contributions:")
 	(call assert_approximate (assoc
-		obs (keep (get result (list 1 "payload" "feature_contributions_full")) (list "height" "tart" "width"))
+		obs (keep (get result (list 1 "payload" "feature_full_prediction_contributions")) (list "height" "tart" "width"))
 		exp
 			(assoc
 				height 0.1
@@ -407,15 +407,15 @@
 				case_indices (list "unit_test" 0)
 				details
 					(assoc
-						"feature_contributions_robust" (true)
-						"case_feature_contributions_robust" (true)
+						"feature_robust_prediction_contributions" (true)
+						"feature_robust_prediction_contributions_for_case" (true)
 					)
 			))
 	))
 
 	(print "Local robust feature contributions:")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "feature_contributions_robust"))
+		obs (get result (list 1 "payload" "feature_robust_prediction_contributions"))
 		exp
 			(assoc
 				height 0.09
@@ -440,7 +440,7 @@
 
 	(print "Case robust feature contributions:")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_contributions_robust"))
+		obs (get result (list 1 "payload" "feature_robust_prediction_contributions_for_case"))
 		exp
 			(assoc
 				height 0.09
@@ -473,8 +473,8 @@
 				case_indices (list "unit_test" 0)
 				details
 					(assoc
-						"feature_contributions_robust" (true)
-						"case_feature_contributions_robust" (true)
+						"feature_robust_prediction_contributions" (true)
+						"feature_robust_prediction_contributions_for_case" (true)
 						"num_robust_influence_samples_per_case" 4
 					)
 			))
@@ -488,21 +488,21 @@
 	(call assert_true (assoc
 		obs
 			(or
-				(> (get result (list "feature_contributions_robust" "height")) .17 )
-				(> (get result (list "feature_contributions_robust" "length")) .15 )
-				(> (get result (list "feature_contributions_robust" "size"))   .08 )
-				(> (get result (list "feature_contributions_robust" "sweet"))  .09 )
-				(> (get result (list "feature_contributions_robust" "tart"))   .23 )
-				(> (get result (list "feature_contributions_robust" "weight")) .25 )
-				(> (get result (list "feature_contributions_robust" "width"))  .48 )
+				(> (get result (list "feature_robust_prediction_contributions" "height")) .17 )
+				(> (get result (list "feature_robust_prediction_contributions" "length")) .15 )
+				(> (get result (list "feature_robust_prediction_contributions" "size"))   .08 )
+				(> (get result (list "feature_robust_prediction_contributions" "sweet"))  .09 )
+				(> (get result (list "feature_robust_prediction_contributions" "tart"))   .23 )
+				(> (get result (list "feature_robust_prediction_contributions" "weight")) .25 )
+				(> (get result (list "feature_robust_prediction_contributions" "width"))  .48 )
 
-				(< (get result (list "feature_contributions_robust" "height")) .01 )
-				(< (get result (list "feature_contributions_robust" "length")) .01 )
-				(< (get result (list "feature_contributions_robust" "size"))   .001 )
-				(< (get result (list "feature_contributions_robust" "sweet"))  .001 )
-				(< (get result (list "feature_contributions_robust" "tart"))   .01 )
-				(< (get result (list "feature_contributions_robust" "weight")) .01 )
-				(< (get result (list "feature_contributions_robust" "width"))  .05 )
+				(< (get result (list "feature_robust_prediction_contributions" "height")) .01 )
+				(< (get result (list "feature_robust_prediction_contributions" "length")) .01 )
+				(< (get result (list "feature_robust_prediction_contributions" "size"))   .001 )
+				(< (get result (list "feature_robust_prediction_contributions" "sweet"))  .001 )
+				(< (get result (list "feature_robust_prediction_contributions" "tart"))   .01 )
+				(< (get result (list "feature_robust_prediction_contributions" "weight")) .01 )
+				(< (get result (list "feature_robust_prediction_contributions" "width"))  .05 )
 			)
 	))
 

--- a/unit_tests/ut_h_case_mda.amlg
+++ b/unit_tests/ut_h_case_mda.amlg
@@ -35,18 +35,18 @@
 				context_values (list 6.4 5.6 2.0 2)
 
 				action_features (list "sepal_width")
-				details (assoc "case_mda_full" (true))
+				details (assoc "case_full_accuracy_contributions" (true))
 			))
 	))
 	(print "standard continuous case mda: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_mda_full"))
+		obs (get result (list 1 "payload" "case_full_accuracy_contributions"))
 		exp
 			(list
-				(assoc ".session" "default" ".session_training_index" 106 "mda" 0.0585)
-				(assoc ".session" "default" ".session_training_index" 93 "mda" 0.0742)
-				(assoc ".session" "default" ".session_training_index" 32 "mda" 0.016)
-				(assoc ".session" "default" ".session_training_index" 18 "mda" -0.004)
+				(assoc ".session" "default" ".session_training_index" 106 "accuracy_contribution" 0.0585)
+				(assoc ".session" "default" ".session_training_index" 93 "accuracy_contribution" 0.0742)
+				(assoc ".session" "default" ".session_training_index" 32 "accuracy_contribution" 0.016)
+				(assoc ".session" "default" ".session_training_index" 18 "accuracy_contribution" -0.004)
 			)
 		thresh .006
 	))
@@ -58,18 +58,18 @@
 				context_values (list 6.4 5.6 2.0 2)
 
 				action_features (list "sepal_width")
-				details (assoc "case_mda_full" (true) )
+				details (assoc "case_full_accuracy_contributions" (true) )
 			))
 	))
 	(print "robust continuous case mda: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_mda_full"))
+		obs (get result (list 1 "payload" "case_full_accuracy_contributions"))
 		exp
 			(list
-				(assoc ".session" "default" ".session_training_index" 106 "mda" 0.058)
-				(assoc ".session" "default" ".session_training_index" 93 "mda" 0.070)
-				(assoc ".session" "default" ".session_training_index" 32 "mda" 0.02)
-				(assoc ".session" "default" ".session_training_index" 18 "mda" 0.025)
+				(assoc ".session" "default" ".session_training_index" 106 "accuracy_contribution" 0.058)
+				(assoc ".session" "default" ".session_training_index" 93 "accuracy_contribution" 0.070)
+				(assoc ".session" "default" ".session_training_index" 32 "accuracy_contribution" 0.02)
+				(assoc ".session" "default" ".session_training_index" 18 "accuracy_contribution" 0.025)
 			)
 		thresh .04
 	))
@@ -82,18 +82,18 @@
 				context_values (list 6.7 5.0 1.7 2.8)
 
 				action_features (list "target")
-				details (assoc "case_mda_full" (true))
+				details (assoc "case_full_accuracy_contributions" (true))
 			))
 	))
 	(print "standard nominal case mda: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_mda_full"))
+		obs (get result (list 1 "payload" "case_full_accuracy_contributions"))
 		exp
 			(list
-				(assoc ".session" "default" ".session_training_index" 144 "mda" 0)
-				(assoc ".session" "default" ".session_training_index" 142 "mda" 0)
-				(assoc ".session" "default" ".session_training_index" 22 "mda" 0.0123)
-				(assoc ".session" "default" ".session_training_index" 47 "mda" 0)
+				(assoc ".session" "default" ".session_training_index" 144 "accuracy_contribution" 0)
+				(assoc ".session" "default" ".session_training_index" 142 "accuracy_contribution" 0)
+				(assoc ".session" "default" ".session_training_index" 22 "accuracy_contribution" 0.0123)
+				(assoc ".session" "default" ".session_training_index" 47 "accuracy_contribution" 0)
 			)
 		thresh 0.075
 	))
@@ -105,18 +105,18 @@
 				context_values (list 6.7 5.0 1.7 2.8)
 
 				action_features (list "target")
-				details (assoc "case_mda_full" (true))
+				details (assoc "case_full_accuracy_contributions" (true))
 			))
 	))
 	(print "robust nominal case mda: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_mda_full"))
+		obs (get result (list 1 "payload" "case_full_accuracy_contributions"))
 		exp
 			(list
-				(assoc ".session" "default" ".session_training_index" 144 "mda" 0)
-				(assoc ".session" "default" ".session_training_index" 142 "mda" 0)
-				(assoc ".session" "default" ".session_training_index" 22 "mda" 0.0123)
-				(assoc ".session" "default" ".session_training_index" 47 "mda" 0)
+				(assoc ".session" "default" ".session_training_index" 144 "accuracy_contribution" 0)
+				(assoc ".session" "default" ".session_training_index" 142 "accuracy_contribution" 0)
+				(assoc ".session" "default" ".session_training_index" 22 "accuracy_contribution" 0.0123)
+				(assoc ".session" "default" ".session_training_index" 47 "accuracy_contribution" 0)
 			)
 		thresh 0.075
 	))

--- a/unit_tests/ut_h_datetimeformat.amlg
+++ b/unit_tests/ut_h_datetimeformat.amlg
@@ -171,14 +171,14 @@
 				context_features (list "nom" "datetime")
 				context_values (list "e" "2020-06-08 lunes 11.33.48")
 				action_features (list "id")
-				details (assoc "feature_residuals_full" (true))
+				details (assoc "feature_full_residuals" (true))
 			))
 	))
 	(print "Delta for residual is in milliseconds: ") ;TODO: 15077: API for requesting custom datetime delta form for datetime residuals
 	(call assert_true (assoc
-		obs (>= (get result (list 1 "payload" "feature_residuals_full" "datetime")) 22)
+		obs (>= (get result (list 1 "payload" "feature_full_residuals" "datetime")) 22)
 	))
-	(print "Mean Absolute Error: " (get result (list 1 "payload" "feature_residuals_full" "datetime")) "\n")
+	(print "Mean Absolute Error: " (get result (list 1 "payload" "feature_full_residuals" "datetime")) "\n")
 
 
 	(call exit_if_failures (assoc msg "Datetime residuals" ))

--- a/unit_tests/ut_h_dynamic_deviations.amlg
+++ b/unit_tests/ut_h_dynamic_deviations.amlg
@@ -33,7 +33,7 @@
 					num_samples 500
 					details
 						(assoc
-							"feature_residuals_full" (true)
+							"feature_full_residuals" (true)
 						)
 				))
 				[1 "payload"]
@@ -44,7 +44,7 @@
 	(print "Price MAE with Dynamic Deviations is as expected: ")
 	(call assert_approximate (assoc
 		exp 400
-		obs (get dd_agg_stats ["feature_residuals_full" "price"])
+		obs (get dd_agg_stats ["feature_full_residuals" "price"])
 		thresh 300
 	))
 	(call exit_if_failures (assoc msg "MAE with DD is not as expected."))

--- a/unit_tests/ut_h_edit_dist_features.amlg
+++ b/unit_tests/ut_h_edit_dist_features.amlg
@@ -337,7 +337,7 @@
 	))
 
 	(call keep_result_payload)
-	(print "MDA for json feature: ")
+	(print "Accuracy contribution for json feature: ")
 	(call assert_approximate (assoc
 		obs result
 		exp
@@ -386,7 +386,7 @@
 		thresh 1.5
 	))
 
-	(call exit_if_failures (assoc msg "MDA and contributions for json feature." ))
+	(call exit_if_failures (assoc msg "Accuracy contribution and prediction contributions for json feature." ))
 
 	(assign (assoc
 		result

--- a/unit_tests/ut_h_edit_dist_features.amlg
+++ b/unit_tests/ut_h_edit_dist_features.amlg
@@ -331,7 +331,7 @@
 				action_feature "json"
 				num_samples 1000
 				details (assoc
-					feature_mda_full (true)
+					feature_full_accuracy_contributions (true)
 				)
 			))
 	))
@@ -342,7 +342,7 @@
 		obs result
 		exp
 			(assoc
-				feature_mda_full {
+				feature_full_accuracy_contributions {
 					amalgam 0.1
 					yaml 0.1
 					string 0.2
@@ -359,7 +359,7 @@
 				action_feature "json"
 				num_samples 1000
 				details (assoc
-					feature_contributions_full (true)
+					feature_full_prediction_contributions (true)
 				)
 			))
 	))
@@ -370,13 +370,13 @@
 		obs result
 		exp
 			(assoc
-				feature_contributions_full {
+				feature_full_prediction_contributions {
 					amalgam 2.5
 					yaml 2.5
 					string 2.5
 					x 2
 				}
-				directional_feature_contributions_full {
+				feature_full_directional_prediction_contributions {
 					amalgam 0
 					yaml 0
 					string 0
@@ -395,7 +395,7 @@
 				action_feature "string"
 				num_samples 1000
 				details (assoc
-					feature_mda_full (true)
+					feature_full_accuracy_contributions (true)
 				)
 			))
 	))
@@ -406,7 +406,7 @@
 		obs result
 		exp
 			(assoc
-				feature_mda_full {
+				feature_full_accuracy_contributions {
 					amalgam 0.2
 					yaml 0.1
 					json 0.2
@@ -423,7 +423,7 @@
 				action_feature "string"
 				num_samples 1000
 				details (assoc
-					feature_contributions_full (true)
+					feature_full_prediction_contributions (true)
 				)
 			))
 	))
@@ -434,13 +434,13 @@
 		obs result
 		exp
 			(assoc
-				feature_contributions_full {
+				feature_full_prediction_contributions {
 					amalgam 3.8
 					yaml 3.5
 					json 3.4
 					x 3.9
 				}
-				directional_feature_contributions_full {
+				feature_full_directional_prediction_contributions {
 					amalgam 0
 					yaml 0
 					json 0

--- a/unit_tests/ut_h_null_react.amlg
+++ b/unit_tests/ut_h_null_react.amlg
@@ -129,7 +129,7 @@
 				context_features ctx_features
 				context_values (list 6 4.99999999999)
 				allow_nulls (false)
-				details (assoc "case_contributions_full" (true))
+				details (assoc "case_full_prediction_contributions" (true))
 			))
 	))
 
@@ -138,13 +138,13 @@
 		obs ;sort list by training index
 			(sort
 				(lambda (> (get (current_value) ".session_training_index") (get (current_value 1) ".session_training_index")))
-				(get result (list 1 "payload" "case_contributions_full"))
+				(get result (list 1 "payload" "case_full_prediction_contributions"))
 			)
 		exp
 			(list
-				(assoc ".session_training_index" 9 ".session" "none" "case_contributions_full" 0.02)
-				(assoc ".session_training_index" 11 ".session" "none" "case_contributions_full" -0.4)
-				(assoc ".session_training_index" 13 ".session" "none" "case_contributions_full" -0.23)
+				(assoc ".session_training_index" 9 ".session" "none" "full_prediction_contribution" 0.02)
+				(assoc ".session_training_index" 11 ".session" "none" "full_prediction_contribution" -0.4)
+				(assoc ".session_training_index" 13 ".session" "none" "full_prediction_contribution" -0.23)
 			)
 	))
 
@@ -155,7 +155,7 @@
 				context_features ctx_features
 				context_values (list 6 5)
 				allow_nulls (false)
-				details (assoc "case_contributions_full" (true))
+				details (assoc "case_full_prediction_contributions" (true))
 			))
 	))
 
@@ -164,13 +164,13 @@
 		obs ;sort list by training index
 			(sort
 				(lambda (> (get (current_value) ".session_training_index") (get (current_value 1) ".session_training_index")))
-				(get result (list 1 "payload" "case_contributions_full"))
+				(get result (list 1 "payload" "case_full_prediction_contributions"))
 			)
 		exp
 			(list
-				(assoc "case_contributions_full" -0.05 ".session_training_index" 9 ".session" "none")
-				(assoc "case_contributions_full" -0.33 ".session_training_index" 11 ".session" "none")
-				(assoc "case_contributions_full" -0.26 ".session_training_index" 13 ".session" "none")
+				(assoc "full_prediction_contribution" -0.05 ".session_training_index" 9 ".session" "none")
+				(assoc "full_prediction_contribution" -0.33 ".session_training_index" 11 ".session" "none")
+				(assoc "full_prediction_contribution" -0.26 ".session_training_index" 13 ".session" "none")
 			)
 		thresh 0.1
 	))
@@ -185,13 +185,13 @@
 				context_features ctx_features
 				context_values (list 6 5)
 				allow_nulls (false)
-				details (assoc "feature_contributions_robust" (true))
+				details (assoc "feature_robust_prediction_contributions" (true))
 			))
 	))
 	(print "Robust Feature contributions for nominal: ")
 	(call assert_approximate (assoc
 		exp (assoc "X" 0.6 "Y" .4)
-		obs (get result (list 1 "payload" "feature_contributions_robust"))
+		obs (get result (list 1 "payload" "feature_robust_prediction_contributions"))
 		thresh 0.2
 	))
 
@@ -289,7 +289,7 @@
 				context_features ctx_features
 				context_values (list 6 4.999999999999)
 				allow_nulls (false)
-				details (assoc "case_contributions_full" (true))
+				details (assoc "case_full_prediction_contributions" (true))
 			))
 	))
 
@@ -298,13 +298,13 @@
 		obs ;sort list by training index
 			(sort
 				(lambda (> (get (current_value) ".session_training_index") (get (current_value 1) ".session_training_index")))
-				(get result (list 1 "payload" "case_contributions_full"))
+				(get result (list 1 "payload" "case_full_prediction_contributions"))
 			)
 		exp
 			(list
-				(assoc ".session_training_index" 9 ".session" "none" "case_contributions_full" 0.02)
-				(assoc ".session_training_index" 11 ".session" "none" "case_contributions_full" -0.4)
-				(assoc ".session_training_index" 13 ".session" "none" "case_contributions_full" -0.23)
+				(assoc ".session_training_index" 9 ".session" "none" "full_prediction_contribution" 0.02)
+				(assoc ".session_training_index" 11 ".session" "none" "full_prediction_contribution" -0.4)
+				(assoc ".session_training_index" 13 ".session" "none" "full_prediction_contribution" -0.23)
 			)
 	))
 
@@ -316,13 +316,13 @@
 				context_features ctx_features
 				context_values (list 6 5)
 				allow_nulls (false)
-				details (assoc "feature_contributions_full" (true))
+				details (assoc "feature_full_prediction_contributions" (true))
 			))
 	))
 	(print "Feature contributions: ")
 	(call assert_approximate (assoc
 		exp (assoc "X" .15 "Y" .07)
-		obs (get result (list 1 "payload" "feature_contributions_full"))
+		obs (get result (list 1 "payload" "feature_full_prediction_contributions"))
 		thresh 0.15
 	))
 
@@ -333,13 +333,13 @@
 				context_features ctx_features
 				context_values (list 6 5)
 				allow_nulls (false)
-				details (assoc "feature_contributions_robust" (true))
+				details (assoc "feature_robust_prediction_contributions" (true))
 			))
 	))
 	(print "Robust Feature contributions: ")
 	(call assert_approximate (assoc
 		exp (assoc "X" 0.46 "Y" .30)
-		obs (get result (list 1 "payload" "feature_contributions_robust"))
+		obs (get result (list 1 "payload" "feature_robust_prediction_contributions"))
 		thresh 0.15
 	))
 

--- a/unit_tests/ut_h_null_residual_convictions.amlg
+++ b/unit_tests/ut_h_null_residual_convictions.amlg
@@ -26,7 +26,7 @@
 
 	(call_entity "howso" "analyze")
 	(call_entity "howso" "react_aggregate" (assoc
-		details (assoc feature_residuals_full (true))
+		details (assoc feature_full_residuals (true))
 	))
 
 	(assign (assoc
@@ -37,7 +37,7 @@
 				leave_case_out (true)
 				details
 					(assoc
-						case_feature_residual_convictions_full (true)
+						feature_full_residual_convictions_for_case (true)
 					)
 			))
 	))
@@ -46,7 +46,7 @@
 	;dataset has nulls for 20 of the setosa cases for 'sepal_width'
 	(print "Continuous feature local residual conviction: ")
 	(call assert_approximate (assoc
-		obs (get result (list "case_feature_residual_convictions_full" "sepal_width"))
+		obs (get result (list "feature_full_residual_convictions_for_case" "sepal_width"))
 		exp 0.2
 		thresh 0.05
 	))
@@ -59,7 +59,7 @@
 				leave_case_out (true)
 				details
 					(assoc
-						case_feature_residual_convictions_full (true)
+						feature_full_residual_convictions_for_case (true)
 					)
 			))
 	))
@@ -68,7 +68,7 @@
 	;dataset has nulls for 20 of the virginica cases for 'class'
 	(print "Nominal feature local residual conviction: ")
 	(call assert_approximate (assoc
-		obs (get result (list "case_feature_residual_convictions_full" "class"))
+		obs (get result (list "feature_full_residual_convictions_for_case" "class"))
 		exp 0.17
 		thresh 0.05
 	))

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -327,7 +327,7 @@
 					context_values (list 6.9 3.2 4.7 1.4)
 					details
 						(assoc
-							"feature_mda_full" (true)
+							"feature_full_accuracy_contributions" (true)
 						)
 				))
 				(list 1 "payload")
@@ -341,7 +341,7 @@
 					context_values (list 6.9 3.2 4.7 1.4)
 					details
 						(assoc
-							"feature_mda_ex_post_full" (true)
+							"feature_full_accuracy_contributions_ex_post" (true)
 						)
 				))
 				(list 1 "payload")
@@ -354,7 +354,7 @@
 					context_values (list 6.9 3.2 4.7 1.4)
 					details
 						(assoc
-							"feature_mda_ex_post_full" (true)
+							"feature_full_accuracy_contributions_ex_post" (true)
 						)
 				))
 				(list 1 "payload")
@@ -373,12 +373,12 @@
 
 	(print "MDA different when providing wrong action feature: ")
 	(declare (assoc
-		custom_mda (get mda_custom_result (list "feature_mda_ex_post_full" "D"))
+		custom_mda (get mda_custom_result (list "feature_full_accuracy_contributions_ex_post" "D"))
 
 		; should be off by a factor of 2
-		predict_mda (get mda_actual_result (list "feature_mda_ex_post_full" "D"))
+		predict_mda (get mda_actual_result (list "feature_full_accuracy_contributions_ex_post" "D"))
 
-		react_mda (get mda_result (list "feature_mda_full" "D"))
+		react_mda (get mda_result (list "feature_full_accuracy_contributions" "D"))
 	))
 	(call assert_approximate (assoc
 		obs (* 2 custom_mda)
@@ -469,7 +469,7 @@
 				context_values (list 6.9 3.2 4.7 1.4)
 				details
 					(assoc
-						feature_residuals_full (true)
+						feature_full_residuals (true)
 						feature_deviations (true)
 						prediction_stats (true)
 						selected_prediction_stats (list "all")
@@ -495,7 +495,7 @@
 	(print "React Lv4 local prediction stats mse vs feature residuals: ")
 	(call assert_same (assoc
 		exp (get result (list "prediction_stats" "mae"))
-		obs (get result (list "feature_residuals_full"))
+		obs (get result (list "feature_full_residuals"))
 	))
 	(call exit_if_failures (assoc msg "Lv4 feature prediction stats boolean input"))
 
@@ -506,7 +506,7 @@
 				obs
 					(<
 						(get result ["feature_deviations" (current_value 2)])
-						(get result ["feature_residuals_full" (current_value 2)])
+						(get result ["feature_full_residuals" (current_value 2)])
 					)
 			))
 		)
@@ -534,7 +534,7 @@
 						"influential_cases" (true)
 						"boundary_cases" (true)
 						"outlying_feature_values" (true)
-						"feature_residuals_full" (true)
+						"feature_full_residuals" (true)
 						"observational_errors" (true)
 					)
 			))
@@ -544,14 +544,14 @@
 	(print "React Lv4 locally feature deviation value for A: ")
 	(call assert_approximate (assoc
 		exp .94321 ;expected user set value, bigger than residual
-		obs (get result (list "feature_residuals_full" "A"))
+		obs (get result (list "feature_full_residuals" "A"))
 	))
 	(call exit_if_failures (assoc msg "Lv4 feature deviations for feature A"))
 
 	(print "React Lv4 locally feature deviation value for C: ")
 	(call assert_approximate (assoc
 		exp .2 ;user set value of  .05 is smaller so should be ignored
-		obs (get result (list "feature_residuals_full" "C"))
+		obs (get result (list "feature_full_residuals" "C"))
 		percent 0.5
 	))
 	(call exit_if_failures (assoc msg "Lv4 feature deviations for feature C"))
@@ -691,15 +691,15 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"case_feature_residuals_full" (true)
-					"case_feature_residual_convictions_full" (true)
+					"feature_full_residuals_for_case" (true)
+					"feature_full_residual_convictions_for_case" (true)
 				)
 			))
 	))
 
 	(print "Standard case residuals and residual convictions for a prediction: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_residuals_full"))
+		obs (get result (list 1 "payload" "feature_full_residuals_for_case"))
 		exp (assoc
 				"A" 0.07
 				"B" 1.76
@@ -711,7 +711,7 @@
 	))
 	(print "standard local: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_residual_convictions_full"))
+		obs (get result (list 1 "payload" "feature_full_residual_convictions_for_case"))
 		exp (assoc
 				"A" 6.2
 				"B" .22
@@ -729,15 +729,15 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"case_feature_residuals_robust" (true)
-					"case_feature_residual_convictions_robust" (true)
+					"feature_robust_residuals_for_case" (true)
+					"feature_robust_residual_convictions_for_case" (true)
 				)
 			))
 	))
 
 	(print "Robust case residuals and residual convictions for a prediction: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_residuals_robust"))
+		obs (get result (list 1 "payload" "feature_robust_residuals_for_case"))
 		exp (assoc
 				"A" 0.3
 				"B" 2.0
@@ -750,7 +750,7 @@
 
 	(print "robust local: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_residual_convictions_robust"))
+		obs (get result (list 1 "payload" "feature_robust_residual_convictions_for_case"))
 		exp (assoc
 				"A" 4
 				"B" .7
@@ -777,7 +777,7 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"case_feature_residuals_robust" (true)
+					"feature_robust_residuals_for_case" (true)
 					"features" (list "A" "C")
 				)
 			))
@@ -785,7 +785,7 @@
 
 	(print "Robust case residuals and residual convictions for a prediction for specific features: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_residuals_robust"))
+		obs (get result (list 1 "payload" "feature_robust_residuals_for_case"))
 		exp (assoc
 				"A" 0.3
 				"C" 1.0
@@ -800,15 +800,15 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"case_feature_residuals_robust" (true)
-					"case_feature_residual_convictions_robust" (true)
+					"feature_robust_residuals_for_case" (true)
+					"feature_robust_residual_convictions_for_case" (true)
 				)
 			))
 	))
 
 	(print "robust local - similar to previous: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_residual_convictions_robust"))
+		obs (get result (list 1 "payload" "feature_robust_residual_convictions_for_case"))
 		exp (assoc
 				"A" 4
 				"B" .7
@@ -835,8 +835,8 @@
 				context_features (trunc iris_features)
 				context_values (list 6.9 7 7 6)
 				details (assoc
-					"case_feature_residuals_robust" (true)
-					"case_feature_residual_convictions_robust" (true)
+					"feature_robust_residuals_for_case" (true)
+					"feature_robust_residual_convictions_for_case" (true)
 					"features" (list "A" "B")
 				)
 			))
@@ -844,7 +844,7 @@
 
 	(print "robust local - similar to previous for specific features: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_residual_convictions_robust"))
+		obs (get result (list 1 "payload" "feature_robust_residual_convictions_for_case"))
 		exp (assoc
 				"A" 4
 				"B" .7
@@ -865,13 +865,13 @@
 				case_indices (list "none" 120)
 				leave_case_out (true)
 				details (assoc
-					"case_feature_residuals_full" (true)
+					"feature_full_residuals_for_case" (true)
 				)
 			 ))
 	))
 	(print "Case residuals and convictions for an existing case: ")
 	(call assert_approximate (assoc
-		obs (get result (list 1 "payload" "case_feature_residuals_full"))
+		obs (get result (list 1 "payload" "feature_full_residuals_for_case"))
 		exp (assoc
 				"D" 5.532885154377776
 				"E" 0.9010000120937572

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -296,8 +296,8 @@
 				details (assoc
 					selected_prediction_stats (list "mae")
 					prediction_stats (true)
-					feature_residuals_full (true)
-					feature_residuals_robust (true)
+					feature_full_residuals (true)
+					feature_robust_residuals (true)
 				)
 			))
 	))
@@ -306,12 +306,12 @@
 	(print "Assert full feature residuals is the same as mae: ")
 	(call assert_equal
 		obs (get result ["tart" "mae"])
-		exp (get result ["tart" "feature_residuals_full"])
+		exp (get result ["tart" "feature_full_residuals"])
 	)
 
 	(print "Robust and full residuals are different: ")
 	(call assert_true (assoc
-		obs (!= (get result ["feature_residuals_robust" "tart"]) (get result ["feature_residuals_full" "tart"]))
+		obs (!= (get result ["feature_robust_residuals" "tart"]) (get result ["feature_full_residuals" "tart"]))
 	))
 
 	(assign (assoc
@@ -673,8 +673,8 @@
 				;this is truly a trivial operation, so low samples is ok
 				num_robust_influence_samples 10
 				details (assoc
-					feature_contributions_robust (true)
-					feature_mda_full (true)
+					feature_robust_prediction_contributions (true)
+					feature_full_accuracy_contributions (true)
 					action_condition (assoc "fruit" (list "strawberry"))
 					context_condition (assoc "weight" (list "strawberry"))
 				)
@@ -683,13 +683,13 @@
 	(call keep_result_payload)
 	(print "Influences are zero as expected: ")
 	(call assert_true (assoc
-		obs (apply "=" (append [0] (values (get result "directional_feature_contributions_robust"))))
+		obs (apply "=" (append [0] (values (get result "feature_robust_directional_prediction_contributions"))))
 	))
 	(call assert_true (assoc
-		obs (apply "=" (append [0] (values (get result "feature_contributions_robust"))))
+		obs (apply "=" (append [0] (values (get result "feature_robust_prediction_contributions"))))
 	))
 	(call assert_true (assoc
-		obs (apply "=" (append [0] (values (get result "feature_mda_robust"))))
+		obs (apply "=" (append [0] (values (get result "feature_robust_accuracy_contributions"))))
 	))
 	(call exit_if_failures (assoc msg "Heavily influenced feature influences"))
 

--- a/unit_tests/ut_h_synthetic_dataset1.amlg
+++ b/unit_tests/ut_h_synthetic_dataset1.amlg
@@ -129,7 +129,7 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "react_aggregate" (assoc
-				details (assoc feature_residuals_full (true))
+				details (assoc feature_full_residuals (true))
 				context_features (trunc features)
 				sample_model_fraction .5
 			))
@@ -138,7 +138,7 @@
 	;residual of y should be ~0, since that's what it's computed as, instead of the minimum theoretical residual of ~0.75
 	(print "Recalculating residuals on smaller sample size: ")
 	(call assert_approximate (assoc
-		obs (get result "feature_residuals_full")
+		obs (get result "feature_full_residuals")
 		exp (assoc "z" 20 "y" 0.0 "w" 2.8 "x" 37)
 		thresh (assoc "z" 6 "y" 0.14 "w" 1.4 "x" 11)
 	))

--- a/unit_tests/ut_h_synthetic_sum.amlg
+++ b/unit_tests/ut_h_synthetic_sum.amlg
@@ -40,8 +40,8 @@
 				num_samples 4000
 				action_feature "sum"
 				details (assoc
-					feature_mda_full (true)
-					feature_contributions_full (true)
+					feature_full_accuracy_contributions (true)
+					feature_full_prediction_contributions (true)
 				)
 			))
 	))
@@ -49,26 +49,26 @@
 	(print "MDA is negligible for noisy D feature: ")
 	(call assert_approximate (assoc
 		exp 0
-		obs (get result ["feature_mda_full" "D"])
+		obs (get result ["feature_full_accuracy_contributions" "D"])
 		thresh 15
 	))
 
 	(print "MDA for features A,B,C and D: ")
 	(call assert_approximate (assoc
 		exp (assoc "A" 230 "B" 230 "C" 230 "D" 0)
-		obs (map (lambda (get result ["feature_mda_full" (current_index 1)])) (zip ["A" "B" "C" "D"]) )
+		obs (map (lambda (get result ["feature_full_accuracy_contributions" (current_index 1)])) (zip ["A" "B" "C" "D"]) )
 		thresh 50
 	))
 
 	(print "Contribution is negligible for noisy D feature: ")
 	(call assert_true (assoc
-		obs (< (get result ["feature_contributions_full" "D"]) 22)
+		obs (< (get result ["feature_full_prediction_contributions" "D"]) 22)
 	))
 
 	(print "Contributions for features A,B and C: ")
 	(call assert_approximate (assoc
 		exp (assoc "A" 230 "B" 230 "C" 230 "D" 0)
-		obs (map (lambda (get result ["feature_contributions_full" (current_index 1)])) (zip ["A" "B" "C" "D"]) )
+		obs (map (lambda (get result ["feature_full_prediction_contributions" (current_index 1)])) (zip ["A" "B" "C" "D"]) )
 		thresh 50
 	))
 
@@ -76,7 +76,7 @@
 	(print "Directional Contributions for all features: ")
 	(call assert_approximate (assoc
 		exp (assoc "A" 0 "B" 0 "C" 0 "D" 0)
-		obs (map (lambda (get result ["directional_feature_contributions_full" (current_index 1)])) (zip ["A" "B" "C" "D"]) )
+		obs (map (lambda (get result ["feature_full_directional_prediction_contributions" (current_index 1)])) (zip ["A" "B" "C" "D"]) )
 		thresh 15
 	))
 

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -674,12 +674,12 @@
 				action_feature "f1"
 				context_features [".f1_lag_1" ".f2_rate_1" ".f2_rate_2" ".f3_rate_1"]
 				num_samples 200
-				details {"feature_mda_full" (true)}
+				details {"feature_full_accuracy_contributions" (true)}
 			))
 	))
 	(call assert_same (assoc
 		exp ".f1_lag_1"
-		obs (first (index_max (get result [1 "payload" "feature_mda_full"])))
+		obs (first (index_max (get result [1 "payload" "feature_full_accuracy_contributions"])))
 	))
 	(call exit_if_failures (assoc msg "Lag has the biggest full contribution."))
 

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -77,7 +77,7 @@
 				leave_case_out (true)
 				details
 					(assoc
-						case_feature_residual_convictions_full (true)
+						feature_full_residual_convictions_for_case (true)
 					)
 			))
 	))
@@ -97,7 +97,7 @@
 				leave_case_out (true)
 				details
 					(assoc
-						feature_residuals_robust (true)
+						feature_robust_residuals (true)
 					)
 				use_case_weights (true)
 			))
@@ -114,7 +114,7 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "react_aggregate" (assoc
-				details (assoc feature_mda_full (true))
+				details (assoc feature_full_accuracy_contributions (true))
 				action_feature "target"
 			))
 	))
@@ -134,7 +134,7 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "react_aggregate" (assoc
-				details (assoc feature_mda_full (true))
+				details (assoc feature_full_accuracy_contributions (true))
 				action_feature "target"
 			))
 	))

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -198,8 +198,8 @@
 		training_data
 	)
 
-;VERIFY DECREASE IN ACCURACY
-	(print "Executing Feature Decrease in Accuracy with analysis:\n")
+;VERIFY ACCURACY CONTRIBUTIONS
+	(print "Executing Feature Accuracy Contributions with analysis:\n")
 	(declare (assoc
 		result
 			(get (call_entity "howso" "react_aggregate" (assoc
@@ -209,7 +209,7 @@
 			)) [1 "payload"])
 	))
 
-	(print "Decrease in accuracy using feature knockout:\n")
+	(print "Accuracy contributions using feature knockout:\n")
 	;feature knockout on iris the accuracy shouldn't drop more than 5% for any feature
 	(map
 		(lambda (seq
@@ -262,7 +262,7 @@
 		thresh 0.05
 	))
 
-	(call exit_if_failures (assoc msg "Feature Decrease in Accuracy"))
+	(call exit_if_failures (assoc msg "Feature Accuracy Contributions"))
 
 
 	;cache targeted model accuracy

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -205,7 +205,7 @@
 			(get (call_entity "howso" "react_aggregate" (assoc
 				context_features context_labels
 				action_feature (first action_labels)
-				details (assoc feature_mda_full (true))
+				details (assoc feature_full_accuracy_contributions (true))
 			)) [1 "payload"])
 	))
 
@@ -216,7 +216,7 @@
 			(print (current_value) " : ")
 			(call assert_approximate (assoc
 				exp 0.035
-				obs (get result ["feature_mda_full" (current_value 2)])
+				obs (get result ["feature_full_accuracy_contributions" (current_value 2)])
 				thresh 0.04
 			))
 		))
@@ -228,7 +228,7 @@
 			(get (call_entity "howso" "react_aggregate" (assoc
 				context_features context_labels
 				action_feature (first action_labels)
-				details (assoc feature_mda_permutation_full (true))
+				details (assoc feature_full_accuracy_contributions_permutation (true))
 			)) [1 "payload"])
 	))
 
@@ -236,28 +236,28 @@
 	(print "\nDecrease in accuracy using feature scrambling:\n")
 	(print "petal_length : ")
 	(call assert_approximate (assoc
-		obs (get result ["feature_mda_permutation_full" "petal_length"])
+		obs (get result ["feature_full_accuracy_contributions_permutation" "petal_length"])
 		exp 0.63
 		thresh 0.3
 	))
 
 	(print "petal_width : ")
 	(call assert_approximate (assoc
-		obs (get result ["feature_mda_permutation_full" "petal_width"])
+		obs (get result ["feature_full_accuracy_contributions_permutation" "petal_width"])
 		exp 0.15
 		thresh 0.6
 	))
 
 	(print "sepal_width : " )
 	(call assert_approximate (assoc
-		obs (get result ["feature_mda_permutation_full" "sepal_width"])
+		obs (get result ["feature_full_accuracy_contributions_permutation" "sepal_width"])
 		exp 0.03
 		thresh 0.05
 	))
 
 	(print "sepal_length : ")
 	(call assert_approximate (assoc
-		obs (get result ["feature_mda_permutation_full" "sepal_length"])
+		obs (get result ["feature_full_accuracy_contributions_permutation" "sepal_length"])
 		exp 0.02
 		thresh 0.05
 	))
@@ -719,9 +719,9 @@
 				context_features  (list "sepal_width" "petal_length" "petal_width" "species")
 				context_values (list 2.2 1.5 0.1 "setosa")
 				action_features (list "sepal_length" )
-				details (assoc "feature_residuals_full" (true))
+				details (assoc "feature_full_residuals" (true))
 			))
-			(list 1 "payload" "feature_residuals_full" "sepal_length" )
+			(list 1 "payload" "feature_full_residuals" "sepal_length" )
 		)
 		" expected value: " expected_value "\n"
 	)


### PR DESCRIPTION
We've decided on renaming our Feature Influence metrics, "Feature MDA" and "Feature Contributions". The new names, respectively, are "Accuracy Contributions" and "Prediction Contributions". To enact these renames, this series of changes changes all parameters and return objects to use the new names. Additionally, we are taking the renaming opportunity to shift around the location of the "robust"/"full" modifier to move it somewhere we find more intuitive. Lastly, we are updating the detail names for react that measure some metric on solely the case in question (case_feature_residuals, case_feature_contributions, and case_feature_residual_convictions) to include "..._for_case" in an effort to make these names more indicative of what they represent. 

The full list of details that have been renamed is below. Note that "{f/r}" represents a section of the name that can be filled with either "full" or "robust".

- feature_mda_{f/r} => feature_{f/r}_accuracy_contributions
- feature_contributions_{f/r} => feature_{f/r}_prediction_contributions
- feature_mda_permutation_{f/r} => feature_{f/r}_accuracy_contributions_permutation
- feature_mda_ex_post_{f/r} => feature_{f/r}_accuracy_contributions_ex_post
- case_feature_contributions_{f/r} => feature_{f/r}_prediction_contributions_for_case
- case_contributions_{f/r} => case_{f/r}_prediction_contributions
- case_mda_{f/r} => case_{f/r}_accuracy_contributions
- case_feature_residuals_{f/r} => feature_{f/r}_residuals_for_case
- case_feature_residual_convictions_{f/r} => feature_{f/r}_residual_convictions_for_case
- feature_residuals_{f/r} => feature_{f/r}_residuals