### PR TITLE
22983: Adds support for goal features to `#react_aggregate`, MINOR

### DIFF
--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -21,6 +21,7 @@
 	; run_on_local_model: optional, if true will use all the provided cases and not store results to model
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; derive_action_feature: flag, if true action feature will be derived and the features needed to derive will be predicted
+	; goal_features_map: assoc of goal feature stuff, to be passed directly into DiscriminativeReact
 	#!CalculateFeaturePredictionContributions
 	(declare
 		(assoc
@@ -36,6 +37,7 @@
 			run_on_local_model (false)
 			context_condition_filter_query (list)
 			derive_action_feature (false)
+			goal_features_map (assoc)
 		)
 
 		(declare (assoc
@@ -679,6 +681,7 @@
 			details (assoc "categorical_action_probabilities" action_is_nominal)
 			hyperparam_map hyperparam_map
 			filtering_queries context_condition_filter_query
+			goal_features_map goal_features_map
 		))
 
 		;need to react to predict the non context features needed for derivation, then derive
@@ -699,6 +702,7 @@
 								details (assoc "categorical_action_probabilities" action_is_nominal)
 								hyperparam_map hyperparam_map
 								filtering_queries context_condition_filter_query
+								goal_features_map goal_features_map
 							))
 							"action_values"
 						)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -21,7 +21,14 @@
 	; run_on_local_model: optional, if true will use all the provided cases and not store results to model
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; derive_action_feature: flag, if true action feature will be derived and the features needed to derive will be predicted
-	; goal_features_map: assoc of goal feature stuff, to be passed directly into DiscriminativeReact
+	; goal_features_map: optional assoc of:
+	;				{ feature : { "goal" : "min"/"max", "value" : value }}
+	;				defining goal features, forces reevaluation of local data in reacts to pull the predicted action values toward
+	;				achieving the specified value or goal as defined by this map. Valid keys in the map are:
+	;				"goal": "min" or "max", will make a prediction while minimizing or maximizing the value for the feature or
+	;				"value" : value, will make a prediction while approaching the specified value
+	;			note: nominal features only support 'value', 'goal' is ignored.
+	;		  		  for non-nominals, if both are provided, only 'goal' is considered.
 	#!CalculateFeaturePredictionContributions
 	(declare
 		(assoc

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -285,6 +285,7 @@
 			null_accuracies_map (assoc)
 			;list of unique features to populate output at the end
 			unique_features_for_populating_output (null)
+			goal_features (null)
 
 			;store an assoc of lag/rate/delta feature -> lag/order amount for time series flows
 			ts_feature_lag_amount_map (null)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -218,6 +218,7 @@
 	; expand_confusion_matrices: flag, optional, default true. When use_shared_deviations is true, if there are confusion matrices for shared features, they will be copied over
 	;		for all non-primary shared features. When false, confusion matrices will not be copied and remain only for the primary features.
 	; features_to_derive: a list of features whose values should be derived rather than interpolated
+	; goal_features_map: assoc of goal feature stuff, to be passed directly into DiscriminativeReact
 	#!CalculateFeatureResiduals
 	(declare
 		(assoc

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -218,7 +218,14 @@
 	; expand_confusion_matrices: flag, optional, default true. When use_shared_deviations is true, if there are confusion matrices for shared features, they will be copied over
 	;		for all non-primary shared features. When false, confusion matrices will not be copied and remain only for the primary features.
 	; features_to_derive: a list of features whose values should be derived rather than interpolated
-	; goal_features_map: assoc of goal feature stuff, to be passed directly into DiscriminativeReact
+	; goal_features_map: optional assoc of:
+	;				{ feature : { "goal" : "min"/"max", "value" : value }}
+	;				defining goal features, forces reevaluation of local data in reacts to pull the predicted action values toward
+	;				achieving the specified value or goal as defined by this map. Valid keys in the map are:
+	;				"goal": "min" or "max", will make a prediction while minimizing or maximizing the value for the feature or
+	;				"value" : value, will make a prediction while approaching the specified value
+	;			note: nominal features only support 'value', 'goal' is ignored.
+	;		  		  for non-nominals, if both are provided, only 'goal' is considered.
 	#!CalculateFeatureResiduals
 	(declare
 		(assoc

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -22,7 +22,14 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; features_to_derive: list of features whose values should be derived rather than interpolated
-	; goal_features_map: assoc of goal feature stuff, to be passed directly into DiscriminativeReact
+	; goal_features_map: optional assoc of:
+	;				{ feature : { "goal" : "min"/"max", "value" : value }}
+	;				defining goal features, forces reevaluation of local data in reacts to pull the predicted action values toward
+	;				achieving the specified value or goal as defined by this map. Valid keys in the map are:
+	;				"goal": "min" or "max", will make a prediction while minimizing or maximizing the value for the feature or
+	;				"value" : value, will make a prediction while approaching the specified value
+	;			note: nominal features only support 'value', 'goal' is ignored.
+	;		  		  for non-nominals, if both are provided, only 'goal' is considered.
 	#!CalculateFeatureAccuracyContributions
 	(declare
 		(assoc
@@ -187,7 +194,14 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; features_to_derive: list of features whose values should be derived rather than interpolated
-	; goal_features_map: assoc of goal feature stuff, to be passed directly into DiscriminativeReact
+	; goal_features_map: optional assoc of:
+	;				{ feature : { "goal" : "min"/"max", "value" : value }}
+	;				defining goal features, forces reevaluation of local data in reacts to pull the predicted action values toward
+	;				achieving the specified value or goal as defined by this map. Valid keys in the map are:
+	;				"goal": "min" or "max", will make a prediction while minimizing or maximizing the value for the feature or
+	;				"value" : value, will make a prediction while approaching the specified value
+	;			note: nominal features only support 'value', 'goal' is ignored.
+	;		  		  for non-nominals, if both are provided, only 'goal' is considered.
 	#!CalculateModelMAE
 	(declare
 		(assoc

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -22,6 +22,7 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; features_to_derive: list of features whose values should be derived rather than interpolated
+	; goal_features_map: assoc of goal feature stuff, to be passed directly into DiscriminativeReact
 	#!CalculateFeatureAccuracyContributions
 	(declare
 		(assoc
@@ -38,6 +39,7 @@
 			hyperparam_map (null)
 			context_condition_filter_query (list)
 			features_to_derive []
+			goal_features_map (assoc)
 		)
 
 		(if (= (null) hyperparam_map)
@@ -92,6 +94,7 @@
 					weight_feature weight_feature
 					context_condition_filter_query context_condition_filter_query
 					features_to_derive features_to_derive
+					goal_features_map goal_features_map
 				))
 		))
 
@@ -126,6 +129,7 @@
 									weight_feature weight_feature
 									context_condition_filter_query context_condition_filter_query
 									features_to_derive features_to_derive
+									goal_features_map goal_features_map
 
 									;the scramble feature index will be null if doing feature knockout
 									scramble_feature_index
@@ -183,6 +187,7 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; features_to_derive: list of features whose values should be derived rather than interpolated
+	; goal_features_map: assoc of goal feature stuff, to be passed directly into DiscriminativeReact
 	#!CalculateModelMAE
 	(declare
 		(assoc
@@ -203,6 +208,7 @@
 			weight_feature ".case_weight"
 			context_condition_filter_query (list)
 			features_to_derive (list)
+			goal_features_map (assoc)
 		)
 
 		(if (size features_to_derive)
@@ -693,6 +699,7 @@
 			;disable usage of dependent features for resdiual computation to prevent recursive behaviour in reacts
 			has_dependent_features (false)
 			filtering_queries context_condition_filter_query
+			goal_features_map goal_features_map
 		))
 
 		;otherwise need to derive the value for each action_feature, and return a react-like format
@@ -739,6 +746,7 @@
 															;disable usage of dependent features for resdiual computation to prevent recursive behaviour in reacts
 															has_dependent_features (false)
 															filtering_queries context_condition_filter_query
+															goal_features_map goal_features_map
 														))
 														"action_values"
 													)
@@ -786,6 +794,7 @@
 										;disable usage of dependent features for resdiual computation to prevent recursive behaviour in reacts
 										has_dependent_features (false)
 										filtering_queries context_condition_filter_query
+										goal_features_map goal_features_map
 									))
 								)
 							)

--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -27,6 +27,8 @@
 			series_id_features (if !tsTimeFeature (get !tsModelFeaturesMap "series_id_features") )
 			;this variable is used in the derivation logic branch of InterpolateAndComputeDiff
 			react_context_features context_features
+			feature_weights (get hyperparam_map "featureWeights")
+			feature_deviations (get hyperparam_map "featureDeviations")
 		))
 
 		;if all 'features' are also context features, then we can do one query per case,
