### PR TITLE
22956: Fixes an issue where `react_aggregate` returns a dictionary of warnings

### DIFF
--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -688,7 +688,7 @@
 
         (call !Return (assoc
 			payload output
-			warnings warnings
+			warnings (if (size warnings) (indices warnings))
 		))
 	)
 


### PR DESCRIPTION
Fixes an issue where `react_aggregate` returns a dictionary of warnings rather than a list.