### PR TITLE
22984: Adds new parameter to all react endpoints, "feature_post_process_code_map", MINOR

### DIFF
--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -377,7 +377,7 @@
 										output_value
 											(get_value
 												(call_sandboxed (get custom_feature_post_process_map (current_value 1)) (assoc
-													case feature_values_map
+													case (append feature_values_map (associate (current_value 3) output_value) )
 												) !sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
 											)
 									))

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -371,12 +371,12 @@
 										)
 								))
 
-								(if (contains_index custom_feature_post_process_map (current_value))
+								(if (contains_index feature_post_process_code_map (current_value))
 									;if custom post process is defined, update feature value with it
 									(assign (assoc
 										output_value
 											(get_value
-												(call_sandboxed (get custom_feature_post_process_map (current_value 1)) (assoc
+												(call_sandboxed (get feature_post_process_code_map (current_value 1)) (assoc
 													case (append feature_values_map (associate (current_value 3) output_value) )
 												) !sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
 											)

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -371,6 +371,18 @@
 										)
 								))
 
+								(if (contains_index custom_feature_post_process_map (current_value))
+									;if custom post process is defined, update feature value with it
+									(assign (assoc
+										output_value
+											(get_value
+												(call_sandboxed (get custom_feature_post_process_map (current_value 1)) (assoc
+													case feature_values_map
+												) !sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
+											)
+									))
+								)
+
 								;append derived feature and value to the input features and values so that they could be used by the next derived feature
 								(accum (assoc feature_values_map (associate (current_value 2) output_value)))
 

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -119,7 +119,7 @@
 		(if (= (null) derived_feature)
 			(conclude (false))
 		)
-
+		(declare (assoc derived_value_index (get feature_index_map derived_feature) ))
 		;pull the max row lag for this derived_feature
 		(declare (assoc max_row_lag  (get !featureAttributes (list derived_feature "max_row_lag")) ))
 
@@ -142,9 +142,34 @@
 						feature_index_map feature_index_map
 						!featureDateTimeMap !featureDateTimeMap
 						!ConvertDateToEpoch !ConvertDateToEpoch
-					) (* (size series_data) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)) 
+					) (* (size series_data) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
 				)
 		))