@@ -91,10 +93,10 @@
 												k_parameter
 												context_features
 												(unzip case_values_map context_features)
-												(get hyperparam_map "featureWeights")
+												feature_weights
 												!queryDistanceTypeMap
 												query_feature_attributes_map
-												(get hyperparam_map "featureDeviations")
+												feature_deviations
 												p_parameter
 												dt_parameter
 												(if valid_weight_feature weight_feature (null))
@@ -165,10 +167,10 @@
 																	k_parameter
 																	query_context_features
 																	(unzip case_values_map query_context_features)
-																	(get hyperparam_map "featureWeights")
+																	feature_weights
 																	!queryDistanceTypeMap
 																	query_feature_attributes_map
-																	(get hyperparam_map "featureDeviations")
+																	feature_deviations
 																	p_parameter
 																	dt_parameter
 																	(if valid_weight_feature weight_feature (null))
@@ -305,7 +307,7 @@
 		)
 	)
 
-	#!UseGoalFeaturesRobustResiduals
+	#!UseGoalFeaturesDeviations
 	(let
 		(assoc
 			;set feature weight of goal features, zero out all other weights
@@ -325,8 +327,8 @@
 					(query_in_entity_list (indices local_cases_map))
 					(query_nearest_generalized_distance
 						(replace k_parameter)
-						(replace react_context_features)
-						(replace (unzip case_values_map react_context_features))
+						(replace goal_context_features)
+						(replace goal_context_values)
 						(replace feature_weights)
 						(replace !queryDistanceTypeMap)
 						(replace query_feature_attributes_map)

--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -74,35 +74,38 @@
 						;see comment where 'single_query_per_case' is defined above.
 						;all features are also context features, so only the one query is needed.
 						(if single_query_per_case
-							(assign (assoc
-								local_cases_map
-									(compute_on_contained_entities (append
-										(if focal_case
-											(query_not_in_entity_list (list case_id focal_case))
-											(query_not_in_entity_list (list case_id))
-										)
-										time_series_filter_query
-										(if (size context_condition_filter_query)
-											context_condition_filter_query
-											(list)
-										)
-										(query_nearest_generalized_distance
-											k_parameter
-											context_features
-											(unzip case_values_map context_features)
-											(get hyperparam_map "featureWeights")
-											!queryDistanceTypeMap
-											query_feature_attributes_map
-											(get hyperparam_map "featureDeviations")
-											p_parameter
-											dt_parameter
-											(if valid_weight_feature weight_feature (null))
-											tie_break_random_seed
-											(null) ;radius
-											!numericalPrecision
-										)
-									))
-							))
+							(seq
+								(assign (assoc
+									local_cases_map
+										(compute_on_contained_entities (append
+											(if focal_case
+												(query_not_in_entity_list (list case_id focal_case))
+												(query_not_in_entity_list (list case_id))
+											)
+											time_series_filter_query
+											(if (size context_condition_filter_query)
+												context_condition_filter_query
+												(list)
+											)
+											(query_nearest_generalized_distance
+												k_parameter
+												context_features
+												(unzip case_values_map context_features)
+												(get hyperparam_map "featureWeights")
+												!queryDistanceTypeMap
+												query_feature_attributes_map
+												(get hyperparam_map "featureDeviations")
+												p_parameter
+												dt_parameter
+												(if valid_weight_feature weight_feature (null))
+												tie_break_random_seed
+												(null) ;radius
+												!numericalPrecision
+											)
+										))
+								))
+								(if goal_features (call !UseGoalFeaturesDeviations (assoc context_features context_features)) )
+							)
 						)
 
 						;create a map of feature -> residual value for each feature
@@ -123,58 +126,61 @@
 										;see comment where 'single_query_per_case' is defined above.
 										;there must be one query for each action feature where it alone is added to the contexts.
 										(if (not single_query_per_case)
-											(assign (assoc
-												local_cases_map
-													(let
-														(assoc
-															query_context_features
-																;context features + feature being predicted
-																(values (append
-																	(if (contains_index features_for_derivation_map feature)
-																		;if this feature should be derived, need to hold out the features that will be used to derive it
-																		(filter
-																			(lambda (or
-																				(not (contains_value (get features_for_derivation_map feature) (current_value)))
-																				(!= feature (get !derivedFeaturesMap (current_value)))
-																				(contains_value (get !tsModelFeaturesMap "lag_features") (current_value))
-																			))
+											(seq
+												(assign (assoc
+													local_cases_map
+														(let
+															(assoc
+																query_context_features
+																	;context features + feature being predicted
+																	(values (append
+																		(if (contains_index features_for_derivation_map feature)
+																			;if this feature should be derived, need to hold out the features that will be used to derive it
+																			(filter
+																				(lambda (or
+																					(not (contains_value (get features_for_derivation_map feature) (current_value)))
+																					(!= feature (get !derivedFeaturesMap (current_value)))
+																					(contains_value (get !tsModelFeaturesMap "lag_features") (current_value))
+																				))
+																				context_features
+																			)
+
 																			context_features
 																		)
+																		feature
+																	) (true))
+															)
 
-																		context_features
-																	)
-																	feature
-																) (true))
+															(compute_on_contained_entities (append
+																(if focal_case
+																	(query_not_in_entity_list (list case_id focal_case))
+																	(query_not_in_entity_list (list case_id))
+																)
+																time_series_filter_query
+																(if (size context_condition_filter_query)
+																	context_condition_filter_query
+																	(list)
+																)
+																(query_nearest_generalized_distance
+																	k_parameter
+																	query_context_features
+																	(unzip case_values_map query_context_features)
+																	(get hyperparam_map "featureWeights")
+																	!queryDistanceTypeMap
+																	query_feature_attributes_map
+																	(get hyperparam_map "featureDeviations")
+																	p_parameter
+																	dt_parameter
+																	(if valid_weight_feature weight_feature (null))
+																	tie_break_random_seed
+																	(null) ;radius
+																	!numericalPrecision
+																)
+															))
 														)
-
-														(compute_on_contained_entities (append
-															(if focal_case
-																(query_not_in_entity_list (list case_id focal_case))
-																(query_not_in_entity_list (list case_id))
-															)
-															time_series_filter_query
-															(if (size context_condition_filter_query)
-																context_condition_filter_query
-																(list)
-															)
-															(query_nearest_generalized_distance
-																k_parameter
-																query_context_features
-																(unzip case_values_map query_context_features)
-																(get hyperparam_map "featureWeights")
-																!queryDistanceTypeMap
-																query_feature_attributes_map
-																(get hyperparam_map "featureDeviations")
-																p_parameter
-																dt_parameter
-																(if valid_weight_feature weight_feature (null))
-																tie_break_random_seed
-																(null) ;radius
-																!numericalPrecision
-															)
-														))
-													)
-											))
+												))
+												(if goal_features (call !UseGoalFeaturesDeviations (assoc context_features query_context_features)) )
+											)
 										)
 
 										;create the feature-specific candidate_cases_lists tuple for intepolation
@@ -299,6 +305,42 @@
 		)
 	)
 
+	#!UseGoalFeaturesRobustResiduals
+	(let
+		(assoc
+			;set feature weight of goal features, zero out all other weights
+			feature_weights (call !FeatureWeightsWithGoals (assoc context_features context_features))
+			goal_context_features (append context_features goal_features)
+			goal_context_values
+				(append
+					(unzip case_values_map context_features)
+					(call !GoalFeatureValues (assoc case_ids (indices local_cases_map)))
+				)
+		)
+
+		;update local_cases_map with influences based on the updated weights/context_values
+		(assign (assoc
+			local_cases_map
+				(compute_on_contained_entities (append
+					(query_in_entity_list (indices local_cases_map))
+					(query_nearest_generalized_distance
+						(replace k_parameter)
+						(replace react_context_features)
+						(replace (unzip case_values_map react_context_features))
+						(replace feature_weights)
+						(replace !queryDistanceTypeMap)
+						(replace query_feature_attributes_map)
+						(replace feature_deviations)
+						(replace p_parameter)
+						(replace dt_parameter)
+						(if valid_weight_feature (replace weight_feature) (null))
+						(replace tie_break_random_seed)
+						(null) ;radius
+						(replace !numericalPrecision)
+					)
+				))
+		))
+	)
 
 	#!ComputeRobustTargetlessMDA
 	(declare

--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -106,7 +106,40 @@
 											)
 										))
 								))
