### PR TITLE
23191: Renames internal variables, attributes and methods to not use the term 'model'

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -80,9 +80,9 @@
 	#!editDistanceFeatureTypesMap (null)
 	#!stringNominalFeaturesSet (null)
 	#!userSpecifiedFeatureErrorsMap (null)
-	#!averageModelCaseEntropyAddition (null)
-	#!averageModelCaseEntropyRemoval (null)
-	#!averageModelCaseDistanceContribution (null)
+	#!averageCaseEntropyAddition (null)
+	#!averageCaseEntropyRemoval (null)
+	#!averageCaseDistanceContribution (null)
 	#!storedCaseConvictionsFeatureAddition (null)
 	#!storedConvictionsFeatureSet (null)
 	#!nominalClassProbabilitiesMap (null)
@@ -98,7 +98,7 @@
 	#!hyperparameterParamPaths (null)
 	#!defaultHyperparameters (null)
 	#!staleOrdinalValuesCount (null)
-	#!minAblatementModelSize (null)
+	#!minAblatementSize (null)
 	#!hasSubstituteFeatureValues (null)
 	#!substitutionValueMap (null)
 	#!unSubstituteValueMap (null)
@@ -142,7 +142,7 @@
 	#!tsTimeFeatureUniversal (null)
 	#!tsMinTimeInterval (null)
 	#!tsSeriesLimitLength (null)
-	#!tsModelFeaturesMap (null)
+	#!tsFeaturesMap (null)
 	#!tsSupportedDetails (null)
 	#!hasStringOrdinals (null)
 	#!ordinalStringToOrdinalMap (null)
@@ -173,7 +173,7 @@
 	#!cachedTotalMass (null)
 	#!queryDistanceTypeMap (null)
 	#!influenceWeightThreshold (null)
-	#!regionalModelMinSize (null)
+	#!regionalMinSize (null)
 	#!revision 0
 	#!synthesisRetriesPerConvictionLevel 3
 	#!sandboxedComputeLimit (null)
@@ -341,20 +341,20 @@
 			!influenceWeightThreshold .99
 
 			;default regional model size
-			!regionalModelMinSize 30
+			!regionalMinSize 30
 
 			;null defaults to "recompute_precise", other options are "fast" or "precise"
 			!numericalPrecision (null)
 
 			;the size of the model when to start ablatement
-			!minAblatementModelSize 100
+			!minAblatementSize 100
 
 			;the average case entropy for the whole model, used for calculating new case conviction. cleared any time the model is changed
-			!averageModelCaseEntropyAddition (null)
-			!averageModelCaseEntropyRemoval (null)
+			!averageCaseEntropyAddition (null)
+			!averageCaseEntropyRemoval (null)
 
 			;the average case distance contribution value for the whole model
-			!averageModelCaseDistanceContribution (null)
+			!averageCaseDistanceContribution (null)
 
 			;name of conviction features, value is set when stored convictions exist and are up-to-date. cleared any time the model is changed
 			!storedCaseConvictionsFeatureAddition (null)
@@ -544,7 +544,7 @@
 			!tsSeriesLimitLength 0
 
 			;time series model various feature names
-			!tsModelFeaturesMap
+			!tsFeaturesMap
 				(assoc
 					;list of all the lag features e.g., (list ".date_lag_1" ".valueA_lag_1" ".valueB_lag_1")
 					"lag_features" (list)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -552,7 +552,7 @@
 					(call !StoreResidualSubTrainee (assoc custom_hyperparam_map baseline_hyperparameter_map) )
 				)
 
-				(call !SetModelHyperParameters)
+				(call !SetHyperparameters)
 			))
 		)
 
@@ -561,7 +561,7 @@
 		(call !ComputeAndUseWeights)
 		(call !TestAccuracyAndKeepOrRevertHyperparameters)  ;w or w/o weights
 
-		(if (= (false) use_deviations) (conclude (call !SetModelHyperParameters)) )
+		(if (= (false) use_deviations) (conclude (call !SetHyperparameters)) )
 
 		(declare (assoc non_deviation_hp_map baseline_hyperparameter_map))
 
@@ -604,7 +604,7 @@
 			(call !StoreResidualSubTrainee (assoc custom_hyperparam_map baseline_hyperparameter_map) )
 		)
 
-		(call !SetModelHyperParameters)
+		(call !SetHyperparameters)
 	)
 
 	;helper method for Analyze that stores a subtrainee of case residuals for each feature
@@ -1216,7 +1216,7 @@
 	)
 
 	;output model Mean Absolute Error (MAE) for the provided baseline_hyperparameter_map
