### PR TITLE
23229: Fixes an issue when using the "boundary_values_action_outcome" detail with features whose values are encoded

### DIFF
--- a/howso/boundary_values.amlg
+++ b/howso/boundary_values.amlg
@@ -11,6 +11,12 @@
 			boundary_value_features (get details "boundary_value_context_features")
 		)
 
+		(if (size !encodingNeededFeaturesSet)
+			(assign (assoc
+				boundary_action_condition (call !EncodeConditionMap (assoc condition boundary_action_condition))
+			))
+		)
+
 		(declare (assoc
 			feature_deviations  (get hyperparam_map "featureDeviations")
 			feature_weights (get hyperparam_map "featureWeights")

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -421,6 +421,7 @@
 		(if (size !encodingNeededFeaturesSet)
 			(assign (assoc
 				condition
+					#!EncodeConditionMap
 					(map
 						(lambda
 							;if the features in the condition need encoding (e.g., booleans, string ordinals), look up the encoded value and


### PR DESCRIPTION
When attempting to specify a boundary condition for a feature whose values are encoded internally, the feature values given by the user were *not* encoded similarly, making the boundary search process fail perpetually.