-								(if goal_features (call !UseGoalFeaturesDeviations (assoc context_features context_features)) )
+								(if goal_features
+									(assign (assoc
+										local_cases_map
+											(call !UpdateLocalInfluencesForGoals (assoc
+												feature_weights feature_weights
+												context_features context_features
+												context_values (unzip case_values_map context_features)
+												dt_parameter dt_parameter
+												case_ids (indices local_cases_map)
+												query_code
+													(lambda
+														#!LocalCasesMapQuery
+														(compute_on_contained_entities (list
+															custom_extra_filtering_queries
+															(query_nearest_generalized_distance
+																(replace k_parameter)
+																(replace context_features)
+																(replace context_values)
+																(replace feature_weights)
+																(replace !queryDistanceTypeMap)
+																query_feature_attributes_map
+																(replace feature_deviations)
+																(replace p_parameter)
+																(replace dt_parameter)
+																(if valid_weight_feature (replace weight_feature) (null))
+																(replace tie_break_random_seed)
+																(null) ;radius
+																(replace !numericalPrecision)
+															)
+														))
+													)
+											))
+									))
+								)
 							)
 						)
 
@@ -181,7 +214,19 @@
 															))
 														)
 												))
-												(if goal_features (call !UseGoalFeaturesDeviations (assoc context_features query_context_features)) )
+												(if goal_features
+													(assign (assoc
+														local_cases_map
+															(call !UpdateLocalInfluencesForGoals (assoc
+																feature_weights feature_weights
+																context_features query_context_features
+																context_values (unzip case_values_map query_context_features)
+																dt_parameter dt_parameter
+																case_ids (indices local_cases_map)
+																query_code (retrieve_from_entity "!LocalCasesMapQuery")
+															))
+													))
+												)
 											)
 										)
 
