### PR TITLE
23269: Fixes missing use_aggregation_based_differential_privacy flag from react_series_stationary

### DIFF
--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -305,7 +305,7 @@
 		(assoc features features)
 
 		(declare (assoc
-			reduce_memory_usage (> (size features) 50)
+			reduce_memory_usage (> (size features) 250)
 		))
 
 		;for each feature, create a list, also length of features, where each column value is the mda

--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -305,7 +305,7 @@
 		(assoc features features)
 
 		(declare (assoc
-			reduce_memory_usage (> (size features) 250)
+			reduce_memory_usage (> (size features) 50)
 		))
 
 		;for each feature, create a list, also length of features, where each column value is the mda
@@ -346,13 +346,13 @@
 									;slower method that does not increase memory usage
 									(declare (assoc
 										with_feature_residuals
-											(filter (map
-												(lambda (get feature_residuals_lists [mda_feature_index (current_value 1)]) )
+											(filter (unzip
+												(replace (get feature_residuals_lists mda_feature_index))
 												case_indices_with_feature
 											))
 										without_feature_residuals
-											(filter (map
-												(lambda (get feature_residuals_lists [mda_feature_index (current_value 1)]) )
+											(filter (unzip
+												(replace (get feature_residuals_lists mda_feature_index))
 												case_indices_without_feature
 											))
 									))

--- a/howso/react_series_stationary.amlg
+++ b/howso/react_series_stationary.amlg
@@ -36,6 +36,10 @@
 			;	larger values will increase the variance (or creativity) of the generated case from the existing model
 			;	smaller values will decrease the variance (or creativity) of the generated case from the existing model
 			desired_conviction (null)
+			;{type "boolean"}
+			;flag, if set to true this changes generative output to use aggregation instead of selection before adding noise.
+			;By default generative output uses selection.
+			use_aggregation_based_differential_privacy (false)
 			;{type "assoc" additional_indices {ref "GoalFeatures"}}
 			; assoc of :
 			;		{ feature : { "goal" : "min"/"max", "value" : value }}


### PR DESCRIPTION
also refactor the memory reducing approach to computing feature weights to use an even faster and less memory consuming approach.