+
+		(if (contains_index custom_feature_post_process_map derived_feature)
+			;if custom post process is defined, update derived feature value with it
+			(assign (assoc
+				derived_feature_value
+					(get_value
+						(call_sandboxed (get custom_feature_post_process_map derived_feature) (assoc
+							series_data
+								;need to use series_data with the updated feature value
+								(append
+									(trunc series_data)
+									[ (append
+										(if derived_value_index (trunc (last series_data) derived_value_index) [])
+										derived_feature_value
+										(tail (last series_data) (- (+ 1 derived_value_index)))
+									) ]
+								)
+							series_row_index last_series_index
+							feature_index_map feature_index_map
+							!featureDateTimeMap !featureDateTimeMap
+							!ConvertDateToEpoch !ConvertDateToEpoch
+						) (* (size series_data) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
+					)
+			))
+		)
 
 		(declare (assoc
 			bounds_map
@@ -254,8 +279,6 @@
 				)
 			)
 		)
-
-		(declare (assoc derived_value_index (get feature_index_map derived_feature) ))
 
 		;edit series_data in place, updating the last row, the column matching the derived_feature with the derived_feature_value
 		(assign (assoc

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -154,6 +154,9 @@
 						(call_sandboxed (get custom_feature_post_process_map derived_feature) (assoc
 							series_data
 								;need to use series_data with the updated feature value
+								;this is equivalent to the following:
+								; [(set (last series_data) (get feature_index_map derived_feature) derived_feature_value) ]
+								;but is much more memory efficient
 								(append
 									(trunc series_data)
 									[ (append

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -146,12 +146,12 @@
 				)
 		))
 
-		(if (contains_index custom_feature_post_process_map derived_feature)
+		(if (contains_index feature_post_process_code_map derived_feature)
 			;if custom post process is defined, update derived feature value with it
 			(assign (assoc
 				derived_feature_value
 					(get_value
-						(call_sandboxed (get custom_feature_post_process_map derived_feature) (assoc
+						(call_sandboxed (get feature_post_process_code_map derived_feature) (assoc
 							series_data
 								;need to use series_data with the updated feature value
 								;this is equivalent to the following:

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -120,11 +120,39 @@
 						))
 				))
 
+				(declare (assoc feat_index (get feature_index_map feature) ))
+				(declare (assoc
+					feature_value
+						(if (contains_index custom_feature_post_process_map feature)
+							(get_value
+								(call_sandboxed (get custom_feature_post_process_map feature) (assoc
+									series_data
+										;need to use series_data with the updated feature value
+										(append
+											(trunc series_data)
+											[ (append
+												(if feat_index (trunc (last series_data) feat_index) [])
+												(first (get react_output "action_values"))
+												(tail (last series_data) (- (+ 1 feat_index)))
+											) ]
+										)
+									series_row_index last_series_index
+									feature_index_map feature_index_map
+									!featureDateTimeMap !featureDateTimeMap
+									!ConvertDateToEpoch !ConvertDateToEpoch
+								) (* (size series_data) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
+							)
+
+							;else just use the output of the react
+							(first (get react_output "action_values"))
+						)
+				))
+
 				;update series_data in place, updating the last row, the column matching the feature with the value
 				(assign
 					"series_data"
 					(list last_series_index (get feature_index_map feature))
-					(first (get react_output "action_values"))
+					feature_value
 				)
 
 				;if gathering details, update the case detail values with those from this react

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -368,6 +368,31 @@
 			(conclude)
 		)
 
+		(if custom_feature_post_process_map
+			;if given the custom post process map, overwrite it with the parsed versions of the code
+			(assign (assoc
+				custom_feature_post_process_map
+					(map
+						(lambda
+							;parse it into code, requires passing series data as a list of list of values and feat_index_map
+							(call !ParseDerivedFeatureCode (assoc
+								code_string (current_value 1)
+								label_to_code
+									(lambda
+										(if (and (>= (- series_row_index label_value) 0) (contains_index feature_index_map label_name))
+											;pull the feature value
+											(get series_data (list (- series_row_index label_value) (get feature_index_map label_name)) )
+
+											(null)
+										)
+									)
+							))
+						)
+						custom_feature_post_process_map
+					)
+			))
+		)
+
 		(declare (assoc
 			all_contexts series_context_features
 			n_samples

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -128,6 +128,9 @@
 								(call_sandboxed (get custom_feature_post_process_map feature) (assoc
 									series_data
 										;need to use series_data with the updated feature value
+										;this is equivalent to the following:
+										; [(set (last series_data) (get feature_index_map derived_feature) derived_feature_value) ]
+										;but is much more memory efficient
 										(append
 											(trunc series_data)
 											[ (append
@@ -410,8 +413,6 @@
 										(if (and (>= (- series_row_index label_value) 0) (contains_index feature_index_map label_name))
 											;pull the feature value
 											(get series_data (list (- series_row_index label_value) (get feature_index_map label_name)) )
-
-											(null)
 										)
 									)
 							))

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -123,9 +123,9 @@
 				(declare (assoc feat_index (get feature_index_map feature) ))
 				(declare (assoc
 					feature_value
-						(if (contains_index custom_feature_post_process_map feature)
+						(if (contains_index feature_post_process_code_map feature)
 							(get_value
-								(call_sandboxed (get custom_feature_post_process_map feature) (assoc
+								(call_sandboxed (get feature_post_process_code_map feature) (assoc
 									series_data
 										;need to use series_data with the updated feature value
 										;this is equivalent to the following:
@@ -399,10 +399,10 @@
 			(conclude)
 		)
 
-		(if custom_feature_post_process_map
+		(if feature_post_process_code_map
 			;if given the custom post process map, overwrite it with the parsed versions of the code
 			(assign (assoc
-				custom_feature_post_process_map
+				feature_post_process_code_map
 					(map
 						(lambda
 							;parse it into code, requires passing series data as a list of list of values and feat_index_map
@@ -417,7 +417,7 @@
 									)
 							))
 						)
-						custom_feature_post_process_map
+						feature_post_process_code_map
 					)
 			))
 		)

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -336,7 +336,8 @@
 			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
 			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
 			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
-			;context in the generation or derivation of other feature values within a single timestep.
+			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access the values
+			;of all context features and all previously generated action feature values.
 			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
@@ -741,7 +742,8 @@
 			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
 			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
 			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
-			;context in the generation or derivation of other feature values within a single timestep.
+			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access the values
+			;of all context features and all previously generated action feature values.
 			custom_feature_post_process_map (null)
 		)
 

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -331,6 +331,13 @@
 			;{type "number"}
 			;total number of cases to generate for generative reacts.
 			num_cases_to_generate (null)
+
+			;{type "assoc" additional_indices "string"}
+			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
+			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
+			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
+			;context in the generation or derivation of other feature values within a single timestep.
+			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
@@ -429,6 +436,30 @@
 		;check and update caches if necessary
 		(call !PreReactCacheChecks)
 
+		(if custom_feature_post_process_map
+			(assign (assoc
+				custom_feature_post_process_map
+					(map
+						(lambda
+							;parse it into code, requires passing case as a map of feature name to value
+							(call !ParseDerivedFeatureCode (assoc
+								code_string (current_value 1)
+								label_to_code
+									(lambda
+										(if (= (lambda label_value) 0)
+											;pull the feature value
+											(get case (lambda label_name))
+
+											(null)
+										)
+									)
+							))
+						)
+						custom_feature_post_process_map
+					)
+			))
+		)
+
 		(declare (assoc
 			output_action_features
 				(if (size derived_action_features)
@@ -506,6 +537,7 @@
 							preserve_feature_values preserve_feature_values
 							new_case_threshold new_case_threshold
 							pre_generated_uniques_map pre_generated_uniques_map
+							custom_feature_post_process_map custom_feature_post_process_map
 						))
 					))
 					0 (- num_reacts 1) 1
@@ -704,6 +736,13 @@
 			; 		'most_similar': the closest distance of the most similar case
 			; 		null: the minimum local distance
 			new_case_threshold "min"
+
+			;{type "assoc" additional_indices "string"}
+			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
+			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
+			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
+			;context in the generation or derivation of other feature values within a single timestep.
+			custom_feature_post_process_map (null)
 		)
 
 		(call !ValidateParameters)
@@ -765,6 +804,30 @@
 				)
 		))
 
+		(if custom_feature_post_process_map
+			(assign (assoc
+				custom_feature_post_process_map
+					(map
+						(lambda
+							;parse it into code, requires passing case as a map of feature name to value
+							(call !ParseDerivedFeatureCode (assoc
+								code_string (current_value 1)
+								label_to_code
+									(lambda
+										(if (= (lambda label_value) 0)
+											;pull the feature value
+											(get case (lambda label_name))
+
+											(null)
+										)
+									)
+							))
+						)
+						custom_feature_post_process_map
+					)
+			))
+		)
+
 		(declare (assoc
 			react_response
 				(call !SingleReact (assoc
@@ -796,6 +859,7 @@
 					preserve_feature_values preserve_feature_values
 					new_case_threshold new_case_threshold
 					pre_generated_uniques_map pre_generated_uniques_map
+					custom_feature_post_process_map custom_feature_post_process_map
 				))
 		))
 

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -303,7 +303,7 @@
 			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
 			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access the values
 			;of all context features and all previously generated action feature values.
-			custom_feature_post_process_map (null)
+			feature_post_process_code_map (null)
 			;{type "list" values "string"}
 			;list of features that will preserve their values from the case specified by case_indices, appending and
 			;	overwriting the specified context and context features as necessary.  For generative reacts, if case_indices isn't specified,
@@ -436,9 +436,9 @@
 		;check and update caches if necessary
 		(call !PreReactCacheChecks)
 
-		(if custom_feature_post_process_map
+		(if feature_post_process_code_map
 			(assign (assoc
-				custom_feature_post_process_map
+				feature_post_process_code_map
 					(map
 						(lambda
 							;parse it into code, requires passing case as a map of feature name to value
@@ -453,7 +453,7 @@
 									)
 							))
 						)
-						custom_feature_post_process_map
+						feature_post_process_code_map
 					)
 			))
 		)
@@ -535,7 +535,7 @@
 							preserve_feature_values preserve_feature_values
 							new_case_threshold new_case_threshold
 							pre_generated_uniques_map pre_generated_uniques_map
-							custom_feature_post_process_map custom_feature_post_process_map
+							feature_post_process_code_map feature_post_process_code_map
 						))
 					))
 					0 (- num_reacts 1) 1
@@ -720,7 +720,7 @@
 			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
 			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access the values
 			;of all context features and all previously generated action feature values.
-			custom_feature_post_process_map (null)
+			feature_post_process_code_map (null)
 			;{type "list" values "string"}
 			;list of features that will preserve their values from the case specified by case_indices, appending and
 			;	overwriting the specified context and context features as necessary.  For generative reacts, if case_indices isn't specified,
@@ -802,9 +802,9 @@
 				)
 		))
 
-		(if custom_feature_post_process_map
+		(if feature_post_process_code_map
 			(assign (assoc
-				custom_feature_post_process_map
+				feature_post_process_code_map
 					(map
 						(lambda
 							;parse it into code, requires passing case as a map of feature name to value
@@ -819,7 +819,7 @@
 									)
 							))
 						)
-						custom_feature_post_process_map
+						feature_post_process_code_map
 					)
 			))
 		)
@@ -855,7 +855,7 @@
 					preserve_feature_values preserve_feature_values
 					new_case_threshold new_case_threshold
 					pre_generated_uniques_map pre_generated_uniques_map
-					custom_feature_post_process_map custom_feature_post_process_map
+					feature_post_process_code_map feature_post_process_code_map
 				))
 		))
 

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -297,6 +297,13 @@
 			;	note: nominal features only support 'value', 'goal' is ignored.
 			;		  for non-nominals, if both are provided, only 'goal' is considered.
 			goal_features_map (assoc)