@@ -305,43 +350,6 @@
 				)
 			)
 		)
-	)
-
-	#!UseGoalFeaturesDeviations
-	(let
-		(assoc
-			;set feature weight of goal features, zero out all other weights
-			feature_weights (call !FeatureWeightsWithGoals (assoc context_features context_features))
-			goal_context_features (append context_features goal_features)
-			goal_context_values
-				(append
-					(unzip case_values_map context_features)
-					(call !GoalFeatureValues (assoc case_ids (indices local_cases_map)))
-				)
-		)
-
-		;update local_cases_map with influences based on the updated weights/context_values
-		(assign (assoc
-			local_cases_map
-				(compute_on_contained_entities (append
-					(query_in_entity_list (indices local_cases_map))
-					(query_nearest_generalized_distance
-						(replace k_parameter)
-						(replace goal_context_features)
-						(replace goal_context_values)
-						(replace feature_weights)
-						(replace !queryDistanceTypeMap)
-						(replace query_feature_attributes_map)
-						(replace feature_deviations)
-						(replace p_parameter)
-						(replace dt_parameter)
-						(if valid_weight_feature (replace weight_feature) (null))
-						(replace tie_break_random_seed)
-						(null) ;radius
-						(replace !numericalPrecision)
-					)
-				))
-		))
 	)
 
 	#!ComputeRobustTargetlessMDA

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1414,6 +1414,7 @@
 				context_values context_values
 				custom_extra_filtering_queries custom_extra_filtering_queries
 				dt_parameter (get hyperparam_map "dt")