-	#!ComputeModelResidualForParameters
+	#!ComputeResidualForParameters
 	(seq
 		(if targetless (assign (assoc action_features context_features)))
 
@@ -1229,7 +1229,7 @@
 		))
 
 		(if (= k_folds 1)
-			(call !CalculateModelMAE (assoc
+			(call !CalculateMAE (assoc
 				action_features action_features
 				context_features context_features
 				case_ids sample_case_ids
@@ -1254,7 +1254,7 @@
 	#!ComputeAndAccumulateKFoldsMAE
 	(accum (assoc
 		accumulated_kfold_errors
-			(call !CalculateModelMAE (assoc
+			(call !CalculateMAE (assoc
 				action_features action_features
 				context_features context_features
 				case_ids validation_case_ids
@@ -1348,7 +1348,7 @@
 							;accumulate the accuracy distance for each set of parameters
 							(declare (assoc
 								accuracy_distance
-									(call !CalculateModelMAE (append
+									(call !CalculateMAE (append
 										;params used in both cases
 										(assoc
 											action_features action_features

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -170,16 +170,16 @@
 		;if user specified how many samples to use for analysis, randomly hold out the rest
 		(if (!= (null) analysis_sub_model_size)
 			(let
-				(assoc model_size (call !GetNumTrainingCases))
+				(assoc dataset_size (call !GetNumTrainingCases))
 
 				;analysis_sub_model_size must be at least 2 * number of k_folds otherwise there may be no cases in a fold
 				(if (< analysis_sub_model_size (* 2 k_folds))
 					(assign (assoc analysis_sub_model_size (* 2 k_folds)))
 				)
 
-				(if (> model_size analysis_sub_model_size)
+				(if (> dataset_size analysis_sub_model_size)
 					(assign (assoc
-						holdout_entity_name (call !HoldOutRandomCases (assoc num_samples (- model_size analysis_sub_model_size)))
+						holdout_entity_name (call !HoldOutRandomCases (assoc num_samples (- dataset_size analysis_sub_model_size)))
 					))
 				)
 			)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -1043,10 +1043,10 @@
 
 		;model definition has changed so clear out these cached value
 		(assign_to_entities (assoc
-			!averageModelCaseEntropyAddition (null)
-			!averageModelCaseEntropyRemoval (null)
+			!averageCaseEntropyAddition (null)
+			!averageCaseEntropyRemoval (null)
 			!storedCaseConvictionsFeatureAddition (null)
-			!averageModelCaseDistanceContribution (null)
+			!averageCaseDistanceContribution (null)
 		))
 
 		;returns whether or not the trainee has cyclic features

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -85,8 +85,8 @@
 										(and
 											(= (get !derivedFeaturesMap (current_value)) action_feature)
 											(or
-												(contains_value (get !tsModelFeaturesMap "rate_features") (current_value))
-												(contains_value (get !tsModelFeaturesMap "delta_features") (current_value))
+												(contains_value (get !tsFeaturesMap "rate_features") (current_value))
+												(contains_value (get !tsFeaturesMap "delta_features") (current_value))
 											)
 										)
 									)

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -105,7 +105,7 @@
 					context_features features
 					weight_feature weight_feature
 				))
-			model_size (call !GetNumTrainingCases)
+			dataset_size (call !GetNumTrainingCases)
 		))
 
 		(call !UpdateCaseWeightParameters)
@@ -143,8 +143,8 @@
 		;if not using dynamic k, closest k must be at least 2 smaller than model size, i.e., a model of 5 needs a K of 3 or less:
 		;when knocking out a case during conviction calculations, each remaining case searches for K cases around itself
 		;meaning that the K must be at least 2 less than the model size
-		(if (and (~ 0 closest_k) (< model_size (+ closest_k 2)) )
-			(assign (assoc closest_k (- model_size 2)))
+		(if (and (~ 0 closest_k) (< dataset_size (+ closest_k 2)) )
+			(assign (assoc closest_k (- dataset_size 2)))
 		)
 
 		(if (or familiarity_conviction_addition p_value_of_addition)
@@ -493,7 +493,7 @@
 	#!CacheAverageModelCaseDistanceContribution
 	(let
 		(assoc
-			base_model_distance_contributions_map
+			base_distance_contributions_map
 				(compute_on_contained_entities (list
 					||(compute_entity_distance_contributions
 						closest_k
@@ -517,8 +517,8 @@
 		(assign_to_entities (assoc
 			!averageModelCaseDistanceContribution
 				(/
-					(apply "+" (values base_model_distance_contributions_map))
-					(size base_model_distance_contributions_map)
+					(apply "+" (values base_distance_contributions_map))
+					(size base_distance_contributions_map)
 				)
 		))
 	)
@@ -527,7 +527,7 @@
 	#!ComputeNewCasesDistanceContributions
 	(let
 		(assoc
-			combined_model_distance_contributions_map
+			combined_distance_contributions_map
 				(compute_on_contained_entities (list
 					||(compute_entity_distance_contributions
 						closest_k
@@ -549,14 +549,14 @@
 		)
 
 		(assign (assoc
-			combined_model_average_distance_contributions
+			combined_average_distance_contribution
 				(/
-					(apply "+" (values combined_model_distance_contributions_map))
-					(size combined_model_distance_contributions_map)
+					(apply "+" (values combined_distance_contributions_map))
+					(size combined_distance_contributions_map)
 				)
 			avg_new_cases_distance_contribution
 				(/
-					(apply "+" (unzip combined_model_distance_contributions_map new_case_ids))
+					(apply "+" (unzip combined_distance_contributions_map new_case_ids))
 					(size new_case_ids)
 				)
 		))
@@ -692,7 +692,7 @@
 				))
 			num_cases_with_distance_contribution
 				(size (contained_entities [ (query_exists "distance_contribution") ] ))
-			local_model_cases
+			local_cases
 				(contained_entities (append
 					filtering_queries
 					(query_nearest_generalized_distance
@@ -724,7 +724,7 @@
 						||(compute_entity_distance_contributions
 							(get hyperparam_map "k")
 							features
-							local_model_cases
+							local_cases
 							feature_weights
 							!queryDistanceTypeMap
 							(get hyperparam_map "featureDomainAttributes")
@@ -747,7 +747,7 @@
 						(lambda
 							(retrieve_from_entity (current_index) "distance_contribution")
 						)
-						(zip local_model_cases)
+						(zip local_cases)
 					)
 			))
 		)
@@ -784,7 +784,7 @@
 			p_parameter (null)
 			query_closest_k (null)
 			dt_parameter (null)
-			model_size (null)
+			dataset_size (null)
 			use_case_weights (false)
 			weight_feature ".case_weight"
 			rebalance_weight_feature (null)
@@ -805,7 +805,7 @@
 				(assign (assoc
 					feature_weights (get hyperparam_map "featureWeights")
 					feature_deviations  (get hyperparam_map "featureDeviations")
-					model_size (call !GetNumTrainingCases)
+					dataset_size (call !GetNumTrainingCases)
 					dt_parameter (get hyperparam_map "dt")
 					p_parameter (get hyperparam_map "p")
 					query_closest_k (get hyperparam_map "k")
@@ -874,11 +874,11 @@
 			;dynamic k (when query_closest_k is a tuple and not a number) doesn't need smart expansion
 			(if (!~ 0 query_closest_k) (conclude) )
 
-			(if (or (> (size non_zero_distances) 0) (= query_closest_k model_size))
+			(if (or (> (size non_zero_distances) 0) (= query_closest_k dataset_size))
 				(assign (assoc done (true)))
 
 				;else double the k and try again, don't go past the model size
-				(assign (assoc query_closest_k (min (* 2 query_closest_k) model_size)))
+				(assign (assoc query_closest_k (min (* 2 query_closest_k) dataset_size)))
 			)
 		)
 

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -421,7 +421,7 @@
 	)
 
 	;Helper method to compute and cache average case entropy of addition for the model
-	#!CacheAverageModelCaseEntropyAddition
+	#!CacheAverageCaseEntropyAddition
 	(let
 		(assoc
 			entropies_map
@@ -455,7 +455,7 @@
 	)
 
 	;Helper method to compute and cache average case entropy of removal for the model
-	#!CacheAverageModelCaseEntropyRemoval
+	#!CacheAverageCaseEntropyRemoval
 	(let
 		(assoc
 			entropies_map
@@ -490,7 +490,7 @@
 	)
 
 	;Helper method to compute and cache average case distance contribution for the model
-	#!CacheAverageModelCaseDistanceContribution
+	#!CacheAverageCaseDistanceContribution
 	(let
 		(assoc
 			base_distance_contributions_map

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -320,7 +320,7 @@
 				;if computing for the whole model, update the calculated average distance contribution
 				(if (= (null) case_ids)
 					(assign_to_entities (assoc
-						!averageModelCaseDistanceContribution
+						!averageCaseDistanceContribution
 							(/
 								(apply "+" (values case_to_dc_map))
 								(size case_to_dc_map)
@@ -446,7 +446,7 @@
 		)
 
 		(assign_to_entities (assoc
-			!averageModelCaseEntropyAddition
+			!averageCaseEntropyAddition
 				(/
 					(apply "+" (values entropies_map))
 					(size entropies_map)
@@ -481,7 +481,7 @@
 		)
 
 		(assign_to_entities (assoc
-			!averageModelCaseEntropyRemoval
+			!averageCaseEntropyRemoval
 				(/
 					(apply "+" (values entropies_map))
 					(size entropies_map)
@@ -515,7 +515,7 @@
 		)
 
 		(assign_to_entities (assoc
-			!averageModelCaseDistanceContribution
+			!averageCaseDistanceContribution
 				(/
 					(apply "+" (values base_distance_contributions_map))
 					(size base_distance_contributions_map)
@@ -591,11 +591,11 @@
 			average_new_cases_conviction_addition
 				(if familiarity_conviction_addition
 					;if the average entropy is 0, that means all cases have entropy of 0, thus return 1 for conviction
-					(if (= 0 !averageModelCaseEntropyAddition)
+					(if (= 0 !averageCaseEntropyAddition)
 						1.0
 
 						;return conviction by taking the average case entropy dividing be the average new case entropy
-						(/ !averageModelCaseEntropyAddition (/ new_case_entropies_value (size new_case_ids)))
+						(/ !averageCaseEntropyAddition (/ new_case_entropies_value (size new_case_ids)))
 					)
 				)
 			p_value_of_addition_value
@@ -636,11 +636,11 @@
 			average_new_cases_conviction_removal
 				(if familiarity_conviction_removal
 					;if the average entropy is 0, that means all cases have entropy of 0, thus return 1 for conviction
-					(if (= 0 !averageModelCaseEntropyRemoval)
+					(if (= 0 !averageCaseEntropyRemoval)
 						1.0
 
 						;return conviction by taking the average case entropy dividing be the average new case entropy
-						(/ !averageModelCaseEntropyRemoval (/ new_case_entropies_value (size new_case_ids)))
+						(/ !averageCaseEntropyRemoval (/ new_case_entropies_value (size new_case_ids)))
 					)
 				)
 			p_value_of_removal_value
@@ -696,7 +696,7 @@
 				(contained_entities (append
 					filtering_queries
 					(query_nearest_generalized_distance
-						(max k_parameter_value !regionalModelMinSize)
+						(max k_parameter_value !regionalMinSize)
 						features
 						feature_values
 						feature_weights

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -385,7 +385,7 @@
 		(assoc single_series (false) )
 
 		(declare (assoc
-			automatic_timeseries_features_list (append !tsTimeFeature (get !tsModelFeaturesMap "series_id_features"))
+			automatic_timeseries_features_list (append !tsTimeFeature (get !tsFeaturesMap "series_id_features"))
 		))
 
 		;check if parameters include time series features to automatically prepare parameters for a time series react:
@@ -455,7 +455,7 @@
 					series_id_features
 						(filter
 							(lambda (not (contains_index all_contexts_set (current_value)) ) )
-							(get !tsModelFeaturesMap "series_id_features")
+							(get !tsFeaturesMap "series_id_features")
 						)
 				))
 
@@ -649,7 +649,7 @@
 		)
 
 		(declare (assoc
-			series_id_features_set (zip (get !tsModelFeaturesMap "series_id_features"))
+			series_id_features_set (zip (get !tsFeaturesMap "series_id_features"))
 			all_contexts_set (zip all_contexts)
 		))
 
@@ -658,7 +658,7 @@
 		(assign (assoc
 			derived_context_features
 				(append
-					(get !tsModelFeaturesMap "lag_features")
+					(get !tsFeaturesMap "lag_features")
 					derived_context_features
 					(if (size final_time_steps)
 						(list)
@@ -667,7 +667,7 @@
 				)
 			derived_action_features
 				(append
-					(get !tsModelFeaturesMap "derived_order_features")
+					(get !tsFeaturesMap "derived_order_features")
 					(filter
 						(lambda (not (contains_index series_id_features_set (current_value))))
 						;list of original features (ones not starting with a '.') that have derived_feature_code should be derived for output
@@ -714,11 +714,11 @@
 				(append
 					;don't synth id features if there should be no id tracking
 					(if (!= "no" series_id_tracking)
-						(get !tsModelFeaturesMap "series_id_features")
+						(get !tsFeaturesMap "series_id_features")
 						(list)
 					)
-					(get !tsModelFeaturesMap "delta_features")
-					(get !tsModelFeaturesMap "rate_features")
+					(get !tsFeaturesMap "delta_features")
+					(get !tsFeaturesMap "rate_features")
 
 					(if (contains_index (first series_stop_maps) ".series_progress")
 						(list ".series_progress_delta")

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -62,7 +62,7 @@
 		(declare (assoc
 			has_rounded_features !hasRoundedFeatures
 			has_datetime_features !hasDateTimeFeatures
-			model_size (call !GetNumTrainingCases)
+			dataset_size (call !GetNumTrainingCases)
 			selected_prediction_stats (get details "selected_prediction_stats")
 			compute_all_statistics (false)
 		))
@@ -266,7 +266,7 @@
 		)
 
 		(if (get details "feature_robust_prediction_contributions")
-			(if (>= model_size 2)
+			(if (>= dataset_size 2)
 				(call !ComputeFeatureContributions (assoc robust (true)))
 				;can't compute contributions if model is too small
 				(accum (assoc output (assoc "feature_robust_prediction_contributions" (zip context_features 0)) ))
@@ -274,7 +274,7 @@
 		)
 
 		(if (get details "feature_full_prediction_contributions")
-			(if (>= model_size 2)
+			(if (>= dataset_size 2)
 				(call !ComputeFeatureContributions (assoc robust (false)))
 				;can't compute contributions if model is too small
 				(accum (assoc output (assoc "feature_full_prediction_contributions" (zip context_features 0)) ))
@@ -282,7 +282,7 @@
 		)
 
 		(if (get details "feature_robust_prediction_contributions_for_case")
-			(if (>= model_size 2)
+			(if (>= dataset_size 2)
 				(call !ComputeCaseFeatureContributions (assoc robust (true)))
 				;can't compute contributions if model is too small
 				(accum (assoc output (assoc "feature_robust_prediction_contributions_for_case" (zip context_features 0)) ))
@@ -290,7 +290,7 @@
 		)
 
 		(if (get details "feature_full_prediction_contributions_for_case")
-			(if (>= model_size 2)
+			(if (>= dataset_size 2)
 				(call !ComputeCaseFeatureContributions (assoc robust (false)))
 				;can't compute contributions if model is too small
 				(accum (assoc output (assoc "feature_full_prediction_contributions_for_case" (zip context_features 0)) ))
@@ -620,7 +620,7 @@
 			;assoc of this react case
 			react_case (zip features (append context_values action_values))
 
-			local_model_case_ids
+			local_cases
 				(if (!= (null) cached_candidate_cases_map)
 					(indices cached_candidate_cases_map)
 
@@ -646,11 +646,11 @@
 				)
 		)
 
-		(declare (assoc
-			local_model_cases
+		(assign (assoc
+			local_cases
 				(map
 					(lambda (retrieve_from_entity (current_value) (zip features)) )
-					local_model_case_ids
+					local_cases
 				)
 		))
 
@@ -658,20 +658,20 @@
 		;values in the local model
 		;react case values that are beyond the min/max values of the local model's cases for each feature
 		(declare (assoc
-			local_model_outlying_feature_values
+			local_outlying_feature_values
 				(map
 					(lambda (let
 						(assoc feature (current_index 1))
 
 						;store the values for this feature for all the local model cases
 						(declare (assoc
-							local_model_feature_values
-								(map (lambda (get (current_value) feature)) local_model_cases)
+							local_feature_values
+								(map (lambda (get (current_value) feature)) local_cases)
 						))
 
 						(declare (assoc
-							local_min (apply "min" local_model_feature_values)
-							local_max (apply "max" local_model_feature_values)
+							local_min (apply "min" local_feature_values)
+							local_max (apply "max" local_feature_values)
 							;convert to number just in case
 							react_value (+ (get react_case feature))
 						))
@@ -697,11 +697,11 @@
 		))
 
 		;filter out any feature values that are null
-		(assign (assoc local_model_outlying_feature_values (filter local_model_outlying_feature_values)))
+		(assign (assoc local_outlying_feature_values (filter local_outlying_feature_values)))
 
 		(accum (assoc
 			output
-				(assoc "outlying_feature_values" local_model_outlying_feature_values)
+				(assoc "outlying_feature_values" local_outlying_feature_values)
 		))
 	)
 

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -562,12 +562,12 @@
 			action_features (list)
 			context_values (list)
 			action_values (list)
-			local_model_n !regionalModelMinSize
+			local_num_cases !regionalModelMinSize
 			num_cases_returned k_parameter_value
 			extra_features (list)
 		)
 		;set the value to be the max of these, that way if closest k is large, it'll just use that as the local model n size
-		(assign (assoc local_model_n (max k_parameter_value local_model_n)))
+		(assign (assoc local_num_cases (max k_parameter_value local_num_cases)))
 
 
 		;(a)get local model, (store num_cases_returned closest)
@@ -761,13 +761,13 @@
 		;if no boundary cases, repeat with double K value and rerun this method until K is at 240
 		; this can happen if there are many identical cases
 		(if (= (null) boundary_case_ids)
-			(if (<= local_model_n 240)
+			(if (<= local_num_cases 240)
 				(call !GetBoundaryCaseIds (assoc
 					context_features context_features
 					action_features action_features
 					context_values context_values
 					action_values action_values
-					local_model_n (* 2 local_model_n)
+					local_num_cases (* 2 local_num_cases)
 					boundary_cases_only boundary_cases_only
 					extra_features extra_features
 				))
@@ -838,7 +838,7 @@
 						;output the closest cases to the filtered contexts
 						(contained_entities (list
 							(query_nearest_generalized_distance
-								(replace local_model_n)
+								(replace local_num_cases)
 								(replace filtered_context_features)
 								;use only the corresponding values
 								(replace (unzip react_case filtered_context_features))

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -568,7 +568,7 @@
 			action_features (list)
 			context_values (list)
 			action_values (list)
-			local_num_cases !regionalModelMinSize
+			local_num_cases !regionalMinSize
 			num_cases_returned k_parameter_value
 			extra_features (list)
 		)

--- a/howso/details_influences.amlg
+++ b/howso/details_influences.amlg
@@ -5,7 +5,7 @@
 	#!ComputeFeatureAC
 	(let
 		(assoc
-			local_model_case_ids
+			case_ids
 				(if (!= (null) cached_candidate_cases_map)
 					(indices cached_candidate_cases_map)
 
@@ -46,7 +46,7 @@
 						)
 				)
 				;pick the needed number of cases randomly with replacement from the set of specified case_ids
-				(assign (assoc local_model_case_ids (rand local_model_case_ids num_robust_cases) ))
+				(assign (assoc case_ids (rand case_ids num_robust_cases) ))
 			)
 		)
 
@@ -57,7 +57,7 @@
 						(call !CalculateFeatureAccuracyContributions (assoc
 							context_features context_features
 							action_features action_features
-							case_ids local_model_case_ids
+							case_ids case_ids
 							robust (true)
 						))
 					)
@@ -65,7 +65,7 @@
 						(call !CalculateFeatureAccuracyContributions (assoc
 							context_features context_features
 							action_features action_features
-							case_ids local_model_case_ids
+							case_ids case_ids
 							robust (false)
 						))
 					)
@@ -87,7 +87,7 @@
 		)
 
 		(declare (assoc
-			local_model_case_ids
+			case_ids
 				(contained_entities (append
 					filtering_queries
 					(query_nearest_generalized_distance
@@ -125,7 +125,7 @@
 						)
 				)
 				;pick the needed number of cases randomly with replacament from the set of specified case_ids
-				(assign (assoc local_model_case_ids (rand local_model_case_ids num_robust_cases) ))
+				(assign (assoc case_ids (rand case_ids num_robust_cases) ))
 			)
 		)
 
@@ -136,7 +136,7 @@
 						(call !CalculateFeatureAccuracyContributions (assoc
 							context_features context_features
 							action_features action_features
-							case_ids local_model_case_ids
+							case_ids case_ids
 							robust (true)
 						))
 					)
@@ -144,7 +144,7 @@
 						(call !CalculateFeatureAccuracyContributions (assoc
 							context_features context_features
 							action_features action_features
-							case_ids local_model_case_ids
+							case_ids case_ids
 							robust (false)
 						))
 					)
@@ -156,7 +156,7 @@
 	#!ComputeCaseAccuracyContributions
 	(let
 		(assoc
-			local_model_cases_tuple
+			local_data_cases_tuple
 				(compute_on_contained_entities (append
 					filtering_queries
 					(query_nearest_generalized_distance
@@ -192,7 +192,7 @@
 		)
 
 		(assign (assoc
-			cases_to_expected_values_map (zip (first local_model_cases_tuple) (last local_model_cases_tuple))
+			cases_to_expected_values_map (zip (first local_data_cases_tuple) (last local_data_cases_tuple))
 			output_categorical_action_probabilities action_is_nominal
 		))
 
@@ -327,7 +327,7 @@
 							(assoc "accuracy_contribution" mda)
 						)
 					))
-					(first local_model_cases_tuple)
+					(first local_data_cases_tuple)
 				)
 		))
 		;restore categorical action probabilities map to whatever it was for the original react
@@ -650,7 +650,7 @@
 	#!ComputeFeatureContributions
 	(let
 		(assoc
-			local_model_case_ids
+			case_ids
 				(if (!= (null) cached_candidate_cases_map)
 					(indices cached_candidate_cases_map)
 
@@ -695,7 +695,7 @@
 					context_features context_features
 					action_feature action_feature
 					robust robust
-					case_ids local_model_case_ids
+					case_ids case_ids
 					num_robust_influence_samples_per_case num_robust_influence_samples_per_case
 					weight_feature weight_feature
 					run_on_local_model (true)

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -10,7 +10,7 @@
 				(compute_on_contained_entities (append
 					filtering_queries
 					(query_nearest_generalized_distance
-						(max k_parameter !regionalModelMinSize)
+						(max k_parameter !regionalMinSize)
 						context_features
 						context_values
 						feature_weights
@@ -95,7 +95,7 @@
 				(contained_entities (append
 					filtering_queries
 					(query_nearest_generalized_distance
-						(max k_parameter !regionalModelMinSize)
+						(max k_parameter !regionalMinSize)
 						context_features
 						context_values
 						feature_weights
@@ -364,7 +364,7 @@
 						(contained_entities (append
 							filtering_queries
 							(query_nearest_generalized_distance
-								(max k_parameter !regionalModelMinSize)
+								(max k_parameter !regionalMinSize)
 								context_features
 								context_values
 								feature_weights
@@ -511,7 +511,7 @@
 								(compute_on_contained_entities (append
 									filtering_queries
 									(query_nearest_generalized_distance
-										(replace (max k_parameter !regionalModelMinSize))
+										(replace (max k_parameter !regionalMinSize))
 										(replace local_context_features)
 										(replace (unzip case_value_map local_context_features))
 										(replace feature_weights)

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -6,7 +6,7 @@
 	(declare
 		(assoc
 			relevant_features (append context_features action_features)
-			regional_model_cases_map
+			regional_cases_map
 				(compute_on_contained_entities (append
 					filtering_queries
 					(query_nearest_generalized_distance
@@ -30,15 +30,15 @@
 
 		(declare (assoc
 			local_feature_metrics
-				(if (>= model_size 2)
+				(if (>= dataset_size 2)
 					(call !ExpandResidualValuesToUncertainty  (assoc
 						feature_residuals_map
 							(call !CalculateFeatureResiduals (assoc
 								;only the features from the details
 								context_features relevant_features
 								features (or details_features relevant_features)
-								case_ids (indices regional_model_cases_map)
-								regional_model_only (true)
+								case_ids (indices regional_cases_map)
+								regional_data_only (true)
 								robust_residuals robust_residuals
 								compute_all_statistics compute_all_statistics
 								;use the same hyperparameters that were used to make the original prediction
@@ -124,7 +124,7 @@
 										features (or details_features relevant_features)
 										context_features context_features
 										case_ids regional_case_ids
-										regional_model_only (true)
+										regional_data_only (true)
 										robust_residuals "deviations"
 										;use the same hyperparameters that were used to make the original prediction
 										custom_hyperparam_map hyperparam_map
@@ -157,7 +157,7 @@
 		)
 
 		;if model is too small to compute residuals, output fixed values
-		(if (<= model_size 2)
+		(if (<= dataset_size 2)
 			(conclude
 				(seq
 					(if (get details "feature_full_residuals_for_case")
@@ -347,10 +347,10 @@
 						action_features
 					)
 				)
+			local_null_feature_convictions (assoc)
 		)
 		(assign (assoc
 			case_residuals_map (zip action_features case_residuals)
-			local_model_null_features_convictions (assoc)
 			local_null_conviction_ratios_map (null)
 		))
 		;replace case residual nulls with computed values if nulls aren't allowed
@@ -360,7 +360,7 @@
 					;leave only features with null values
 					null_features
 						(indices (filter (lambda (= (null) (current_value))) case_residuals_map))
-					regional_model_cases
+					regional_cases
 						(contained_entities (append
 							filtering_queries
 							(query_nearest_generalized_distance
@@ -391,7 +391,7 @@
 							(lambda (let
 								(assoc
 									null_feature (current_index 1)
-									num_local_cases (size regional_model_cases)
+									num_local_cases (size regional_cases)
 									;list of all non null values for this null_feature in this regional model
 									non_null_local_values (list)
 								)
@@ -400,7 +400,7 @@
 									non_null_local_values
 										(filter (map
 											(lambda (retrieve_from_entity (current_value) null_feature))
-											regional_model_cases
+											regional_cases
 										))
 								))
 
@@ -410,7 +410,7 @@
 										computing_case_feature_residual_convictions
 										(= 0 (size non_null_local_values))
 									)
-									(accum (assoc local_model_null_features_convictions (associate null_feature 1)))
+									(accum (assoc local_null_feature_convictions (associate null_feature 1)))
 								)
 
 								;if nominal, output residual of 1 and the appropriate ratio
@@ -504,10 +504,10 @@
 							;context features without the residual feature
 							local_context_features (indices (remove context_map (current_index 1)))
 							residual_feature_map (assoc)
-							regional_model_cases_map (assoc)
+							regional_cases_map (assoc)
 						)
 						(assign (assoc
-							regional_model_cases_map
+							regional_cases_map
 								(compute_on_contained_entities (append
 									filtering_queries
 									(query_nearest_generalized_distance
@@ -534,8 +534,8 @@
 									(call !CalculateFeatureResiduals (assoc
 										features (append local_context_features residual_feature)
 										target_residual_feature residual_feature
-										case_ids (indices regional_model_cases_map)
-										regional_model_only (true)
+										case_ids (indices regional_cases_map)
+										regional_data_only (true)
 										robust_residuals robust_residuals
 										focal_case ignore_case
 										;use the same hyperparameters that were used to make the original prediction
@@ -551,8 +551,8 @@
 		))
 
 		;if there were pre-computed null feature convictions, overwrite them here
-		(if (size local_model_null_features_convictions)
-			(accum (assoc local_residuals_map local_model_null_features_convictions))
+		(if (size local_null_feature_convictions)
+			(accum (assoc local_residuals_map local_null_feature_convictions))
 		)
 
 		(assign (assoc

--- a/howso/distances.amlg
+++ b/howso/distances.amlg
@@ -21,7 +21,7 @@
 		)
 
 		(declare (assoc
-			local_model_cases_tuple
+			local_data_cases_tuple
 				(if local_cases_tuple
 					(if truncate_closest_cases_tuple
 						[
@@ -61,7 +61,7 @@
 		))
 
 		(assign (assoc
-			dist_to_closest_case (first (last local_model_cases_tuple))
+			dist_to_closest_case (first (last local_data_cases_tuple))
 
 			;find any cases that are within dbl_precision_epsilon of the farthest case in the local space,
 			;ignoring the cases that have already been found
@@ -69,17 +69,17 @@
 				;look for extra equidistance cases only if the distance between last two cases are the same (within dbl_precision_epsilon)
 				(if (<=
 						(-
-							(last (last local_model_cases_tuple))
-							(get (last local_model_cases_tuple) (- (size (last local_model_cases_tuple)) 2))
+							(last (last local_data_cases_tuple))
+							(get (last local_data_cases_tuple) (- (size (last local_data_cases_tuple)) 2))
 						)
 						dbl_precision_epsilon
 					)
 					(contained_entities (append
 						filtering_queries
-						(query_not_in_entity_list (first local_model_cases_tuple))
+						(query_not_in_entity_list (first local_data_cases_tuple))
 						(query_within_generalized_distance
 							;dbl_precision_epsilon for defining whether two values are equal within acceptable precision
-							(+ dbl_precision_epsilon (last (last local_model_cases_tuple)) )
+							(+ dbl_precision_epsilon (last (last local_data_cases_tuple)) )
 							context_features
 							context_values
 							feature_weights
@@ -99,17 +99,17 @@
 
 		;Compute distance contributions with k=1 to determine the smallest non-zero
 		;distance between any two cases in the local model.
-		(assign (assoc
-			local_model_min_distance_contribution
-				(call !QueryLocalModelMinDistanceContribution (assoc
+		(declare (assoc
+			local_data_min_distance
+				(call !QueryLocalDataMinDistance (assoc
 					feature_labels context_features
 					entity_ids_to_compute
 						(if extra_equidistant_cases
-							(append (first local_model_cases_tuple) extra_equidistant_cases)
+							(append (first local_data_cases_tuple) extra_equidistant_cases)
 
-							(if (<= model_size (size (first local_model_cases_tuple)))
-								(first local_model_cases_tuple)
-								(trunc (first local_model_cases_tuple))
+							(if (<= dataset_size (size (first local_data_cases_tuple)))
+								(first local_data_cases_tuple)
+								(trunc (first local_data_cases_tuple))
 							)
 						)
 					filtering_queries filtering_queries
@@ -133,15 +133,15 @@
 								(last (current_value))
 							)
 						)
-						(trunc (first local_model_cases_tuple) num_most_similar_case_indices)
-						(trunc (last local_model_cases_tuple) num_most_similar_case_indices)
+						(trunc (first local_data_cases_tuple) num_most_similar_case_indices)
+						(trunc (last local_data_cases_tuple) num_most_similar_case_indices)
 					)
 					(list)
 				)
 			distance_ratio
 				(if (= .infinity dist_to_closest_case)
 					1
-					(/ dist_to_closest_case local_model_min_distance_contribution)
+					(/ dist_to_closest_case local_data_min_distance)
 				)
 		))
 
@@ -161,7 +161,7 @@
 						)
 					"distance_ratio_parts"
 						(assoc
-							"local_distance_contribution" local_model_min_distance_contribution
+							"local_distance_contribution" local_data_min_distance
 							"nearest_distance" dist_to_closest_case
 						)
 					"most_similar_case_indices" audit_data
@@ -684,20 +684,20 @@
 		))
 	)
 
-	;given a list of entity ids, determine the minimum distance contribution between
-	; all of those cases. Returns the minimum entity distance contribution.
+	;given a list of entity ids, determine the minimum distance between
+	; all of those cases. Returns the minimum entity distance.
 	;parameters:
-	; feature_labels : list of feature labels to use for determining distance contributions
+	; feature_labels : list of feature labels to use for determining distance
 	; entity_ids_to_compute : list of entity IDs to compute minimum distance between.
-	; filtering_queries : optional, list of filtering queries to apply before computing entity distance
-	;					  contributions. Most useful for when calling this method when computing distance ratios.
+	; filtering_queries : optional, list of filtering queries to apply before computing entity distances.
+	;					  Most useful for when calling this method when computing distance ratios.
 	; use_feature_deviations : optional, flag which determines whether feature_deviations are used in the query.
 
 	; Queries local distances based on new_case_threshold
 	; max is the maximum local distance
 	; min is the minimum local distance
 	; most_similar is the closest distance of the most similar case
-	#!QueryLocalModelMinDistanceContribution
+	#!QueryLocalDataMinDistance
 	(declare
 		(assoc
 			feature_labels (list)

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -75,13 +75,13 @@
 
 		;remove feature from model if no conditions are specified
 		(declare (assoc
-			remove_feature_from_model (and (= (null) condition) (= (null) condition_session))
+			remove_feature_from_dataset (and (= (null) condition) (= (null) condition_session))
 		))
 
 		;get the list of cases to operate on, if condition isn't specified, operate on all cases
 		(declare (assoc
 			entities
-				(if (not remove_feature_from_model)
+				(if (not remove_feature_from_dataset)
 					;specify no limit for how many to match as long as they match the condition
 					(call !GetCasesByCondition (assoc
 						condition condition
@@ -126,7 +126,7 @@
 			entities
 		)
 
-		(if remove_feature_from_model
+		(if remove_feature_from_dataset
 			(seq
 				(if (contains_index !nominalsMap feature)
 					(assign_to_entities (assoc
@@ -335,14 +335,14 @@
 
 		;add feature to model if no conditions are specified
 		(declare (assoc
-			add_feature_to_model (and (= (null) condition) (= (null) condition_session))
+			add_feature_to_dataset (and (= (null) condition) (= (null) condition_session))
 		))
 
 		;get all cases that need to be updated
 		(if (= (null) entities)
 			(assign (assoc
 				entities
-					(if (not add_feature_to_model)
+					(if (not add_feature_to_dataset)
 						;specify no limit for how many to match as long as they match the condition
 						(call !GetCasesByCondition (assoc
 							condition condition
@@ -358,19 +358,19 @@
 
 		;only add feature to model if it is not an internal feature (e.g., .imputed) or if feature_attributes were provided or feature isn't defined
 		(assign (assoc
-			add_feature_to_model
+			add_feature_to_dataset
 				(and
 					(not internal_feature)
 					(not (contains_index !featureAttributes feature))
 					(or
 						feature_attributes
-						add_feature_to_model
+						add_feature_to_dataset
 						(not (contains_index !featureAttributes feature))
 					)
 				)
 		))
 
-		(if add_feature_to_model
+		(if add_feature_to_dataset
 			(let
 				(assoc
 					min_deviation_value (/ 1 (call !GetNumTrainingCases))

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -62,9 +62,9 @@
 
 		;model has changed so clear out these cached value
 		(assign_to_entities (assoc
-			!averageModelCaseEntropyAddition (null)
-			!averageModelCaseEntropyRemoval (null)
-			!averageModelCaseDistanceContribution (null)
+			!averageCaseEntropyAddition (null)
+			!averageCaseEntropyRemoval (null)
+			!averageCaseDistanceContribution (null)
 			!storedCaseConvictionsFeatureAddition (null)
 			!nominalClassProbabilitiesMap
 				(if (contains_index !nominalClassProbabilitiesMap feature)

--- a/howso/feature_conviction.amlg
+++ b/howso/feature_conviction.amlg
@@ -226,7 +226,7 @@
 					prior_nearest_entity_probabilities (assoc)
 
 					;probability of a new point having each entity as its nearest neighbor given new_cases
-					full_model_entity_probabilities (assoc)
+					all_entity_probabilities (assoc)
 
 					entities
 						(if (> (size case_ids) 0)
@@ -238,7 +238,7 @@
 
 				;compute probabilities for trainee with all contexts
 				(assign (assoc
-					full_model_entity_probabilities
+					all_entity_probabilities
 						(call !CalculateAllClosestCaseProbabilities (assoc
 							features
 								(if (= 0 (size action_features))
@@ -288,13 +288,13 @@
 										;prior data with model with specific feature subset
 										prior_nearest_entity_probabilities
 										;full model
-										full_model_entity_probabilities
+										all_entity_probabilities
 									)
 
 									;output the kl divergence for each feature as removal
 									(entropy
 										;prior data of full model
-										full_model_entity_probabilities
+										all_entity_probabilities
 										;posterior data with model with specific feature subset
 										prior_nearest_entity_probabilities
 									)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -201,7 +201,7 @@
 	; context_condition_filter_query: optional list of filtering queries for the context set.
 	; strict_case_ids: flag, default to false. If true, then any augmentations to case ids is prohibited (selecting additional non-null cases, more null cases, etc.)
 	; focal_case: optional case id of case for which to compute residuals for  is to be ignored during computation
-	; regional_model_only: flag, default to false. when set to true will only explicitly use the specified case_ids for computation.
+	; regional_data_only: flag, default to false. when set to true will only explicitly use the specified case_ids for computation.
 	; robust_residuals: string, default to (null). when "deviations" calculates accurate local residuals, otherwise computes residuals robust with respect to the set of contexts used
 	;		(across the power set of contexts).  when "robust_mda" will only compute and output MDA using robust residuals.
 	; hyperparameter_feature: optional  default (null).  feature whose hyperparameters to use
@@ -226,7 +226,7 @@
 			;the features to be used as context
 			context_features (null)
 			target_residual_feature (null)
-			regional_model_only (false)
+			regional_data_only (false)
 			focal_case (null)
 			robust_residuals (null)
 			strict_case_ids (false)
@@ -390,7 +390,7 @@
 						null_cases_map
 							(map
 								(if (or
-										regional_model_only
+										regional_data_only
 										(< (size case_ids) 200)
 									)
 									;if regional model only or small dataset/sample, just filter which of the case ids have nulls for each feature

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -666,7 +666,7 @@
 		;set model time series (lag, delta, rate, start, end, derived order) features for series react
 		;to be used for constructing react_series parameters
 		(accum_to_entities (assoc
-			!tsModelFeaturesMap
+			!tsFeaturesMap
 				(assoc
 					"lag_features" lag_features
 					"delta_features" delta_features

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -307,17 +307,17 @@
 
 		;run through one pass using feature weights to see if they should be used
 		(assign (assoc
-			model_mae (call !ComputeModelResidualForParameters (assoc targetless (= targeted_model "targetless")))
+			dataset_mae (call !ComputeModelResidualForParameters (assoc targetless (= targeted_model "targetless")))
 		))
 
 		;if previous pass did better than this pass, revert baseline_hyperparameter_map
-		(if (>= model_mae (get baseline_hyperparameter_map "gridSearchError"))
+		(if (>= dataset_mae (get baseline_hyperparameter_map "gridSearchError"))
 			(assign (assoc baseline_hyperparameter_map previous_analyzed_hp_map))
 
 			;else keep update current hyperparams with new error value and back them up
 			(seq
 				(assign (assoc
-					baseline_hyperparameter_map (set baseline_hyperparameter_map "gridSearchError" model_mae)
+					baseline_hyperparameter_map (set baseline_hyperparameter_map "gridSearchError" dataset_mae)
 				))
 				(assign (assoc previous_analyzed_hp_map baseline_hyperparameter_map))
 			)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -219,7 +219,7 @@
 
 	;write baseline_hyperparameter_map out to the model's !hyperparameterMetadataMap
 	;null action feature assumes targetless hyperparameters
-	#!SetModelHyperParameters
+	#!SetHyperparameters
 	(seq
 		(if derived_auto_analyzed
 			(accum (assoc baseline_hyperparameter_map (assoc "derivedAutoAnalyzed" (true)) ))
@@ -307,7 +307,7 @@
 
 		;run through one pass using feature weights to see if they should be used
 		(assign (assoc
-			dataset_mae (call !ComputeModelResidualForParameters (assoc targetless (= targeted_model "targetless")))
+			dataset_mae (call !ComputeResidualForParameters (assoc targetless (= targeted_model "targetless")))
 		))
 
 		;if previous pass did better than this pass, revert baseline_hyperparameter_map

--- a/howso/impute.amlg
+++ b/howso/impute.amlg
@@ -42,10 +42,10 @@
 
 		;reset any cached feature or case entropies
 		(assign_to_entities (assoc
-			!averageModelCaseEntropyAddition (null)
-			!averageModelCaseEntropyRemoval (null)
+			!averageCaseEntropyAddition (null)
+			!averageCaseEntropyRemoval (null)
 			!storedCaseConvictionsFeatureAddition (null)
-			!averageModelCaseDistanceContribution (null)
+			!averageCaseDistanceContribution (null)
 		))
 
 		;pull all the cases that have nulls

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -232,8 +232,8 @@
 										(and
 											(contains_value action_features (get !derivedFeaturesMap (current_value)))
 											(or
-												(contains_value (get !tsModelFeaturesMap "rate_features") (current_value))
-												(contains_value (get !tsModelFeaturesMap "delta_features") (current_value))
+												(contains_value (get !tsFeaturesMap "rate_features") (current_value))
+												(contains_value (get !tsFeaturesMap "delta_features") (current_value))
 											)
 										)
 									)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -80,7 +80,7 @@
 
 		(declare (assoc
 			baseline_error
-				(call !CalculateModelMAE (assoc
+				(call !CalculateMAE (assoc
 					action_features action_features
 					context_features context_features
 					case_ids case_ids
@@ -114,7 +114,7 @@
 					(let
 						(assoc
 							feature_mda
-								(call !CalculateModelMAE (assoc
+								(call !CalculateMAE (assoc
 									action_features action_features
 									context_features mae_context_features
 									case_ids case_ids
@@ -183,7 +183,7 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; features_to_derive: list of features whose values should be derived rather than interpolated
-	#!CalculateModelMAE
+	#!CalculateMAE
 	(declare
 		(assoc
 			action_features (list)
@@ -412,7 +412,7 @@
 						)
 
 						(declare (assoc
-							reaction_values (call !ModelMAEReact)
+							reaction_values (call !SingleMAEReact)
 							expected_values (retrieve_from_entity (if cases_already_removed (list "_temp_" case_id ) case_id) react_action_features)
 						))
 
@@ -623,7 +623,7 @@
 		)
 	)
 
-	;helper method for !CalculateModelMAE, calculates the mean of the accumulated error value
+	;helper method for !CalculateMAE, calculates the mean of the accumulated error value
 	;for each action feature
 	#!CalculateActionFeatureMAEs
 	(map
@@ -672,7 +672,7 @@
 		action_feature_maes
 	)
 
-	#!ModelMAEReact
+	#!SingleMAEReact
 	(if (not (size features_for_derivation_map))
 		(call !ReactDiscriminative (assoc
 			return_action_values_only (true)

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -216,7 +216,7 @@
 	; feature : name of feature
 	; case_ids : optional list of case ids from which to consider expected values, if not specified uses all cases in the model
 	; store_global_probabilities : flag, will default to storing computed global nominal probabilities. if false, will only output them
-	#!ComputeModelNominalClassProbabilities
+	#!ComputeNominalClassProbabilities
 		(declare
 			(assoc
 				feature (null)
@@ -373,7 +373,7 @@
 								||(map
 									(lambda (let
 										(assoc feature (current_index 1))
-										(call !ComputeModelNominalClassProbabilities (assoc
+										(call !ComputeNominalClassProbabilities (assoc
 											feature feature
 											weight_feature ".none"
 											store_global_probabilities (false)
@@ -395,7 +395,7 @@
 									||(map
 										(lambda (let
 											(assoc feature (current_index 1))
-											(call !ComputeModelNominalClassProbabilities (assoc
+											(call !ComputeNominalClassProbabilities (assoc
 												feature feature
 												weight_feature weight_feature
 												store_global_probabilities (false)

--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -241,7 +241,7 @@
 		;determine if any of the lists in feature_residuals_lists are too short (< 50 values), if so keep feature as needing to be resampled
 		;applicable only to global models
 		(if (and
-				(!= (true) regional_model_only)
+				(!= (true) regional_data_only)
 				(not strict_case_ids)
 			)
 			(let

--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -24,7 +24,7 @@
 						)
 					)
 				)
-			series_id_features (if !tsTimeFeature (get !tsModelFeaturesMap "series_id_features") )
+			series_id_features (if !tsTimeFeature (get !tsFeaturesMap "series_id_features") )
 			;this variable is used in the derivation logic branch of InterpolateAndComputeDiff
 			react_context_features context_features
 		))
@@ -136,7 +136,7 @@
 																			(lambda (or
 																				(not (contains_value (get features_for_derivation_map feature) (current_value)))
 																				(!= feature (get !derivedFeaturesMap (current_value)))
-																				(contains_value (get !tsModelFeaturesMap "lag_features") (current_value))
+																				(contains_value (get !tsFeaturesMap "lag_features") (current_value))
 																			))
 																			context_features
 																		)

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1381,7 +1381,7 @@
 								(lambda (query_not_equals (current_value) (get context_map (current_value))) )
 								(indices (keep
 									context_map
-									(get !tsModelFeaturesMap "series_id_features")
+									(get !tsFeaturesMap "series_id_features")
 								))
 							)
 					))
@@ -1556,16 +1556,16 @@
 		(if (and
 				!tsTimeFeature
 				!tsTimeFeatureUniversal
-				(not (get !tsModelFeaturesMap "minimum_time_bound"))
+				(not (get !tsFeaturesMap "minimum_time_bound"))
 			)
 			;update "minimum_time_bound" which is the stored minimum time value that can be used as an upper bound
 			;in queries when the time feature is universal
 			;needs "hyperparam_map"
 			#!UpdateMinimumTimeBound
 			(assign_to_entities (assoc
-				!tsModelFeaturesMap
+				!tsFeaturesMap
 					(set
-						!tsModelFeaturesMap
+						!tsFeaturesMap
 						["minimum_time_bound"]
 						(retrieve_from_entity
 							(last

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1399,7 +1399,7 @@
 		)
 
 		(declare (assoc
-			local_model_cases_tuple
+			local_data_cases_tuple
 				#!ReactionQuery
 				(compute_on_contained_entities
 					(append
@@ -1458,7 +1458,7 @@
 		;if there is no context or local model, calculate the expected value
 		(if (or
 				(= (list) context_features)
-				(= 0 (size (first local_model_cases_tuple)))
+				(= 0 (size (first local_data_cases_tuple)))
 			)
 			(let
 				(assoc
@@ -1485,9 +1485,9 @@
 			;else interpolate the result from the nearest neighbors
 			(call !InterpolateActionValues (assoc
 				action_feature (first action_features)
-				candidate_case_ids (first local_model_cases_tuple)
-				candidate_case_weights (get local_model_cases_tuple 1)
-				candidate_case_values (last local_model_cases_tuple)
+				candidate_case_ids (first local_data_cases_tuple)
+				candidate_case_weights (get local_data_cases_tuple 1)
+				candidate_case_values (last local_data_cases_tuple)
 				allow_nulls allow_nulls
 			))
 		)

--- a/howso/react_group.amlg
+++ b/howso/react_group.amlg
@@ -216,15 +216,15 @@
 		)
 
 		;cache average case entropies and distance contributions if necessary
-		(if (and familiarity_conviction_addition (= (null) !averageModelCaseEntropyAddition) )
+		(if (and familiarity_conviction_addition (= (null) !averageCaseEntropyAddition) )
 			(call !CacheAverageCaseEntropyAddition)
 		)
 
-		(if (and familiarity_conviction_removal (= (null) !averageModelCaseEntropyRemoval) )
+		(if (and familiarity_conviction_removal (= (null) !averageCaseEntropyRemoval) )
 			(call !CacheAverageCaseEntropyRemoval)
 		)
 
-		(if (and distance_contributions (= (null) !averageModelCaseDistanceContribution) )
+		(if (and distance_contributions (= (null) !averageCaseDistanceContribution) )
 			(call !CacheAverageCaseDistanceContribution)
 		)
 
@@ -288,7 +288,7 @@
 			(if distance_contributions
 				(assoc
 					"distance_contribution" avg_new_cases_distance_contribution
-					"base_model_average_distance_contribution" !averageModelCaseDistanceContribution
+					"base_model_average_distance_contribution" !averageCaseDistanceContribution
 					"combined_model_average_distance_contribution" combined_average_distance_contribution
 				)
 				(assoc)
@@ -332,7 +332,7 @@
 				ts_derived_context_features
 					(if !tsTimeFeature
 						(filter
-							(lambda (contains_value (get !tsModelFeaturesMap "ts_derived_features") (current_value)))
+							(lambda (contains_value (get !tsFeaturesMap "ts_derived_features") (current_value)))
 							context_features
 						)
 					)

--- a/howso/react_group.amlg
+++ b/howso/react_group.amlg
@@ -132,10 +132,10 @@
 			weight_feature ".case_weight"
 		)
 
-		(declare (assoc model_size (call !GetNumTrainingCases)))
+		(declare (assoc dataset_size (call !GetNumTrainingCases)))
 
 		;if the model is too small, just return 0, otherwise compute conviction
-		(if (<= model_size 2)
+		(if (<= dataset_size 2)
 			(conclude
 				(assoc
 					"familiarity_conviction_addition" 0
@@ -145,8 +145,8 @@
 					"p_value_of_addition" 0
 					"p_value_of_removal" 0
 					"distance_contribution" 0
-					"base_model_average_distance_contribution" 0
-					"combined_model_average_distance_contribution" 0
+					"base_average_distance_contribution" 0
+					"combined_average_distance_contribution" 0
 				)
 			)
 		)
@@ -188,7 +188,7 @@
 				))
 			valid_weight_feature (false)
 
-			combined_model_average_distance_contributions (null)
+			combined_average_distance_contribution (null)
 			avg_new_cases_distance_contribution (null)
 			new_case_entropies_value (null)
 			average_new_cases_conviction_addition (null)
@@ -211,8 +211,8 @@
 		;closest k must be at least 2 smaller than model size, i.e., a model of 5 needs a K of 3 or less:
 		;when knocking out a case during conviction calculations, each remaining case searches for K cases around itself
 		;meaning that the K must be at least 2 less than the model size
-		(if (and (< model_size (+ closest_k 2)) (~ 0 closest_k))
-			(assign (assoc closest_k (- model_size 2)))
+		(if (and (< dataset_size (+ closest_k 2)) (~ 0 closest_k))
+			(assign (assoc closest_k (- dataset_size 2)))
 		)
 
 		;cache average case entropies and distance contributions if necessary
@@ -289,7 +289,7 @@
 				(assoc
 					"distance_contribution" avg_new_cases_distance_contribution
 					"base_model_average_distance_contribution" !averageModelCaseDistanceContribution
-					"combined_model_average_distance_contribution" combined_model_average_distance_contributions
+					"combined_model_average_distance_contribution" combined_average_distance_contribution
 				)
 				(assoc)
 			)

--- a/howso/react_group.amlg
+++ b/howso/react_group.amlg
@@ -217,15 +217,15 @@
 
 		;cache average case entropies and distance contributions if necessary
 		(if (and familiarity_conviction_addition (= (null) !averageModelCaseEntropyAddition) )
-			(call !CacheAverageModelCaseEntropyAddition)
+			(call !CacheAverageCaseEntropyAddition)
 		)
 
 		(if (and familiarity_conviction_removal (= (null) !averageModelCaseEntropyRemoval) )
-			(call !CacheAverageModelCaseEntropyRemoval)
+			(call !CacheAverageCaseEntropyRemoval)
 		)
 
 		(if (and distance_contributions (= (null) !averageModelCaseDistanceContribution) )
-			(call !CacheAverageModelCaseDistanceContribution)
+			(call !CacheAverageCaseDistanceContribution)
 		)
 
 		;create new cases

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -184,7 +184,7 @@
 				(size series_id_features)
 				(!=
 					(zip series_id_features)
-					(zip (get !tsModelFeaturesMap "series_id_features"))
+					(zip (get !tsFeaturesMap "series_id_features"))
 				)
 			)
 			(conclude
@@ -555,7 +555,7 @@
 				(size series_id_features)
 				(!=
 					(zip series_id_features)
-					(zip (get !tsModelFeaturesMap "series_id_features"))
+					(zip (get !tsFeaturesMap "series_id_features"))
 				)
 			)
 			(conclude

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -73,7 +73,7 @@
 			;	smaller values will decrease the variance (or creativity) of the generated case from the existing model
 			desired_conviction (null)
 			;{type "number"}
-			;maximum size a series is allowed to be.  Default is 3 * model_size, a 0 or less is no limit.
+			;maximum size a series is allowed to be.  Default is 3 * dataset_size, a 0 or less is no limit.
 			;	If forecasting with 'continue_series', this defines the maximum length of the forecast.
 			max_series_length (null)
 			;{type "boolean"}
@@ -337,7 +337,7 @@
 			; one assoc is used per series.
 			series_stop_maps (list)
 			;{type "list" values "number"}
-			;list of maximum sizes each series is allowed to be.  Default is 3 * model_size, a 0 or less is no limit.
+			;list of maximum sizes each series is allowed to be.  Default is 3 * dataset_size, a 0 or less is no limit.
 			;	If forecasting with 'continue_series', this defines the maximum length of the forecast.
 			max_series_lengths (null)
 			;{type "boolean"}

--- a/howso/react_series_stationary.amlg
+++ b/howso/react_series_stationary.amlg
@@ -95,7 +95,7 @@
 							(not (contains_value context_features (current_value)))
 							(contains_value context_features (get !derivedFeaturesMap (current_value)))
 						))
-						(get !tsModelFeaturesMap "ts_derived_features")
+						(get !tsFeaturesMap "ts_derived_features")
 					)
 			))
 		)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -206,8 +206,8 @@
 						(assoc)
 					)
 				)
-			series_has_terminators (get !tsModelFeaturesMap "series_has_terminators")
-			stop_on_terminator (get !tsModelFeaturesMap "stop_on_terminator")
+			series_has_terminators (get !tsFeaturesMap "series_has_terminators")
+			stop_on_terminator (get !tsFeaturesMap "stop_on_terminator")
 		))
 
 		;defaults to "no" if unspecified
@@ -261,7 +261,7 @@
 			user_specified_context_features series_context_features
 
 			;features used for uniqueness validation should not include id features
-			output_features_no_ids (if (!= "no" generate_new_cases) (indices (remove (zip output_features) (get !tsModelFeaturesMap "series_id_features"))) )
+			output_features_no_ids (if (!= "no" generate_new_cases) (indices (remove (zip output_features) (get !tsFeaturesMap "series_id_features"))) )
 			do_uniqueness_check (true)
 			retries 0
 			original_desired_conviction desired_conviction
@@ -890,7 +890,7 @@
 				(if has_non_tracked_ids
 					(filter
 						(lambda (contains_value output_features (current_value)))
-						(get !tsModelFeaturesMap "series_id_features")
+						(get !tsFeaturesMap "series_id_features")
 					)
 				)
 		))
@@ -1089,7 +1089,7 @@
 			series_id_features
 				(if (size series_id_features)
 					series_id_features
-					(get !tsModelFeaturesMap "series_id_features")
+					(get !tsFeaturesMap "series_id_features")
 				)
 			id_values_map (assoc)
 			existing_series_cases (list)
@@ -1275,7 +1275,7 @@
 											)
 											(contains_value features (current_value))
 										))
-										(get !tsModelFeaturesMap "delta_features")
+										(get !tsFeaturesMap "delta_features")
 									)
 									;non-time-lags that are populated based on last series index
 									(filter
@@ -1284,7 +1284,7 @@
 											(<= (get ts_feature_lag_amount_map (current_value)) last_series_index)
 											(contains_value features (current_value))
 										))
-										(get !tsModelFeaturesMap "lag_features")
+										(get !tsFeaturesMap "lag_features")
 									)
 									;rates that are populated based on last series index
 									(filter
@@ -1292,7 +1292,7 @@
 											(<= (get ts_feature_lag_amount_map (current_value)) last_series_index)
 											(contains_value features (current_value))
 										))
-										(get !tsModelFeaturesMap "rate_features")
+										(get !tsFeaturesMap "rate_features")
 									)
 								)
 							)

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -633,13 +633,13 @@
 		;if time feature is universal, only consider cases that are not in the future
 		(list (query_less_or_equal_to
 			!tsTimeFeature
-			(max (get context_map !tsTimeFeature) (get !tsModelFeaturesMap "minimum_time_bound"))
+			(max (get context_map !tsTimeFeature) (get !tsFeaturesMap "minimum_time_bound"))
 		))
 
 		;else not universal and only applies to this specific series, if series IDs are provided
 		(if
 			(not (contains_value
-				(unzip context_map (get !tsModelFeaturesMap "series_id_features"))
+				(unzip context_map (get !tsFeaturesMap "series_id_features"))
 				(null)
 			))
 			;exclude all cases for this series from the future
@@ -649,7 +649,7 @@
 						;cases matching this series id
 						(map
 							(lambda (query_equals (current_value) (get context_map (current_value))) )
-							(get !tsModelFeaturesMap "series_id_features")
+							(get !tsFeaturesMap "series_id_features")
 						)
 						;where !tsTimeFeature > time value
 						(query_greater_or_equal_to !tsTimeFeature (get context_map !tsTimeFeature))

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -497,7 +497,7 @@
 		))
 
 		(declare (assoc
-			regional_model_cases_tuple
+			regional_cases_tuple
 				(compute_on_contained_entities (append
 					(if ignore_case
 						(query_not_in_entity_list (list ignore_case))
@@ -528,7 +528,7 @@
 
 		(if use_regional_residuals
 			(let
-				(assoc regional_cases_map (apply "zip" regional_model_cases_tuple) )
+				(assoc regional_cases_map (apply "zip" regional_cases_tuple) )
 
 				;update the the min/max for all the dependent context features from the computed regional residuals
 				(map
@@ -543,7 +543,7 @@
 								(call !ExpandResidualValuesToUncertainty (assoc
 									feature_residuals_map
 										(call !ComputeRegionalResiduals (assoc
-											regional_model_cases_map regional_cases_map
+											regional_cases_map regional_cases_map
 											features (append context_features feature)
 											target_residual_feature feature
 											ignore_case ignore_case
@@ -563,7 +563,7 @@
 
 			;else approximate residual for each dependent context feature
 			(let
-				(assoc regional_case_ids (first regional_model_cases_tuple))
+				(assoc regional_case_ids (first regional_cases_tuple))
 				(declare (assoc local_case_ids (trunc regional_cases local_k) ))
 
 				(map
@@ -890,7 +890,7 @@
 		)
 	)
 
-	;Helper method for reacts to update contexts with goal feature values from results of local_model_cases_tuple and rerun the query
+	;Helper method for reacts to update contexts with goal feature values from results of local_data_cases_tuple and rerun the query
 	#!UpdateLocalInfluencesForGoals
 	(seq
 		(assign (assoc
@@ -942,7 +942,7 @@
 								(get
 									(first
 										(compute_on_contained_entities [
-											(query_in_entity_list (first local_model_cases_tuple))
+											(query_in_entity_list (first local_data_cases_tuple))
 											(query_max goal_feature 1)
 											(query_exists goal_feature)
 										])
@@ -954,7 +954,7 @@
 								(get
 									(first
 										(compute_on_contained_entities [
-											(query_in_entity_list (first local_model_cases_tuple))
+											(query_in_entity_list (first local_data_cases_tuple))
 											(query_min goal_feature 1)
 											(query_exists goal_feature)
 										])
@@ -969,7 +969,7 @@
 										local_goal_values
 											(map
 												(lambda (retrieve_from_entity (current_value) goal_feature))
-												(first local_model_cases_tuple)
+												(first local_data_cases_tuple)
 											)
 									)
 									(declare (assoc local_max (apply "max" local_goal_values) ))
@@ -992,12 +992,12 @@
 			;limit the secondary goal-oriented query to only run on cases in this local space
 			custom_extra_filtering_queries
 				(if custom_extra_filtering_queries
-					(append custom_extra_filtering_queries (query_in_entity_list (first local_model_cases_tuple)) )
-					(query_in_entity_list (first local_model_cases_tuple))
+					(append custom_extra_filtering_queries (query_in_entity_list (first local_data_cases_tuple)) )
+					(query_in_entity_list (first local_data_cases_tuple))
 				)
 		))
 
 		;call the react query again with the goal-oriented contexts and weights
-		(assign (assoc local_model_cases_tuple (call (retrieve_from_entity query_label)) ))
+		(assign (assoc local_data_cases_tuple (call (retrieve_from_entity query_label)) ))
 	)
 )

--- a/howso/remove_cases.amlg
+++ b/howso/remove_cases.amlg
@@ -376,7 +376,7 @@
 		(call !UpdateHasNulls (assoc features !trainedFeatures))
 
 		(call !UpdateRegionalModelMinSize (assoc
-			model_size (call !GetNumTrainingCases)
+			dataset_size (call !GetNumTrainingCases)
 		))
 
 		(null)
@@ -386,11 +386,11 @@
 	#!UpdateRegionalModelMinSize
 	(assign_to_entities (assoc
 		!regionalModelMinSize
-			(if (> model_size 81)
+			(if (> dataset_size 81)
 				30
 
-				;else set it to model_size / e
-				(/ model_size 2.71828182845)
+				;else set it to dataset_size / e
+				(/ dataset_size 2.71828182845)
 			)
 	))
 

--- a/howso/remove_cases.amlg
+++ b/howso/remove_cases.amlg
@@ -275,7 +275,7 @@
 		;derived features can be-rederived below after cases are removed
 		(if (and (!= (null) !tsTimeFeature) (size !derivedFeaturesMap))
 			(let
-				(assoc series_id_features (get !tsModelFeaturesMap "series_id_features") )
+				(assoc series_id_features (get !tsFeaturesMap "series_id_features") )
 
 				;for each case pull the list of series id values for all the series id features
 				(declare (assoc
@@ -368,7 +368,7 @@
 			(call !DeriveTrainFeatures (assoc
 				features !trainedFeatures
 				;keep and derive only those features that are not in the features list
-				derived_features (get !tsModelFeaturesMap "ts_derived_features")
+				derived_features (get !tsFeaturesMap "ts_derived_features")
 				case_ids re_derivation_series_case_ids
 			))
 		)
@@ -382,10 +382,10 @@
 		(null)
 	)
 
-	;Helper method to update !regionalModelMinSize to 30 for any model over 81 since 30 * e ~ 81.5
+	;Helper method to update !regionalMinSize to 30 for any model over 81 since 30 * e ~ 81.5
 	#!UpdateRegionalMinSize
 	(assign_to_entities (assoc
-		!regionalModelMinSize
+		!regionalMinSize
 			(if (> dataset_size 81)
 				30
 

--- a/howso/remove_cases.amlg
+++ b/howso/remove_cases.amlg
@@ -375,7 +375,7 @@
 
 		(call !UpdateHasNulls (assoc features !trainedFeatures))
 
-		(call !UpdateRegionalModelMinSize (assoc
+		(call !UpdateRegionalMinSize (assoc
 			dataset_size (call !GetNumTrainingCases)
 		))
 
@@ -383,7 +383,7 @@
 	)
 
 	;Helper method to update !regionalModelMinSize to 30 for any model over 81 since 30 * e ~ 81.5
-	#!UpdateRegionalModelMinSize
+	#!UpdateRegionalMinSize
 	(assign_to_entities (assoc
 		!regionalModelMinSize
 			(if (> dataset_size 81)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -929,7 +929,7 @@
 										(lambda (or
 											(not (contains_value (get features_for_derivation_map feature) (current_value)))
 											(!= feature (get !derivedFeaturesMap (current_value)))
-											(contains_value (get !tsModelFeaturesMap "lag_features") (current_value))
+											(contains_value (get !tsFeaturesMap "lag_features") (current_value))
 										))
 										react_context_features
 									)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -300,10 +300,10 @@
 	)
 
 	;Wrapper method for computing regional model residuals that doesn't run the full method if the regional model is only of size 1.
-	;Computes regional residuals for the specified target_residual_feature provided a 'regional_model_cases_map' and 'features' to use as contexts.
+	;Computes regional residuals for the specified target_residual_feature provided a 'regional_cases_map' and 'features' to use as contexts.
 	;returns an assoc of target_residual_feature -> residual value
 	#!ComputeRegionalResiduals
-	(if (= 1 (size regional_model_cases_map))
+	(if (= 1 (size regional_cases_map))
 		(assoc
 			"residual_map"
 				;if regional model is of size of 1, residual cannot be calculated, therefore
@@ -354,8 +354,8 @@
 		(call !CalculateFeatureResiduals (assoc
 			features features
 			target_residual_feature target_residual_feature
-			case_ids (indices regional_model_cases_map)
-			regional_model_only (true)
+			case_ids (indices regional_cases_map)
+			regional_data_only (true)
 			compute_null_uncertainties (false)
 			use_case_weights use_case_weights
 			weight_feature weight_feature
@@ -479,7 +479,7 @@
 							))
 							;else just use all the case ids because the model size is <= num_samples or the model is small
 							(seq
-								(declare (assoc using_full_model (true) ))
+								(declare (assoc using_all_cases (true) ))
 								(call !AllCases)
 							)
 						)
@@ -489,7 +489,7 @@
 
 		;ensure features with nulls have cases that have values for computation but only if the selected cases were not conditioned
 		(if (and
-				(not using_full_model)
+				(not using_all_cases)
 				(not robust_residuals)
 				(not strict_case_ids)
 			)
@@ -828,8 +828,8 @@
 		))
 
 		;determine if any of the lists in feature_residuals_lists are too short (< 50 values), if so keep feature as needing to be resampled
-		;applicable only to global models (i.e. not regional_model_only)
-		(if (not regional_model_only)
+		;applicable only to global models (i.e. not regional_data_only)
+		(if (not regional_data_only)
 			(let
 				(assoc
 					num_valid_values_per_feature_map

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1181,7 +1181,7 @@
 
 										;else return expected value
 										(get
-											(call !ComputeModelNominalClassProbabilities (assoc feature feature))
+											(call !ComputeNominalClassProbabilities (assoc feature feature))
 											case_feature_value
 										)
 									)
@@ -1408,7 +1408,7 @@
 											;else there's no local model, return expected values
 											(if feature_is_nominal
 												;pull global probability for feature
-												(get (call !ComputeModelNominalClassProbabilities (assoc feature feature)) feature)
+												(get (call !ComputeNominalClassProbabilities (assoc feature feature)) feature)
 
 												;else get continuous expected value
 												(call !CalculateFeatureExpectedValue (assoc feature feature allow_nulls (true) ))

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -152,7 +152,7 @@
 			))
 		)
 
-		;synth a value for each feature, outputting a tuple of [residual, local_model_cases_map] for each feature value generated
+		;synth a value for each feature, outputting a tuple of [residual, local_cases_map] for each feature value generated
 		(declare (assoc
 			threshold_feature_residuals
 				;iterate over features, reacting to the growing context to generate new feature values, outputs the local residual
@@ -169,18 +169,18 @@
 								)
 							feature_is_ordinal (contains_index ordinal_features_map (current_value 1))
 							local_class_probabilities_map (null)
-							regional_model_context_features (list)
-							regional_model_context_values (list)
-							regional_model_cases_map (null)
+							regional_context_features (list)
+							regional_context_values (list)
+							regional_cases_map (null)
 							allow_nulls (!= (false) (get feature_bounds_map (list (current_value 2) "allow_null")))
 							cycle_length (get !cyclicFeaturesMap (current_value 1))
 							local_case_ids (list)
 							react_map (assoc)
-							local_model_cases_map (null)
+							local_cases_map (null)
 
 							action_feature_is_dependent_and_continuous (false)
 							action_feature_is_dependent (false)
-							local_model_case_values_map (assoc)
+							local_case_values_map (assoc)
 							edit_distance_code_feature (contains_value (list "json" "yaml" "amalgam") (get !editDistanceFeatureTypesMap (current_value 1)) )
 						)
 
@@ -204,9 +204,9 @@
 						;if RMR flag is specified, recalculate residuals around this particular reaction
 						(if (and
 								use_regional_residuals
-								(> (size regional_model_context_features) 0)
+								(> (size regional_context_features) 0)
 								;can't do regional residuals if only one feature is provided
-								(!= regional_model_context_features (list feature))
+								(!= regional_context_features (list feature))
 							)
 							(call !ComputeRegionalModelResidual)
 
@@ -231,9 +231,9 @@
 									(or
 										feature_is_nominal
 										feature_is_ordinal
-										(= 0 (size local_model_case_values_map))
+										(= 0 (size local_case_values_map))
 										;continuous features that have all the same value in the local space should only add laplace noise randomly based on desired_conviction
-										(not (apply "=" (values local_model_case_values_map)))
+										(not (apply "=" (values local_case_values_map)))
 									)
 									(call !GenerateFeatureValue)
 
@@ -302,11 +302,11 @@
 							context_values (append context_values new_feature_value)
 						))
 
-						;output a tuple of feature residual, local probabilities and local_model_cases_map for influences, if requested
+						;output a tuple of feature residual, local probabilities and local_cases_map for influences, if requested
 						(list
 							feature_residual
 							(if output_cap local_class_probabilities_map)
-							local_model_cases_map
+							local_cases_map
 						)
 					))
 
@@ -498,8 +498,8 @@
 	(seq
 		(if use_time_series_filter_query
 			(call !CreateAndCacheTimeSeriesFilterQuery (assoc
-				regional_model_context_features context_features
-				regional_model_context_values context_values
+				regional_context_features context_features
+				regional_context_values context_values
 			))
 		)
 
@@ -536,8 +536,8 @@
 		)
 
 		(assign (assoc
-			regional_model_context_features (append context_features feature)
-			regional_model_context_values (append context_values action_value)
+			regional_context_features (append context_features feature)
+			regional_context_values (append context_values action_value)
 		))
 
 		(if use_time_series_filter_query (call !CreateAndCacheTimeSeriesFilterQuery) )
@@ -549,8 +549,8 @@
 				(assign (assoc
 					react_map
 						(call !NearestRegionReact (assoc
-							context_features regional_model_context_features
-							context_values regional_model_context_values
+							context_features regional_context_features
+							context_values regional_context_values
 							action_feature feature
 							allow_nulls allow_nulls
 							hyperparam_map hyperparam_map
@@ -571,12 +571,12 @@
 
 				(assign (assoc
 					local_case_ids (get react_map "local_case_ids")
-					local_model_case_values_map (get react_map "local_model_case_values_map")
+					local_case_values_map (get react_map "local_case_values_map")
 				))
 			)
 		)
 
-		(if output_influential_cases (assign (assoc local_model_cases_map (get react_map "local_model_cases_map") )) )
+		(if output_influential_cases (assign (assoc local_cases_map (get react_map "local_cases_map") )) )
 	)
 
 	;Helper method for GenerateCase that selects a random case to pull an initial feature value at the start of synthing a case
@@ -603,8 +603,8 @@
 
 		(assign (assoc
 			action_value (retrieve_from_entity case_id feature)
-			regional_model_context_features action_features
-			regional_model_context_values (retrieve_from_entity case_id action_features)
+			regional_context_features action_features
+			regional_context_values (retrieve_from_entity case_id action_features)
 		))
 
 		(if use_time_series_filter_query (call !CreateAndCacheTimeSeriesFilterQuery) )
@@ -613,8 +613,8 @@
 		(assign (assoc
 			react_map
 				(call !NearestRegionReact (assoc
-					context_features regional_model_context_features
-					context_values regional_model_context_values
+					context_features regional_context_features
+					context_values regional_context_values
 					action_feature feature
 					allow_nulls allow_nulls
 					hyperparam_map hyperparam_map
@@ -634,11 +634,11 @@
 
 			(assign (assoc
 				local_case_ids (get react_map "local_case_ids")
-				local_model_case_values_map (get react_map "local_model_case_values_map")
+				local_case_values_map (get react_map "local_case_values_map")
 			))
 		)
 
-		(if output_influential_cases (assign (assoc local_model_cases_map (get react_map "local_model_cases_map") )) )
+		(if output_influential_cases (assign (assoc local_cases_map (get react_map "local_cases_map") )) )
 	)
 
 	;Helper method for GenerateCase to computes the regional model residual instead of the approximate one
@@ -657,8 +657,8 @@
 				(if action_feature_is_dependent
 					(call !ComputeDependentQueries (assoc
 						action_feature feature
-						context_features regional_model_context_features
-						context_values regional_model_context_values
+						context_features regional_context_features
+						context_values regional_context_values
 					))
 					(list)
 				)
@@ -686,7 +686,7 @@
 		(if use_time_series_filter_query (call !CreateAndCacheTimeSeriesFilterQuery) )
 
 		(assign (assoc
-			regional_model_cases_map
+			regional_cases_map
 				#!NearestRegionalResidualCasesQuery
 				(compute_on_contained_entities (append
 					(if ignore_case
@@ -701,8 +701,8 @@
 					cached_time_series_filter_query
 					(query_nearest_generalized_distance
 						(if (~ 0 k_parameter) (max k_parameter 30) k_parameter )
-						regional_model_context_features
-						regional_model_context_values
+						regional_context_features
+						regional_context_values
 						;if weight for action feature is 0 and using suprisal, ensure weight is set to avg feature weight
 						(if (and
 								(= 0 (get feature_weights feature))
@@ -724,17 +724,17 @@
 				))
 		))
 
-		;reduce dependent feature queries list if regional_model_cases_map is too small, as appropriate
-		;if regional_model_cases_map is too small to be viable, then remove dependent feature queries and recompute
-		;regional_model_cases_map until sufficiently many cases are returned
+		;reduce dependent feature queries list if regional_cases_map is too small, as appropriate
+		;if regional_cases_map is too small to be viable, then remove dependent feature queries and recompute
+		;regional_cases_map until sufficiently many cases are returned
 		(if action_feature_is_dependent
 			(while
 				(and
-					(< (size regional_model_cases_map) 3)
+					(< (size regional_cases_map) 3)
 					(> (size dependent_queries_list) 0)
 				)
 				(assign (assoc dependent_queries_list (trunc dependent_queries_list)))
-				(assign (assoc regional_model_cases_map (call !NearestRegionalResidualCasesQuery) ))
+				(assign (assoc regional_cases_map (call !NearestRegionalResidualCasesQuery) ))
 			)
 		)
 
@@ -744,8 +744,8 @@
 				(call !ExpandResidualValuesToUncertainty  (assoc
 					feature_residuals_map
 						(call !ComputeRegionalResiduals (assoc
-							regional_model_cases_map regional_model_cases_map
-							features regional_model_context_features
+							regional_cases_map regional_cases_map
+							features regional_context_features
 							target_residual_feature feature
 							ignore_case ignore_case
 						))
@@ -782,7 +782,7 @@
 			(seq
 				;TODO: 14477 - if residual is 0 for a continuous feature, we know that all values are same, skip this query
 				(assign (assoc
-					regional_model_cases_map
+					regional_cases_map
 						(compute_on_contained_entities (append
 							(if ignore_case
 								(query_not_in_entity_list (list ignore_case))
@@ -796,8 +796,8 @@
 							cached_time_series_filter_query
 							(query_nearest_generalized_distance
 								k_parameter
-								regional_model_context_features
-								regional_model_context_values
+								regional_context_features
+								regional_context_values
 								;if weight for action feature is 0 and using suprisal, ensure weight is set to avg feature weight
 								(if (and
 										(= 0 (get feature_weights feature))
@@ -822,10 +822,10 @@
 				))
 
 				(assign (assoc
-					local_model_case_values_map
+					local_case_values_map
 						(zip
-							(first regional_model_cases_map)
-							(last regional_model_cases_map)
+							(first regional_cases_map)
+							(last regional_cases_map)
 						)
 				))
 			)

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -208,10 +208,10 @@
 								;can't do regional residuals if only one feature is provided
 								(!= regional_context_features (list feature))
 							)
-							(call !ComputeRegionalModelResidual)
+							(call !AccurateRegionalResidual)
 
 							;else local and regional model feature gaps to approximate regional residual for the feature
-							(call !ApproximateRegionalModelResidual)
+							(call !ApproximateRegionalResidual)
 						)
 
 						;if the action features is dependent and continuous, store its min and max now that the residual has been calculated
@@ -642,7 +642,7 @@
 	)
 
 	;Helper method for GenerateCase to computes the regional model residual instead of the approximate one
-	#!ComputeRegionalModelResidual
+	#!AccurateRegionalResidual
 	(let
 		(assoc
 			feature_hyperparam_map
@@ -833,7 +833,7 @@
 	)
 
 	;Helper method for GenerateCase to compute the approximate regional model residual
-	#!ApproximateRegionalModelResidual
+	#!ApproximateRegionalResidual
 	(seq
 		;set residual to be the max(min feature gap/2, largest local model feature gap)
 		(if (and (not feature_is_nominal) (> (size local_case_ids) 1))

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -128,7 +128,7 @@
 									;treated like any other string.  Must use lambda in filter specifically to filter out (null) indices.
 									(filter
 										(lambda (!= (current_index) (null)))
-										(call !ComputeModelNominalClassProbabilities (assoc feature feature))
+										(call !ComputeNominalClassProbabilities (assoc feature feature))
 									)
 
 							))
@@ -302,7 +302,7 @@
 		)
 
 		(declare (assoc
-			global_class_probabilities_map (call !ComputeModelNominalClassProbabilities (assoc feature feature))
+			global_class_probabilities_map (call !ComputeNominalClassProbabilities (assoc feature feature))
 		))
 
 		;if there are less cases than (1-1/e)*classes, always use domain probabilities instead of global

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -3,12 +3,12 @@
 
 	;helper method to cache time series filter query for reuse in reacts into 'cached_time_series_filter_query'
 	;parameters:
-	; regional_model_context_features: list of context features
-	; regional_model_context_values: list of corresponding context values
+	; regional_context_features: list of context features
+	; regional_context_values: list of corresponding context values
 	#!CreateAndCacheTimeSeriesFilterQuery
 	(if (= 0 (size cached_time_series_filter_query))
 		(let
-			(assoc context_map (zip regional_model_context_features regional_model_context_values) )
+			(assoc context_map (zip regional_context_features regional_context_values) )
 			(if (contains_index context_map !tsTimeFeature)
 				(assign (assoc cached_time_series_filter_query (call !ComputeTimeSeriesFilterQuery) ))
 			)
@@ -396,95 +396,91 @@
 		(if (< desired_conviction 1)
 			(assign (assoc
 				local_class_probabilities_map
-					(let
-						(assoc local_model_has_zero_probability_classes (contains_value (values local_class_probabilities_map) 0))
+					;lowest conviction boundary is 0, and therefore lowest probabliity for all non-zero classes is 0
+					(if (contains_value (values local_class_probabilities_map) 0)
+						(let
+							(assoc zero_probability_classes_map (filter (lambda (= (current_value) 0)) local_class_probabilities_map))
+							(map
+								(lambda (let
+									(assoc
+										;all 0-probability classes have a 1/N probability where N is the count of all '0-probability' classes
+										zero_prob_class_zero_conv_probability_value (/ 1 (size zero_probability_classes_map))
+									)
 
-						;lowest conviction boundary is 0, and therefore lowest probabliity for all non-zero classes is 0
-						(if local_model_has_zero_probability_classes
-							(let
-								(assoc zero_probability_classes_map (filter (lambda (= (current_value) 0)) local_class_probabilities_map))
-								(map
-									(lambda (let
-										(assoc
-											;all 0-probability classes have a 1/N probability where N is the count of all '0-probability' classes
-											zero_prob_class_zero_conv_probability_value (/ 1 (size zero_probability_classes_map))
-										)
+									(if (not (contains_index zero_probability_classes_map (current_index)))
+										;the selected probability has a zero conviction probability value of 0, so just scale it directly
+										(* (current_value) desired_conviction)
 
-										(if (not (contains_index zero_probability_classes_map (current_index)))
-											;the selected probability has a zero conviction probability value of 0, so just scale it directly
-											(* (current_value) desired_conviction)
+										;probability for classes that had 0 probability approaches 0 as desired_conviction approaches 1
+										;and approaches zero_prob_class_zero_conv_probability_value as desired_conviction approaches 0
+										(- zero_prob_class_zero_conv_probability_value (* zero_prob_class_zero_conv_probability_value desired_conviction))
+									)
+								))
+								local_class_probabilities_map
+							)
+						)
 
-											;probability for classes that had 0 probability approaches 0 as desired_conviction approaches 1
-											;and approaches zero_prob_class_zero_conv_probability_value as desired_conviction approaches 0
-											(- zero_prob_class_zero_conv_probability_value (* zero_prob_class_zero_conv_probability_value desired_conviction))
-										)
-									))
-									local_class_probabilities_map
-								)
+						;else compute entropy to calculate the lowest conviction bound
+						(let
+							(assoc
+								;compute the entropy (expected surprisal) of the current set of probabilities for the action class
+								entropy_of_local_probabilities (entropy (values local_class_probabilities_map))
+								lowest_probability (apply "min" (values local_class_probabilities_map))
 							)
 
-							;else compute entropy to calculate the lowest conviction bound
-							(let
-								(assoc
-									;compute the entropy (expected surprisal) of the current set of probabilities for the action class
-									entropy_of_local_probabilities (entropy (values local_class_probabilities_map))
-									lowest_probability (apply "min" (values local_class_probabilities_map))
-								)
+							(declare (assoc
+								lowest_conviction_boundary
+									;entropy is zero if there's only one class in the local probabilities. then just set the boundary
+									;to 1 to just output the probability of this one class
+									(if (= 0 entropy_of_local_probabilities)
+										1
 
-								(declare (assoc
-									lowest_conviction_boundary
-										;entropy is zero if there's only one class in the local probabilities. then just set the boundary
-										;to 1 to just output the probability of this one class
-										(if (= 0 entropy_of_local_probabilities)
-											1
+										(/ entropy_of_local_probabilities (- (log lowest_probability )))
+									)
 
-											(/ entropy_of_local_probabilities (- (log lowest_probability )))
+								lowest_probability_classes_map (filter (lambda (= (current_value) lowest_probability )) local_class_probabilities_map)
+							))
+
+							(map
+								(lambda (let
+									(assoc
+										;all non-lowest classes have lowest probabilities of 0, all lowest are 1/N where N is the count of 'all lowest'
+										boundary_probability (/ 1 (size lowest_probability_classes_map))
+									)
+
+									(if (<= desired_conviction lowest_conviction_boundary)
+										(if (contains_index lowest_probability_classes_map (current_index))
+											boundary_probability
+
+											0
 										)
 
-									lowest_probability_classes_map (filter (lambda (= (current_value) lowest_probability )) local_class_probabilities_map)
-								))
+										;else need to linearly interpolate between lowest_conviction_boundary and 1
+										(let
+											(assoc
+												;invert and normalize the conviction value to be between 1 and 0:
+												;value approaches 1 as as conviction approaches the lowest boundary probability
+												;and approaches 0 as conviction approaches 1
+												inverted_one_to_boundary_conviction_value
+													(/ (- 1 desired_conviction) (- 1 lowest_conviction_boundary))
+											)
 
-								(map
-									(lambda (let
-										(assoc
-											;all non-lowest classes have lowest probabilities of 0, all lowest are 1/N where N is the count of 'all lowest'
-											boundary_probability (/ 1 (size lowest_probability_classes_map))
-										)
-
-										(if (<= desired_conviction lowest_conviction_boundary)
 											(if (contains_index lowest_probability_classes_map (current_index))
-												boundary_probability
-
-												0
-											)
-
-											;else need to linearly interpolate between lowest_conviction_boundary and 1
-											(let
-												(assoc
-													;invert and normalize the conviction value to be between 1 and 0:
-													;value approaches 1 as as conviction approaches the lowest boundary probability
-													;and approaches 0 as conviction approaches 1
-													inverted_one_to_boundary_conviction_value
-														(/ (- 1 desired_conviction) (- 1 lowest_conviction_boundary))
-												)
-
-												(if (contains_index lowest_probability_classes_map (current_index))
-													;lowest probability classes increase their probability as they approach boundary_probability
-													;original_low_prob + (boundary_probability - original_low_prob) * inverted_conv_value
-													(+ (current_value)
-														(* (- boundary_probability  (current_value))
-															inverted_one_to_boundary_conviction_value
-														)
+												;lowest probability classes increase their probability as they approach boundary_probability
+												;original_low_prob + (boundary_probability - original_low_prob) * inverted_conv_value
+												(+ (current_value)
+													(* (- boundary_probability  (current_value))
+														inverted_one_to_boundary_conviction_value
 													)
-
-													;original_prob - original_prob * inverted_conv_value
-													(- (current_value) (* (current_value) inverted_one_to_boundary_conviction_value))
 												)
+
+												;original_prob - original_prob * inverted_conv_value
+												(- (current_value) (* (current_value) inverted_one_to_boundary_conviction_value))
 											)
 										)
-									))
-									local_class_probabilities_map
-								)
+									)
+								))
+								local_class_probabilities_map
 							)
 						)
 					)
@@ -576,8 +572,8 @@
 					(not feature_is_ordinal)
 					(< (rand) (pow 2.718281828 (/ -1.693147181 desired_conviction)))
 				)
-			local_model_cases_map (assoc)
-			local_model_case_values_map (assoc)
+			local_cases_map (assoc)
+			local_case_values_map (assoc)
 
 			feature_weights
 				(if (= (null) (get hyperparam_map "featureMdaMap"))
@@ -611,7 +607,7 @@
 		)
 
 		(declare (assoc
-			local_model_cases_tuple
+			local_data_cases_tuple
 				#!NearestRegionalCasesQuery
 				(compute_on_contained_entities
 					(append
@@ -667,8 +663,8 @@
 			))
 		)
 
-		;if local_model_cases_tuple is too small to be viable, then remove dependent feature queries and recompute
-		;local_model_cases_tuple until sufficiently many cases are returned
+		;if local_data_cases_tuple is too small to be viable, then remove dependent feature queries and recompute
+		;local_data_cases_tuple until sufficiently many cases are returned
 		(if action_feature_is_dependent
 			(if action_feature_is_dependent_and_continuous
 				;continuous values should have at least 3 values for privacy when it should be generating new cases
@@ -676,23 +672,23 @@
 				(while
 					(and
 						(<
-							(size (first local_model_cases_tuple))
+							(size (first local_data_cases_tuple))
 							(if (= "no" generate_new_cases) 1 3)
 						)
 						(> (size dependent_queries_list) 0)
 					)
 					(assign (assoc dependent_queries_list (trunc dependent_queries_list)))
-					(assign (assoc local_model_cases_tuple (call !NearestRegionalCasesQuery) ))
+					(assign (assoc local_data_cases_tuple (call !NearestRegionalCasesQuery) ))
 				)
 
 				;nominals need to have at least one value
 				(while
 					(and
-						(= (size (first local_model_cases_tuple)) 0)
+						(= (size (first local_data_cases_tuple)) 0)
 						(> (size dependent_queries_list) 0)
 					)
 					(assign (assoc dependent_queries_list (trunc dependent_queries_list)))
-					(assign (assoc local_model_cases_tuple (call !NearestRegionalCasesQuery) ))
+					(assign (assoc local_data_cases_tuple (call !NearestRegionalCasesQuery) ))
 				)
 			)
 		)
@@ -700,46 +696,46 @@
 		;if approximating regional residual for continuous, need to truncate the regional model to output probabilities for local only
 		(if approximate_residual
 			(seq
-				(assign (assoc regional_case_ids (first local_model_cases_tuple) ))
+				(assign (assoc regional_case_ids (first local_data_cases_tuple) ))
 
 				;keep only the local k closest case ids
 				(assign (assoc local_case_ids (trunc regional_case_ids local_k)))
 
 				;keep only the local k cases in the map
 				(assign (assoc
-					local_model_cases_map (zip local_case_ids (trunc (get local_model_cases_tuple 1) local_k))
-					local_model_case_values_map (zip local_case_ids (trunc (last local_model_cases_tuple) local_k))
+					local_cases_map (zip local_case_ids (trunc (get local_data_cases_tuple 1) local_k))
+					local_case_values_map (zip local_case_ids (trunc (last local_data_cases_tuple) local_k))
 				))
 			)
 
 			;else the local case_ids are the same as the indices of local model map
 			(assign (assoc
-				local_case_ids (first local_model_cases_tuple)
-				local_model_cases_map (zip (first local_model_cases_tuple) (get local_model_cases_tuple 1))
-				local_model_case_values_map (zip (first local_model_cases_tuple) (last local_model_cases_tuple))
+				local_case_ids (first local_data_cases_tuple)
+				local_cases_map (zip (first local_data_cases_tuple) (get local_data_cases_tuple 1))
+				local_case_values_map (zip (first local_data_cases_tuple) (last local_data_cases_tuple))
 			))
 		)
 
-		(declare (assoc local_cases_total_weight (apply "+" (values local_model_cases_map))))
+		(declare (assoc local_cases_total_weight (apply "+" (values local_cases_map))))
 
 		;normalize the weights in the local model
 		(assign (assoc
-			local_model_cases_map
+			local_cases_map
 				;if has perfect matches, set their weight to 1, others to 0
 				(if (= .infinity local_cases_total_weight)
 					(map
 						(lambda (if (= .infinity (current_value)) 1 0))
-						local_model_cases_map
+						local_cases_map
 					)
 
 					;all equally terrible, set to even weight
 					(= 0 local_cases_total_weight)
-					(map (lambda (/ 1 (size local_model_cases_map))) local_model_cases_map)
+					(map (lambda (/ 1 (size local_cases_map))) local_cases_map)
 
 					;else just scale the weights
 					(map
 						(lambda (/ (current_value) local_cases_total_weight))
-						local_model_cases_map
+						local_cases_map
 					)
 				)
 		))
@@ -755,8 +751,8 @@
 									neighbor_id_to_values_map
 										;only keep perfect match neighbors that have a weight of 1
 										(filter
-											(lambda (= 1 (get local_model_cases_map (current_index))) )
-											local_model_case_values_map
+											(lambda (= 1 (get local_cases_map (current_index))) )
+											local_case_values_map
 										)
 								)
 
@@ -776,12 +772,12 @@
 								(lambda (+ (current_value 1) (current_value)))
 								;feature value for each case
 								(map
-									(lambda (get local_model_case_values_map (current_value)))
-									(indices local_model_cases_map)
+									(lambda (get local_case_values_map (current_value)))
+									(indices local_cases_map)
 								)
 
 								;weights of corresponding case
-								(values local_model_cases_map)
+								(values local_cases_map)
 							)
 						)
 				)
@@ -791,16 +787,16 @@
 					;returns the highest weighted categorical value
 					"action_value" (first (index_max categorical_value_weights_map))
 					"categorical_value_weights_map" categorical_value_weights_map
-					"local_model_cases_map" local_model_cases_map
+					"local_cases_map" local_cases_map
 				)
 			)
 
 			;else continuous action feature output
 			(assoc
 				;select action value by weighted probability using the weight of each cases's influence as the probability
-				"action_value" (get local_model_case_values_map (rand local_model_cases_map))
-				"local_model_case_values_map" (if output_continuous_case_values local_model_case_values_map {})
-				"local_model_cases_map" local_model_cases_map
+				"action_value" (get local_case_values_map (rand local_cases_map))
+				"local_case_values_map" (if output_continuous_case_values local_case_values_map {})
+				"local_cases_map" local_cases_map
 				"regional_case_ids" regional_case_ids
 				"local_case_ids" local_case_ids
 			)

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -27,8 +27,7 @@
 			closest_case (null)
 			dist_to_closest_case (null)
 
-			local_model_cases_map (assoc)
-			local_model_cases_tuple (list)
+			local_data_cases_tuple (list)
 			threshold_distance 0
 			closest_case_values (list)
 			ignore_case (if leave_case_out preserve_case_id)
@@ -163,7 +162,7 @@
 
 				;find the closest case
 				(assign (assoc
-					local_model_cases_tuple
+					local_data_cases_tuple
 						(compute_on_contained_entities (append
 							(if ignore_case
 								(query_not_in_entity_list (list ignore_case))
@@ -197,12 +196,12 @@
 
 			;set closest case to be the one with the smallest distance
 			(assign (assoc
-				closest_case (first (first local_model_cases_tuple))
+				closest_case (first (first local_data_cases_tuple))
 				dist_to_closest_case
 					;if constraint_function_failed, then force distance to closest case to be 0 to fast-track the retries
 					(if constraint_function_failed
 						0
-						(first (last local_model_cases_tuple))
+						(first (last local_data_cases_tuple))
 					)
 			))
 
@@ -278,8 +277,8 @@
 									;look for extra equidistance cases only if the distance between last two cases are the same (within dbl_precision_epsilon)
 									(if (<=
 											(-
-												(last (last local_model_cases_tuple))
-												(get (last local_model_cases_tuple) (- (size (last local_model_cases_tuple)) 2))
+												(last (last local_data_cases_tuple))
+												(get (last local_data_cases_tuple) (- (size (last local_data_cases_tuple)) 2))
 											)
 											dbl_precision_epsilon
 										)
@@ -290,10 +289,10 @@
 											)
 											;find any cases that are within dbl_precision_epsilon of the farthest case in the local space,
 											;ignoring the cases that have alraedy been found
-											(query_not_in_entity_list (first local_model_cases_tuple))
+											(query_not_in_entity_list (first local_data_cases_tuple))
 											(query_within_generalized_distance
 												;dbl_precision_epsilon for defining whether two values are equal within acceptable precision
-												(+ dbl_precision_epsilon (last (last local_model_cases_tuple)) )
+												(+ dbl_precision_epsilon (last (last local_data_cases_tuple)) )
 												(if has_novel_substitions non_novel_context_features context_features)
 												(if has_novel_substitions non_novel_context_values context_numeric_values)
 												feature_weights
@@ -316,12 +315,12 @@
 							(if
 								(<
 									dist_to_closest_case
-									(call !QueryLocalModelMinDistanceContribution (assoc
+									(call !QueryLocalDataMinDistance (assoc
 										feature_labels (if has_novel_substitions non_novel_context_features context_features)
 										entity_ids_to_compute
 											(if extra_equidistant_cases
-												(append (first local_model_cases_tuple) extra_equidistant_cases)
-												(trunc (first local_model_cases_tuple))
+												(append (first local_data_cases_tuple) extra_equidistant_cases)
+												(trunc (first local_data_cases_tuple))
 											)
 										use_feature_deviations (false)
 										dbl_precision_epsilon dbl_precision_epsilon
@@ -448,7 +447,7 @@
 					feature (null)
 					weight_feature weight_feature
 				))
-			local_model_cases_tuple (null)
+			local_data_cases_tuple (null)
 		)
 		(declare (assoc
 			feature_weights (get hyperparam_map "featureWeights")
@@ -466,12 +465,12 @@
 		(call !FindClosestCasesForUniquenessCheck (assoc generate_attempt 2))
 
 		;if distance to closest case is 0 return true because this case is a duplicate,
-		(if (= 0 (first (last local_model_cases_tuple)) )
+		(if (= 0 (first (last local_data_cases_tuple)) )
 			(conclude (true))
 		)
 
 		(declare (assoc
-			dist_to_closest_case (first (last local_model_cases_tuple))
+			dist_to_closest_case (first (last local_data_cases_tuple))
 			has_dupes (false)
 		))
 

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -359,7 +359,7 @@
 			(let
 				(assoc
 					new_features (remove (zip features) !trainedFeatures)
-					model_size (+ num_cases (size new_case_ids))
+					dataset_size (+ num_cases (size new_case_ids))
 				)
 
 				(accum (assoc trained_instance_count (size new_case_ids)))
@@ -1371,7 +1371,7 @@
 				))
 		)
 		(declare (assoc
-			model_size (call !GetNumTrainingCases)
+			dataset_size (call !GetNumTrainingCases)
 			weight_feature (if !autoAblationEnabled !autoAblationWeightFeature ".case_weight")
 			feature_weights (get hyperparam_map "featureWeights")
 			feature_deviations  (get hyperparam_map "featureDeviations")

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -405,7 +405,7 @@
 					)
 				)
 
-				(call !UpdateRegionalModelMinSize)
+				(call !UpdateRegionalMinSize)
 
 				;update cached data properties such as has_nulls, null ratios, marginal stats, average model case entropies, etc
 				(call !ClearCachedDataProperties)

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -102,7 +102,7 @@
 		;get time series derived features list, if applicable
 		(if (and (= (null) derived_features) (!= (null) !tsTimeFeature) )
 			(assign (assoc
-				derived_features (get !tsModelFeaturesMap "ts_derived_features")
+				derived_features (get !tsFeaturesMap "ts_derived_features")
 			))
 		)
 
@@ -1278,15 +1278,15 @@
 		;model has changed so clear out these cached value
 		#!ClearCachedCountsAndEntropies
 		(assign_to_entities (assoc
-			!averageModelCaseEntropyAddition (null)
-			!averageModelCaseEntropyRemoval (null)
+			!averageCaseEntropyAddition (null)
+			!averageCaseEntropyRemoval (null)
 			!storedCaseConvictionsFeatureAddition (null)
-			!averageModelCaseDistanceContribution (null)
+			!averageCaseDistanceContribution (null)
 			!staleOrdinalValuesCount (true)
 			!nominalClassProbabilitiesMap (assoc)
 			!expectedValuesMap (assoc)
 			!featureMarginalStatsMap (assoc)
-			!tsModelFeaturesMap (set !tsModelFeaturesMap ["minimum_time_bound"] (null))
+			!tsModelFeaturesMap (set !tsFeaturesMap ["minimum_time_bound"] (null))
 		))
 	)
 

--- a/howso/train_ts_ablation.amlg
+++ b/howso/train_ts_ablation.amlg
@@ -169,8 +169,8 @@
 			progress_features [".series_progress" ".series_index" ".series_progress_delta"]
 			ts_series_length_limit (retrieve_from_entity "!tsSeriesLimitLength")
 			time_feature_index (get feature_index_map !tsTimeFeature)
-			id_features (get !tsModelFeaturesMap "series_id_features")
-			id_indices (unzip feature_index_map (get !tsModelFeaturesMap "series_id_features"))
+			id_features (get !tsFeaturesMap "series_id_features")
+			id_indices (unzip feature_index_map (get !tsFeaturesMap "series_id_features"))
 			original_features (replace features)
 		))
 		(declare (assoc

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -452,4 +452,38 @@
 			session_entities
 		)
 	)
+"97.2.6"
+	(assign_to_entities (assoc
+		!averageCaseEntropyAddition
+			(if (contains_index import_metadata_map "!averageModelCaseEntropyAddition")
+				(get import_metadata_map "!averageModelCaseEntropyAddition")
+				!averageCaseEntropyAddition
+			)
+		!averageCaseEntropyRemoval
+			(if (contains_index import_metadata_map "!averageModelCaseEntropyRemoval")
+				(get import_metadata_map "!averageModelCaseEntropyRemoval")
+				!averageCaseEntropyRemoval
+			)
+		!averageCaseDistanceContribution
+			(if (contains_index import_metadata_map "!averageModelCaseDistanceContribution")
+				(get import_metadata_map "!averageModelCaseDistanceContribution")
+				!averageCaseDistanceContribution
+			)
+		!minAblatementSize
+			(if (contains_index import_metadata_map "!minAblatementModelSize")
+				(get import_metadata_map "!minAblatementModelSize")
+				!minAblatementSize
+			)
+		!tsFeaturesMap
+			(if (contains_index import_metadata_map "!tsModelFeaturesMap")
+				(get import_metadata_map "!tsModelFeaturesMap")
+				!tsFeaturesMap
+			)
+		!regionalMinSize
+			(if (contains_index import_metadata_map "!regionalModelMinSize")
+				(get import_metadata_map "!regionalModelMinSize")
+				"!regionalMinSize"
+			)
+	))
+
 ))

--- a/unit_tests/ut_h_ablate.amlg
+++ b/unit_tests/ut_h_ablate.amlg
@@ -126,7 +126,7 @@
 	(call exit_if_failures (assoc msg "Accumulate data mass"))
 
 	(declare (assoc
-		model_size
+		dataset_size
 			(get
 				(call_entity "howso" "get_num_training_cases")
 				(list 1 "payload" "count")
@@ -134,7 +134,7 @@
 	))
 	(print "model size after training and ablating is less than total train data: ")
     (call assert_same (assoc
-		obs model_size
+		obs dataset_size
 		exp 9
 	))
 

--- a/unit_tests/ut_h_basic_ablation.amlg
+++ b/unit_tests/ut_h_basic_ablation.amlg
@@ -81,7 +81,7 @@
 		conviction_upper_threshold 0.9
 		min_num_cases 0
 	))
-	(assign (assoc model_size (call !get_num_cases) ))
+	(assign (assoc dataset_size (call !get_num_cases) ))
 
 	;this should not be added to the model b/c conviction of this case is > 0.9
 	(call_entity "howso" "train" (assoc
@@ -92,7 +92,7 @@
 
 	(print "Unchanged model size after threshold filter: ")
 	(call assert_same (assoc
-		exp model_size
+		exp dataset_size
 		obs (call !get_num_cases)
 	))
 
@@ -114,14 +114,14 @@
 	))
 	(print "New model size after threshold filter: ")
 	(call assert_same (assoc
-		exp (+ 1 model_size)
+		exp (+ 1 dataset_size)
 		obs (call !get_num_cases)
 	))
 
 	(call exit_if_failures (assoc msg "Conviction upper threshold"))
 
 ;VERIFY ABSOLUTE THRESHOLD
-	(assign (assoc model_size (call !get_num_cases) ))
+	(assign (assoc dataset_size (call !get_num_cases) ))
 
 	(call_entity "howso" "set_auto_ablation_params" (assoc
 		auto_ablation_enabled (true)
@@ -137,7 +137,7 @@
 	))
 	(print "Unchanged model size after absolute threshold filter: ")
 	(call assert_same (assoc
-		exp model_size
+		exp dataset_size
 		obs (call !get_num_cases)
 	))
 
@@ -156,7 +156,7 @@
 	))
 	(print "New model size after absolute threshold filter: ")
 	(call assert_same (assoc
-		exp (+ 1 model_size)
+		exp (+ 1 dataset_size)
 		obs (call !get_num_cases)
 	))
 
@@ -164,7 +164,7 @@
 
 
 ;VERIFY RELATIVE THRESHOLD
-	(assign (assoc model_size (call !get_num_cases) ))
+	(assign (assoc dataset_size (call !get_num_cases) ))
 
 	(call_entity "howso" "set_auto_ablation_params" (assoc
 		auto_ablation_enabled (true)
@@ -181,7 +181,7 @@
 	))
 	(print "Unchanged model size after relative threshold filter: ")
 	(call assert_same (assoc
-		exp model_size
+		exp dataset_size
 		obs (call !get_num_cases)
 	))
 
@@ -201,7 +201,7 @@
 	))
 	(print "New model size after relative threshold filter: ")
 	(call assert_same (assoc
-		exp (+ 1 model_size)
+		exp (+ 1 dataset_size)
 		obs (call !get_num_cases)
 	))
 

--- a/unit_tests/ut_h_box_conviction.amlg
+++ b/unit_tests/ut_h_box_conviction.amlg
@@ -139,7 +139,7 @@
 	(print "\nnew case conviction for point at 3,0 with x as a cyclic: ")
 	(call assert_approximate (assoc percent 0.00001 obs (get result (list "familiarity_conviction_addition" 0)) exp 0.111692205))
 
-	(print "combined_model_average_distance_contribution:" )
+	(print "combined_average_distance_contribution:" )
 	(call assert_approximate (assoc percent 0.00001 obs (get result (list "combined_model_average_distance_contribution" 0)) exp 0.8828427124))
 
 	(print "distance_contribution: " )

--- a/unit_tests/ut_h_react_distance_ratio.amlg
+++ b/unit_tests/ut_h_react_distance_ratio.amlg
@@ -62,7 +62,7 @@
 	;next we train a non-duplicate case into the model
 
 	;since the distance ratio computation uses entity distance contributions
-	;rather than raw distance, this should mean that the local_model_min_distance
+	;rather than raw distance, this should mean that the local_data_min_distance
 	;(the denominator of the distance ratio) will not be zero
 	(call_entity "howso" "train" (assoc
 		features context_features
@@ -117,7 +117,7 @@
 	;the values produced by react are identical to ones produced by manually
 	;querying the model
 	(declare (assoc
-			local_model_min_distance
+			local_data_min_distance
 				(first (values
 					(compute_on_contained_entities
 						"howso"
@@ -242,7 +242,7 @@
 		(print "result_too_close math check: ")
 		(call assert_same (assoc
 			obs result_too_close_dist_ratio
-			exp (/ result_too_close_distance local_model_min_distance)
+			exp (/ result_too_close_distance local_data_min_distance)
 		))
 		(print "result_too_close ratio is less than 1: ")
 		(call assert_true (assoc
@@ -259,7 +259,7 @@
 		(print "result_just_right math check: ")
 		(call assert_same (assoc
 			obs result_just_right_dist_ratio
-			exp (/ result_just_right_distance local_model_min_distance)
+			exp (/ result_just_right_distance local_data_min_distance)
 		))
 		(print "result_just_right ratio is equal to 1: ")
 		(call assert_same (assoc
@@ -277,7 +277,7 @@
 		(print "result_very_private math check: ")
 		(call assert_same (assoc
 			obs result_very_private_dist_ratio
-			exp (/ result_very_private_distance local_model_min_distance))
+			exp (/ result_very_private_distance local_data_min_distance))
 		)
 		(print "result_very_private ratio is greater than 1: ")
 		(call assert_true (assoc

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -223,7 +223,7 @@
 	))
 
 	(print "Time Series Model Features are correctly configured:\n")
-	(assign (assoc result (call_entity "howso" "debug_label" (assoc label "!tsModelFeaturesMap")) ))
+	(assign (assoc result (call_entity "howso" "debug_label" (assoc label "!tsFeaturesMap")) ))
 	(map
 		(lambda (seq
 			(print "Verifying " (current_index) " :")

--- a/unit_tests/ut_h_train_react.amlg
+++ b/unit_tests/ut_h_train_react.amlg
@@ -28,10 +28,10 @@
 
 ;VERIFY TRAINING AND MODEL SIZE
 	(print "model size (trains on all nulls): ")
-	(declare (assoc model_size (call_entity "howso" "get_num_training_cases")))
+	(declare (assoc dataset_size (call_entity "howso" "get_num_training_cases")))
 	(call assert_same (assoc
 		exp 5
-		obs (get model_size (list 1 "payload" "count"))
+		obs (get dataset_size (list 1 "payload" "count"))
 	))
 
 	(print "trained features: ")


### PR DESCRIPTION
- no external API changes
- removed usage of the term 'model' from most internal methods, parameters, attributes and variables that did not affect the API (method parameters and outputs were not changed)