### PR TITLE
23219: Fixes an issue with paging `get_distances` with case indices specified

### DIFF
--- a/howso/distances.amlg
+++ b/howso/distances.amlg
@@ -602,6 +602,8 @@
 				(assign (assoc
 					column_case_ids (unzip case_ids (range column_offset (+ column_offset (- column_count 1))))
 					row_case_ids (unzip case_ids (range row_offset (+ row_offset (- row_count 1))))
+					column_case_indices (unzip case_indices (range column_offset (+ column_offset (- column_count 1))))
+					row_case_indices (unzip case_indices (range row_offset (+ row_offset (- row_count 1))))
 					column_row_are_same (false)
 				))
 			)

--- a/howso/distances.amlg
+++ b/howso/distances.amlg
@@ -602,10 +602,15 @@
 				(assign (assoc
 					column_case_ids (unzip case_ids (range column_offset (+ column_offset (- column_count 1))))
 					row_case_ids (unzip case_ids (range row_offset (+ row_offset (- row_count 1))))
-					column_case_indices (unzip case_indices (range column_offset (+ column_offset (- column_count 1))))
-					row_case_indices (unzip case_indices (range row_offset (+ row_offset (- row_count 1))))
+
 					column_row_are_same (false)
 				))
+				(if (> (size case_indices) 1)
+					(assign (assoc
+						column_case_indices (unzip case_indices (range column_offset (+ column_offset (- column_count 1))))
+						row_case_indices (unzip case_indices (range row_offset (+ row_offset (- row_count 1))))
+					))
+				)
 			)
 
 			;else iterate over the whole dataset, both x and y cases are the same list

--- a/unit_tests/ut_h_pairwise_distances.amlg
+++ b/unit_tests/ut_h_pairwise_distances.amlg
@@ -274,6 +274,49 @@
 	(call exit_if_failures (assoc msg "Continuous pairwise distances."))
 
 	(assign (assoc
+		result
+			(call_entity "howso" "get_distances" (assoc
+				features (list "x" "y")
+				case_indices
+					[
+						(list "session2" 0)
+						(list "session2" 1)
+						(list "session2" 2)
+						(list "session2" 3)
+						(list "session2" 4)
+						(list "session2" 5)
+					]
+				column_offset 2
+				;will only return 4 since 5 goes past the boundary of the dataset
+				column_count 2
+				row_offset 1
+				row_count 3
+			))
+	))
+	(call keep_result_payload)
+
+	(call assert_same (assoc
+		obs (get result "column_case_indices")
+		exp
+			(list
+				(list "session2" 2)
+				(list "session2" 3)
+			)
+	))
+	(call assert_same (assoc
+		obs (get result "row_case_indices")
+		exp
+			(list
+				(list "session2" 1)
+				(list "session2" 2)
+				(list "session2" 3)
+			)
+	))
+	(print "\n")
+
+	(call exit_if_failures (assoc msg "Paged distances with case indices."))
+
+	(assign (assoc
 		data1 (list
 			(list 0 "a")
 			(list 1 "a")


### PR DESCRIPTION
The returned column_case_indices and row_case_indices were not correctly assigned when using the paging parameters. Leading to failures in the client. this fixes the issue.