+				case_ids (first local_model_cases_tuple)
 				query_label "!ReactionQuery"
 			))
 		)

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1408,14 +1408,17 @@
 		))
 
 		(if goal_features
-			(call !UpdateLocalInfluencesForGoals (assoc
-				feature_weights feature_weights
-				context_features context_features
-				context_values context_values
-				custom_extra_filtering_queries custom_extra_filtering_queries
-				dt_parameter (get hyperparam_map "dt")
-				case_ids (first local_model_cases_tuple)
-				query_label "!ReactionQuery"
+			(assign (assoc
+				local_model_cases_tuple
+					(call !UpdateLocalInfluencesForGoals (assoc
+						feature_weights feature_weights
+						context_features context_features
+						context_values context_values
+						custom_extra_filtering_queries custom_extra_filtering_queries
+						dt_parameter (get hyperparam_map "dt")
+						case_ids (first local_model_cases_tuple)
+						query_code (retrieve_from_entity "!ReactionQuery")
+					))
 			))
 		)
 

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -147,6 +147,19 @@
 			;			If null, will be set to k. default is null
 			;	)
 			details (null)
+			;{type "assoc" additional_indices {ref "GoalFeatures"}}
+			; assoc of :
+			;		{ feature : { "goal" : "min"/"max", "value" : value }}
+			;		A mapping of feature name to the goals for the feature, which will cause the react to achieve the goals as appropriate
+			;		for the context.  This is useful for conditioning responses when it is challenging or impossible to know appropriate
+			;		values ahead of time, such as maximizing the reward or minimizing cost for reinforcement learning, or conditioning a
+			;		forecast based on attempting to achieve some value.  Goal features will reevaluate the inference for the given context
+			;		optimizing for the specified goals. Valid keys in the map are:
+			;		"goal": "min" or "max", will make a prediction while minimizing or maximizing the value for the feature or
+			;		"value" : value, will make a prediction while approaching the specified value
+			;	note: nominal features only support 'value', 'goal' is ignored.
+			;		  for non-nominals, if both are provided, only 'goal' is considered.
+			goal_features_map (assoc)
 		)
 
 		(call !ValidateParameters)
@@ -625,6 +638,7 @@
 										hyperparam_map custom_hyperparam_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
+										goal_features_map goal_features_map
 									))
 							)
 					))
@@ -646,6 +660,7 @@
 										hyperparam_map custom_hyperparam_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
+										goal_features_map goal_features_map
 									))
 							)
 					))
@@ -667,6 +682,7 @@
 										hyperparam_map custom_hyperparam_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
+										goal_features_map goal_features_map
 									))
 							)
 					))
@@ -688,6 +704,7 @@
 										hyperparam_map custom_hyperparam_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
+										goal_features_map goal_features_map
 									))
 							)
 					))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -447,6 +447,7 @@
 							case_ids case_ids
 							strict_case_ids (!= 0 (size action_condition_filter_query))
 							features_to_derive features_to_derive
+							goal_features_map goal_features_map
 						))
 					selected_prediction_stats
 						(call !ProcessSelectedPredictionStats (assoc selected_prediction_stats (or (get details "selected_prediction_stats") [])))
@@ -495,6 +496,7 @@
 									context_condition_filter_query context_condition_filter_query
 									strict_case_ids (!= 0 (size action_condition_filter_query))
 									features_to_derive features_to_derive
+									goal_features_map goal_features_map
 								))
 								"residual_map"
 							)
@@ -524,6 +526,7 @@
 										context_condition_filter_query context_condition_filter_query
 										strict_case_ids (!= 0 (size action_condition_filter_query))
 										features_to_derive features_to_derive
+										goal_features_map goal_features_map
 									))
 									"residual_map"
 								)
@@ -553,6 +556,7 @@
 										valid_weight_feature valid_weight_feature
 										strict_case_ids (!= 0 (size action_condition_filter_query))
 										features_to_derive features_to_derive
+										goal_features_map goal_features_map
 									))
 									"residual_map"
 								)
@@ -585,6 +589,7 @@
 								context_condition_filter_query context_condition_filter_query
 								num_samples num_samples
 								derive_action_feature (contains_value features_to_derive feature_influences_action_feature)
+								goal_features_map goal_features_map
 							))
 					))
 				)
@@ -603,6 +608,7 @@
 								num_robust_influence_samples_per_case num_robust_influence_samples_per_case
 								context_condition_filter_query context_condition_filter_query
 								derive_action_feature (contains_value features_to_derive feature_influences_action_feature)
