### PR TITLE
23145: Fixes an issue when computing distance ratios with very small datasets

### DIFF
--- a/howso/distances.amlg
+++ b/howso/distances.amlg
@@ -107,7 +107,7 @@
 						(if extra_equidistant_cases
 							(append (first local_model_cases_tuple) extra_equidistant_cases)
 
-							(if (= model_size k_parameter)
+							(if (<= model_size k_parameter)
 								(first local_model_cases_tuple)
 								(trunc (first local_model_cases_tuple))
 							)


### PR DESCRIPTION
One case would be removed from the local model even when it should not have been.