### PR TITLE
23054: Improves early exploration for RL flows

### DIFF
--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -313,6 +313,8 @@
 						(indices global_class_probabilities_map)
 						(/ 1 (size global_class_probabilities_map))
 					)
+				;cap max desired_conviction at 1 to increase chance of using these domain probabilities
+				desired_conviction (if (> desired_conviction 1) 1 desired_conviction)
 			))
 		)
 


### PR DESCRIPTION
This change increases the chance of using nominal feature domain probabilities instead of global ones for extremely small datasets (ie, at the start of RL flows) 