+								goal_features_map goal_features_map
 							))
 					))
 				)

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -896,6 +896,7 @@
 		(assign (assoc
 			;set feature weight of goal features, zero out all other weights
 			feature_weights
+				#!FeatureWeightsWithGoals
 				(map
 					(lambda
 						(if (contains_index goal_features_map (current_index))
@@ -931,6 +932,7 @@
 			context_values
 				(append
 					context_values
+					#!GoalFeatureValues
 					(map
 						(lambda (let
 							(assoc
@@ -942,7 +944,7 @@
 								(get
 									(first
 										(compute_on_contained_entities [
-											(query_in_entity_list (first local_model_cases_tuple))
+											(query_in_entity_list case_ids)
 											(query_max goal_feature 1)
 											(query_exists goal_feature)
 										])
@@ -954,7 +956,7 @@
 								(get
 									(first
 										(compute_on_contained_entities [
-											(query_in_entity_list (first local_model_cases_tuple))
+											(query_in_entity_list case_ids)
 											(query_min goal_feature 1)
 											(query_exists goal_feature)
 										])
@@ -969,7 +971,7 @@
 										local_goal_values
 											(map
 												(lambda (retrieve_from_entity (current_value) goal_feature))
-												(first local_model_cases_tuple)
+												case_ids
 											)
 									)
 									(declare (assoc local_max (apply "max" local_goal_values) ))
@@ -992,8 +994,8 @@
 			;limit the secondary goal-oriented query to only run on cases in this local space
 			custom_extra_filtering_queries
 				(if custom_extra_filtering_queries
-					(append custom_extra_filtering_queries (query_in_entity_list (first local_model_cases_tuple)) )
-					(query_in_entity_list (first local_model_cases_tuple))
+					(append custom_extra_filtering_queries (query_in_entity_list case_ids) )
+					(query_in_entity_list case_ids)
 				)
 		))
 

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -891,12 +891,15 @@
 	)
 
 	;Helper method for reacts to update contexts with goal feature values from results of local_model_cases_tuple and rerun the query
+	;requires the following parameters to be passed or populated:
+	;context_features, context_values, feature_weights, dt_parameter, goal_features, goal_features_map, case_ids
+	;and query_code: which should be the code to return the desired query using the above variables
+	;(should use context_values and context_features + the hyperparameter variable names)
 	#!UpdateLocalInfluencesForGoals
-	(seq
-		(assign (assoc
+	(let
+		(assoc
 			;set feature weight of goal features, zero out all other weights
 			feature_weights
-				#!FeatureWeightsWithGoals
 				(map
 					(lambda
 						(if (contains_index goal_features_map (current_index))
@@ -932,7 +935,6 @@
 			context_values
 				(append
 					context_values
-					#!GoalFeatureValues
 					(map
 						(lambda (let
 							(assoc
@@ -992,14 +994,10 @@
 				)
 
 			;limit the secondary goal-oriented query to only run on cases in this local space
-			custom_extra_filtering_queries
-				(if custom_extra_filtering_queries
-					(append custom_extra_filtering_queries (query_in_entity_list case_ids) )
-					(query_in_entity_list case_ids)
-				)
-		))
+			custom_extra_filtering_queries (query_in_entity_list case_ids)
+		)
 
 		;call the react query again with the goal-oriented contexts and weights
-		(assign (assoc local_model_cases_tuple (call (retrieve_from_entity query_label)) ))
+		(call query_code)
 	)
 )

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -720,6 +720,19 @@
 								)
 						))
 
+						(if (and (size local_cases_map) goal_features)
+							(assign (assoc
+								local_cases_map
+									(call !UpdateLocalInfluencesForGoals (assoc
+										feature_weights feature_weights
+										context_features react_context_features
+										context_values (unzip case_values_map react_context_features)
+										dt_parameter dt_parameter
+										case_ids (indices local_cases_map)
+										query_code (retrieve_from_entity "!LocalCasesMapQuery")
+									))
+							))
+						)
 						(if goal_features (call !UseGoalFeaturesRobustResiduals))
 
 						;create a map of removed feature -> residual value for each removed feature
@@ -900,43 +913,6 @@
 		)
 	)
 
-	#!UseGoalFeaturesRobustResiduals
-	(let
-		(assoc
-			;set feature weight of goal features, zero out all other weights
-			feature_weights (call !FeatureWeightsWithGoals (assoc context_features react_context_features))
-			goal_context_features (append react_context_features goal_features)
-			goal_context_values
-				(append
-					(unzip case_values_map react_context_features)
-					(call !GoalFeatureValues (assoc case_ids (indices local_cases_map)))
-				)
-		)
-
-		;update local_cases_map with influences based on the updated weights/context_values
-		(assign (assoc
-			local_cases_map
-				(compute_on_contained_entities (append
-					(query_in_entity_list (indices local_cases_map))
-					(query_nearest_generalized_distance
-						(replace k_parameter)
-						(replace goal_context_features)
-						(replace goal_context_values)
-						(replace feature_weights)
-						(replace !queryDistanceTypeMap)
-						(replace query_feature_attributes_map)
-						(replace feature_deviations)
-						(replace p_parameter)
-						(replace dt_parameter)
-						(if valid_weight_feature (replace weight_feature) (null))
-						(replace tie_break_random_seed)
-						(null) ;radius
-						(replace !numericalPrecision)
-					)
-				))
-		))
-	)
-
 	;helper method for CalculateFeatureResiduals to calculate full residuals
 	#!RunFullResiduals
 	(seq
@@ -1079,7 +1055,41 @@
 										case_feature_value (get case_values_map feature)
 									))
 
-									(if goal_features (call !UseGoalFeaturesFullResiduals))
+									(if goal_features
+										(assign (assoc
+											candidate_cases_lists
+												(call !UpdateLocalInfluencesForGoals (assoc
+													feature_weights feature_weights
+													context_features react_context_features
+													context_values (unzip case_values_map react_context_features)
+													custom_extra_filtering_queries custom_extra_filtering_queries
+													dt_parameter dt_parameter
+													case_ids (first candidate_cases_lists)
+													query_code
+														(lambda
+															(compute_on_contained_entities (list
+																custom_extra_filtering_queries
+																(query_nearest_generalized_distance
+																	(replace k_parameter)
+																	(replace context_features)
+																	(replace context_values)
+																	(replace feature_weights)
+																	(replace !queryDistanceTypeMap)
+																	query_feature_attributes_map
+																	(replace feature_deviations)
+																	(replace p_parameter)
+																	(replace dt_parameter)
+																	(if valid_weight_feature (replace weight_feature) (null))
+																	(replace tie_break_random_seed)
+																	(null) ;radius
+																	(replace !numericalPrecision)
+																	(replace feature)
+																)
+															))
+														)
+												))
+										))
+									)
 
 									(call !InterpolateAndComputeDiffToCase)
 								))
@@ -1283,45 +1293,6 @@
 				)
 			)
 		)
-	)
-
-	#!UseGoalFeaturesFullResiduals
-	(let
-		(assoc
-			;set feature weight of goal features, zero out all other weights
-			feature_weights (call !FeatureWeightsWithGoals (assoc context_features react_context_features))
-			goal_context_features (append react_context_features goal_features)
-			goal_context_values
-				(append
-					(unzip case_values_map react_context_features)
-					(call !GoalFeatureValues (assoc case_ids (first candidate_cases_lists)))
-				)
-		)
-
-		;update candidate_cases_lists with influences based on the updated weights/context_values
-		(assign (assoc
-			candidate_cases_lists
-				(compute_on_contained_entities (append
-					;can drop other entity filtering queries as we have the case IDs we want from the previous query
-					(query_in_entity_list (first candidate_cases_lists))
-					(query_nearest_generalized_distance
-						(replace k_parameter)
-						(replace goal_context_features)
-						(replace goal_context_values)
-						(replace feature_weights)
-						(replace !queryDistanceTypeMap)
-						query_feature_attributes_map
-						(replace feature_deviations)
-						(replace p_parameter)
-						(replace dt_parameter)
-						(if valid_weight_feature (replace weight_feature) (null))
-						(replace tie_break_random_seed)
-						(null) ;radius
-						(replace !numericalPrecision)
-						(replace feature)
-					)
-				))
-		))
 	)
 
 	;output assoc of 1-based ranks for specified values. duplicates are averaged out

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -920,8 +920,8 @@
 					(query_in_entity_list (indices local_cases_map))
 					(query_nearest_generalized_distance
 						(replace k_parameter)
-						(replace react_context_features)
-						(replace (unzip case_values_map react_context_features))
+						(replace goal_context_features)
+						(replace goal_context_values)
 						(replace feature_weights)
 						(replace !queryDistanceTypeMap)
 						(replace query_feature_attributes_map)
@@ -1303,7 +1303,7 @@
 			candidate_cases_lists
 				(compute_on_contained_entities (append
 					;can drop other entity filtering queries as we have the case IDs we want from the previous query
-					(query_in_entity_list (first local_model_cases_tuple))
+					(query_in_entity_list (first candidate_cases_lists))
 					(query_nearest_generalized_distance
 						(replace k_parameter)
 						(replace goal_context_features)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -391,6 +391,10 @@
 			(assign (assoc context_features features))
 		)
 
+		(if (size goal_features_map)
+			(assign (assoc goal_features (indices goal_features_map)))
+		)
+
 		(if (size features_to_derive)
 			(assign (assoc
 				;map of features to features needed for derivation (empty list if derivation is not necessary)
@@ -716,6 +720,8 @@
 								)
 						))
 
+						(if goal_features (call !UseGoalFeaturesRobustResiduals))
+
 						;create a map of removed feature -> residual value for each removed feature
 						(assign (assoc
 							removed_features_map
@@ -894,6 +900,43 @@
 		)
 	)
 
+	#!UseGoalFeaturesRobustResiduals
+	(let
+		(assoc
+			;set feature weight of goal features, zero out all other weights
+			feature_weights (call !FeatureWeightsWithGoals (assoc context_features react_context_features))
+			goal_context_features (append react_context_features goal_features)
+			goal_context_values
+				(append
+					(unzip case_values_map react_context_features)
+					(call !GoalFeatureValues (assoc case_ids (indices local_cases_map)))
+				)
+		)
+
+		;update local_cases_map with influences based on the updated weights/context_values
+		(assign (assoc
+			local_cases_map
+				(compute_on_contained_entities (append
+					(query_in_entity_list (indices local_cases_map))
+					(query_nearest_generalized_distance
+						(replace k_parameter)
+						(replace react_context_features)
+						(replace (unzip case_values_map react_context_features))
+						(replace feature_weights)
+						(replace !queryDistanceTypeMap)
+						(replace query_feature_attributes_map)
+						(replace feature_deviations)
+						(replace p_parameter)
+						(replace dt_parameter)
+						(if valid_weight_feature (replace weight_feature) (null))
+						(replace tie_break_random_seed)
+						(null) ;radius
+						(replace !numericalPrecision)
+					)
+				))
+		))
+	)
+
 	;helper method for CalculateFeatureResiduals to calculate full residuals
 	#!RunFullResiduals
 	(seq
@@ -1035,6 +1078,8 @@
 											))
 										case_feature_value (get case_values_map feature)
 									))
+
+									(if goal_features (call !UseGoalFeaturesFullResiduals))
 
 									(call !InterpolateAndComputeDiffToCase)
 								))
@@ -1238,6 +1283,45 @@
 				)
 			)
 		)