+			;{type "assoc" additional_indices "string"}
+			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
+			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
+			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
+			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access the values
+			;of all context features and all previously generated action feature values.
+			custom_feature_post_process_map (null)
 			;{type "list" values "string"}
 			;list of features that will preserve their values from the case specified by case_indices, appending and
 			;	overwriting the specified context and context features as necessary.  For generative reacts, if case_indices isn't specified,
@@ -331,14 +338,6 @@
 			;{type "number"}
 			;total number of cases to generate for generative reacts.
 			num_cases_to_generate (null)
-
-			;{type "assoc" additional_indices "string"}
-			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
-			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
-			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
-			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access the values
-			;of all context features and all previously generated action feature values.
-			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
@@ -450,8 +449,6 @@
 										(if (= (lambda label_value) 0)
 											;pull the feature value
 											(get case (lambda label_name))
-
-											(null)
 										)
 									)
 							))
@@ -717,6 +714,13 @@
 			;	note: nominal features only support 'value', 'goal' is ignored.
 			;		  for non-nominals, if both are provided, only 'goal' is considered.
 			goal_features_map (assoc)
+			;{type "assoc" additional_indices "string"}
+			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
+			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
+			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
+			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access the values
+			;of all context features and all previously generated action feature values.
+			custom_feature_post_process_map (null)
 			;{type "list" values "string"}
 			;list of features that will preserve their values from the case specified by case_indices, appending and
 			;	overwriting the specified context and context features as necessary.  For generative reacts, if case_indices isn't specified,
@@ -737,14 +741,6 @@
 			; 		'most_similar': the closest distance of the most similar case
 			; 		null: the minimum local distance
 			new_case_threshold "min"
-
-			;{type "assoc" additional_indices "string"}
-			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
-			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
-			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
-			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access the values
-			;of all context features and all previously generated action feature values.
-			custom_feature_post_process_map (null)
 		)
 
 		(call !ValidateParameters)
@@ -819,8 +815,6 @@
 										(if (= (lambda label_value) 0)
 											;pull the feature value
 											(get case (lambda label_name))
-
-											(null)
 										)
 									)
 							))

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -385,6 +385,18 @@
 							))
 					))
 
+					(if (contains_index custom_feature_post_process_map action_feature)
+						;if custom post process is defined, update feature value with it
+						(assign (assoc
+							action_value
+								(get_value
+									(call_sandboxed (get custom_feature_post_process_map action_feature) (assoc
+										case (append (zip context_features context_values) (associate action_feature action_value) )
+									) !sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
+								)
+						))
+					)
+
 					;null values by themselves aren't appended to the list, must append nulls in a list
 					(accum (assoc
 						react_action_values

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -385,12 +385,12 @@
 							))
 					))
 
-					(if (contains_index custom_feature_post_process_map action_feature)
+					(if (contains_index feature_post_process_code_map action_feature)
 						;if custom post process is defined, update feature value with it
 						(assign (assoc
 							action_value
 								(get_value
-									(call_sandboxed (get custom_feature_post_process_map action_feature) (assoc
+									(call_sandboxed (get feature_post_process_code_map action_feature) (assoc
 										case (append (zip context_features context_values) (associate action_feature action_value) )
 									) !sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
 								)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -100,6 +100,13 @@
 			;	note: nominal features only support 'value', 'goal' is ignored.
 			;		  for non-nominals, if both are provided, only 'goal' is considered.
 			goal_features_map (assoc)
+			;{type "assoc" additional_indices "string"}
+			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
+			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
+			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
+			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access feature
+			;values of the current time step as well as previously generated timesteps.
+			custom_feature_post_process_map (null)
 			;{type "list" values "string"}
 			;list of features that will preserve their values from the case specified by case_indices, appending and
 			;	overwriting the specified context and context features as necessary.  For generative reacts, if case_indices isn't specified,
@@ -129,14 +136,6 @@
 			;	'always' : only output original cases, outputs null for all feature values if unable to generate a new case
 			;	'attempt' : output any generated case only if generation fails all initial attempts to output original cases
 			generate_new_cases "no"
-
-			;{type "assoc" additional_indices "string"}
-			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
-			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
-			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
-			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access feature
-			;values of the current time step as well as previously generated timesteps.
-			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
@@ -442,6 +441,13 @@
 			;	note: nominal features only support 'value', 'goal' is ignored.
 			;		  for non-nominals, if both are provided, only 'goal' is considered.
 			goal_features_map (assoc)
+			;{type "assoc" additional_indices "string"}
+			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
+			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
+			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
+			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access feature
+			;values of the current time step as well as previously generated timesteps.
+			custom_feature_post_process_map (null)
 			;{type "list" values "string"}
 			;list of features that will preserve their values from the case specified by case_indices, appending and
 			;	overwriting the specified context and context features as necessary.  For generative reacts, if case_indices isn't specified,
@@ -465,14 +471,6 @@
 			;{type "boolean"}
 			;flag, if set to true assumes provided categorical (nominal or ordinal) feature values already been substituted.
 			input_is_substituted (false)
-
-			;{type "assoc" additional_indices "string"}
-			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
-			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
-			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
-			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access feature
-			;values of the current time step as well as previously generated timesteps.
-			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -129,6 +129,9 @@
 			;	'always' : only output original cases, outputs null for all feature values if unable to generate a new case
 			;	'attempt' : output any generated case only if generation fails all initial attempts to output original cases
 			generate_new_cases "no"
+
+			;{type "assoc" additional_indices "string"}
+			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
@@ -457,6 +460,9 @@
 			;{type "boolean"}
 			;flag, if set to true assumes provided categorical (nominal or ordinal) feature values already been substituted.
 			input_is_substituted (false)
+
+			;{type "assoc" additional_indices "string"}
+			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -131,6 +131,10 @@
 			generate_new_cases "no"
 
 			;{type "assoc" additional_indices "string"}
+			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
+			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
+			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
+			;context in the generation or derivation of other feature values within a single timestep.
 			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
@@ -462,6 +466,10 @@
 			input_is_substituted (false)
 
 			;{type "assoc" additional_indices "string"}
+			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
+			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
+			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
+			;context in the generation or derivation of other feature values within a single timestep.
 			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -106,7 +106,7 @@
 			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
 			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access feature
 			;values of the current time step as well as previously generated timesteps.
-			custom_feature_post_process_map (null)
+			feature_post_process_code_map (null)
 			;{type "list" values "string"}
 			;list of features that will preserve their values from the case specified by case_indices, appending and
 			;	overwriting the specified context and context features as necessary.  For generative reacts, if case_indices isn't specified,
@@ -447,7 +447,7 @@
 			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
 			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access feature
 			;values of the current time step as well as previously generated timesteps.
-			custom_feature_post_process_map (null)
+			feature_post_process_code_map (null)
 			;{type "list" values "string"}
 			;list of features that will preserve their values from the case specified by case_indices, appending and
 			;	overwriting the specified context and context features as necessary.  For generative reacts, if case_indices isn't specified,

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -134,7 +134,8 @@
 			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
 			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
 			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
-			;context in the generation or derivation of other feature values within a single timestep.
+			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access feature
+			;values of the current time step as well as previously generated timesteps.
 			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)
@@ -469,7 +470,8 @@
 			;A mapping of feature name to custom code strings that will be evaluated to update the value of the feature they are mapped from.
 			;In the time-series synthesis, these custom codes are executed just after the original feature value is derived or synthed, but before
 			;any other features would be derived or generated from the value. This means that the result of this custom code may be used as the
-			;context in the generation or derivation of other feature values within a single timestep.
+			;context in the generation or derivation of other feature values within a single timestep. Custom code will be able to access feature
+			;values of the current time step as well as previously generated timesteps.
 			custom_feature_post_process_map (null)
 		)
 		(call !ValidateParameters)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1482,7 +1482,7 @@
 		;overwrite the values for the action features in the current case map now that they have values
 		(accum (assoc current_case_map (zip action_features (get react_output "action_values")) ))
 
-		(if (size (keep custom_feature_post_process_map action_features))
+		(if (size (keep feature_post_process_code_map action_features))
 			;if any of the action features have a custom post_process, update their values using them
 			(accum (assoc
 				current_case_map
@@ -1503,7 +1503,7 @@
 								) (* (size series_data) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
 							)
 						)
-						(keep custom_feature_post_process_map action_features)
+						(keep feature_post_process_code_map action_features)
 					)
 			))
 		)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1482,6 +1482,32 @@
 		;overwrite the values for the action features in the current case map now that they have values
 		(accum (assoc current_case_map (zip action_features (get react_output "action_values")) ))
 
+		(if (size (keep custom_feature_post_process_map action_features))
+			;if any of the action features have a custom post_process, update their values using them
+			(accum (assoc
+				current_case_map
+					(map
+						(lambda
+							(get_value
+								(call_sandboxed (current_value) (assoc
+									series_data
+										;need to use series_data with the updated feature value
+										(append
+											(trunc series_data)
+											[(unzip current_case_map features)]
+										)
+									series_row_index last_series_index
+									feature_index_map feature_index_map
+									!featureDateTimeMap !featureDateTimeMap
+									!ConvertDateToEpoch !ConvertDateToEpoch
+								) (* (size series_data) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
+							)
+						)
+						(keep custom_feature_post_process_map action_features)
+					)
+			))
+		)
+
 		;overwrite the last row in series data with the values from the updated current case
 		(assign (assoc
 			series_data

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -251,6 +251,18 @@
 							(call !GenerateAllowedOrdinalFeatureValue)
 						)
 
+						(if (contains_index custom_feature_post_process_map feature)
+							;if custom post process is defined, update feature value with it
+							(assign (assoc
+								new_feature_value
+									(get_value
+										(call_sandboxed (get custom_feature_post_process_map feature) (assoc
+											case (append (zip context_features context_values) (associate feature new_feature_value) )
+										) !sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
+									)
+							))
+						)
+
 						;if feature bounds are specified, ensure generated values are within the bounds by regenerating the value up to 5 times
 						;only applies to non-nominal features since those have their bounds enforced inside the GenerateFeatureValue method since
 						;nominals are generated from a list that may be predetermined, and thus are guaranteed to be within the bounds specified

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -251,12 +251,12 @@
 							(call !GenerateAllowedOrdinalFeatureValue)
 						)
 
-						(if (contains_index custom_feature_post_process_map feature)
+						(if (contains_index feature_post_process_code_map feature)
 							;if custom post process is defined, update feature value with it
 							(assign (assoc
 								new_feature_value
 									(get_value
-										(call_sandboxed (get custom_feature_post_process_map feature) (assoc
+										(call_sandboxed (get feature_post_process_code_map feature) (assoc
 											case (append (zip context_features context_values) (associate feature new_feature_value) )
 										) !sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false))
 									)


### PR DESCRIPTION
Adds new parameter, "feature_post_process_code_map" to all react* endpoints. This parameter takes a mapping feature name to custom code string that is used to derive an updated feature value based on whatever code is defined. At the time of execution, the code will have access to all context features and previously generated action features (including the feature itself).