+	)
+
+	#!UseGoalFeaturesFullResiduals
+	(let
+		(assoc
+			;set feature weight of goal features, zero out all other weights
+			feature_weights (call !FeatureWeightsWithGoals (assoc context_features react_context_features))
+			goal_context_features (append react_context_features goal_features)
+			goal_context_values
+				(append
+					(unzip case_values_map react_context_features)
+					(call !GoalFeatureValues (assoc case_ids (first candidate_cases_lists)))
+				)
+		)
+
+		;update candidate_cases_lists with influences based on the updated weights/context_values
+		(assign (assoc
+			candidate_cases_lists
+				(compute_on_contained_entities (append
+					;can drop other entity filtering queries as we have the case IDs we want from the previous query
+					(query_in_entity_list (first local_model_cases_tuple))
+					(query_nearest_generalized_distance
+						(replace k_parameter)
+						(replace goal_context_features)
+						(replace goal_context_values)
+						(replace feature_weights)
+						(replace !queryDistanceTypeMap)
+						query_feature_attributes_map
+						(replace feature_deviations)
+						(replace p_parameter)
+						(replace dt_parameter)
+						(if valid_weight_feature (replace weight_feature) (null))
+						(replace tie_break_random_seed)
+						(null) ;radius
+						(replace !numericalPrecision)
+						(replace feature)
+					)
+				))
+		))
 	)
 
 	;output assoc of 1-based ranks for specified values. duplicates are averaged out

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -651,14 +651,17 @@
 		))
 
 		(if goal_features
-			(call !UpdateLocalInfluencesForGoals (assoc
-				feature_weights feature_weights
-				context_features context_features
-				context_values context_values
-				custom_extra_filtering_queries custom_extra_filtering_queries
-				dt_parameter (get hyperparam_map "dt")
-				case_ids (first local_model_cases_tuple)
-				query_label "!NearestRegionalCasesQuery"
+			(assign (assoc
+				local_model_cases_tuple
+					(call !UpdateLocalInfluencesForGoals (assoc
+						feature_weights feature_weights
+						context_features context_features
+						context_values context_values
+						custom_extra_filtering_queries custom_extra_filtering_queries
+						dt_parameter (get hyperparam_map "dt")
+						case_ids (first local_model_cases_tuple)
+						query_code (retrieve_from_entity "!NearestRegionalCasesQuery")
+					))
 			))
 		)
 

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -657,6 +657,7 @@
 				context_values context_values
 				custom_extra_filtering_queries custom_extra_filtering_queries
 				dt_parameter (get hyperparam_map "dt")
+				case_ids (first local_model_cases_tuple)
 				query_label "!NearestRegionalCasesQuery"
 			))
 		)

--- a/unit_tests/ut_h_anomaly.amlg
+++ b/unit_tests/ut_h_anomaly.amlg
@@ -2,8 +2,6 @@
 	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_anomaly.amlg"))
 
-	(call_entity "howso" "create_trainee" (assoc trainee "model"))
-
 	(declare (assoc
 		model_data (load "unit_test_data/iris.csv")
 	))

--- a/unit_tests/ut_h_goal_features.amlg
+++ b/unit_tests/ut_h_goal_features.amlg
@@ -2,8 +2,6 @@
 	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_goal_features.amlg"))
 
-	(call_entity "howso" "create_trainee" (assoc trainee "model"))
-
 	(declare (assoc
 		model_data (load "unit_test_data/iris.csv")
 	))


### PR DESCRIPTION
Adds support for specfying goal features and their values to `#react_aggregate`, allowing users to evaluate the performance of their model when attempting to optimize or condition their predictions on certain feature values/maxima.

This all takes place through the "goal_features_map" which is added to `#react_aggregate` in these changes.
This parameter will be used for predictions for all react_aggregate details.