### PR TITLE
22983: Adds support for goal features and goal dependent features to react_aggregate, MINOR

### DIFF
--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -39,6 +39,10 @@
 	; num: number of samples to return
 	; rand_seed: optional random seed
 	; case_weight_feature: optional, if provided will use this feature to do case weighted sampling
+	; query_conditions: a set of queries that can limits the available cases for sampling
+	; goal_features_map: the standard goal features map. When specified, will compute an extra query for
+	;	each originally sampled case which will select it's nearest case that optimizes the goal. Leaving
+	;	the number of desired cases that maximizes the goal but still is sampled randomly from the model.
 	#!SampleCases
 	(declare
 		(assoc
@@ -46,6 +50,7 @@
 			rand_seed (null)
 			case_weight_feature (null)
 			query_conditions (list)
+			goal_features_map (assoc)
 		)
 		(if (!= (null) num)
 			(contained_entities (append
@@ -61,6 +66,46 @@
 				query_conditions
 				(query_sample (call !GetNumTrainingCases) case_weight_feature (rand))
 			))
+		)
+	)
+
+	;for each case id given, gets its influential cases and selects the case that optimizes the goal
+	;parameters:
+	; goal_features_map: the map of goal features and their specified goals (value/max/min)
+	; case_ids: the originally sampled case_ids
+	; query_conditions: a set of queries that can limits the available cases for selection
+	#!SampleCasesForGoals
+	(declare
+		(assoc
+			goal_features_map (assoc)
+			case_ids (list)
+			query_conditions (list)
+		)
+
+		(declare (assoc
+			hyperparam_map
+				(call !GetHyperparameters (assoc
+					feature ""
+					weight_feature (if valid_weight_feature weight_feature)
+				))
+		))
+
+		(map
+			(lambda
+				(let
+					(assoc
+						case_id (current_value 1)
+					)
+
+					(declare (assoc
+						nearest_case_ids
+							(compute_on_contained_entities )
+					))
+
+					;TODO
+				)
+			)
+			case_ids
 		)
 	)
 

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -78,8 +78,10 @@
 	(declare
 		(assoc
 			goal_features_map (assoc)
+			goal_dependent_features (list)
 			case_ids (list)
 			query_conditions (list)
+			context_features (list)
 		)
 
 		(declare (assoc
@@ -88,6 +90,14 @@
 					feature ""
 					weight_feature (if valid_weight_feature weight_feature)
 				))
+			goal_features (indices goal_features_map)
+		))
+
+		;setting up variables to use goal_feature influence code correctly
+		(declare (assoc
+			feature_weights (get hyperparam_map "featureWeights")
+			context_features (indices (remove (zip !trainedFeatures) goal_features))
+			dt_parameter (get hyperparam_map "dt")
 		))
 
 		(map
@@ -95,14 +105,49 @@
 				(let
 					(assoc
 						case_id (current_value 1)
+						context_values (retrieve_from_entity (current_value 1) context_features)
+						custom_extra_filtering_queries (append query_conditions (query_not_in_entity_list [(current_value 2)]))
 					)
 
 					(declare (assoc
-						nearest_case_ids
-							(compute_on_contained_entities )
+						inf_cases_map
+							#!GoalFeatureSamplingQuery
+							(compute_on_contained_entities (append
+								(query_exists !internalLabelSession)
+								custom_extra_filtering_queries
+								(query_nearest_generalized_distance
+									15; 30
+									context_features
+									context_values
+									feature_weights
+									!queryDistanceTypeMap
+									(get hyperparam_map "featureAttributes")
+									(get hyperparam_map "featureDeviations")
+									(get hyperparam_map "p")
+									dt_parameter
+									(if valid_weight_feature weight_feature (null))
+									;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
+									"fixed rand seed"
+									(null) ;radius
+									!numericalPrecision
+								)
+							))
 					))
 
-					;TODO
+					(assign (assoc
+						inf_cases_map
+							(call !UpdateLocalInfluencesForGoals (assoc
+								case_ids (append (indices inf_cases_map) case_id)
+								feature_weights feature_weights
+								context_features context_features
+								context_values context_values
+								custom_extra_filtering_queries (trunc custom_extra_filtering_queries)
+								dt_parameter dt_parameter
+								query_label "!GoalFeatureSamplingQuery"
+							))
+					))
+
+					(first (index_max inf_cases_map))
 				)
 			)
 			case_ids

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -95,19 +95,19 @@
 		;setting up variables to use goal_feature influence code correctly
 		(declare (assoc
 			feature_weights (get hyperparam_map "featureWeights")
-			context_features (indices (remove (zip !trainedFeatures) goal_features))
 			dt_parameter (get hyperparam_map "dt")
+			all_context_features (append features goal_dependent_features)
 		))
 
-		(map
+		||(map
 			(lambda
 				(let
 					(assoc
 						case_id (current_value 1)
 						context_map
 							(zip
-								(append features goal_dependent_features)
-								(retrieve_from_entity (current_value 1) (append features goal_dependent_features))
+								all_context_features
+								(retrieve_from_entity (current_value 1) all_context_features)
 							)
 						custom_extra_filtering_queries (append query_conditions (query_not_in_entity_list [(current_value 2)]))
 					)
@@ -142,7 +142,7 @@
 					))
 
 					(declare (assoc
-						inf_cases_map
+						similar_cases_map
 							#!GoalFeatureSamplingQuery
 							(compute_on_contained_entities (append
 								(query_exists !internalLabelSession)
@@ -169,17 +169,19 @@
 					(assign (assoc
 						inf_cases_map
 							(call !UpdateLocalInfluencesForGoals (assoc
-								case_ids (append (indices inf_cases_map) case_id)
+								case_ids (append (indices similar_cases_map) case_id)
 								feature_weights feature_weights
 								context_features context_features
 								context_values context_values
+								;a ignore-this-case query was added to custom_extra_filtering queries above
+								;so removing it here so that the current case can still be chosen by the goal optimization
 								custom_extra_filtering_queries (trunc custom_extra_filtering_queries)
 								dt_parameter dt_parameter
 								query_label "!GoalFeatureSamplingQuery"
 							))
 					))
 
-					(first (index_max inf_cases_map))
+					(first (index_max similar_cases_map))
 				)
 			)
 			case_ids

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -72,8 +72,10 @@
 	;for each case id given, gets its influential cases and selects the case that optimizes the goal
 	;parameters:
 	; goal_features_map: the map of goal features and their specified goals (value/max/min)
+	; goal_dependent_features: list of features that will not be ignored while optimizing the goal
 	; case_ids: the originally sampled case_ids
 	; query_conditions: a set of queries that can limits the available cases for selection
+	; features: a list of feature to robustly select from when querying for similar cases
 	#!SampleCasesForGoals
 	(declare
 		(assoc
@@ -81,7 +83,7 @@
 			goal_dependent_features (list)
 			case_ids (list)
 			query_conditions (list)
-			context_features (list)
+			features (list)
 		)
 
 		(declare (assoc
@@ -91,6 +93,7 @@
 					weight_feature (if valid_weight_feature weight_feature)
 				))
 			goal_features (indices goal_features_map)
+			goal_dependent_features_set (zip goal_dependent_features)
 		))
 
 		;setting up variables to use goal_feature influence code correctly
@@ -105,9 +108,42 @@
 				(let
 					(assoc
 						case_id (current_value 1)
-						context_values (retrieve_from_entity (current_value 1) context_features)
+						context_map
+							(zip
+								(append features goal_dependent_features)
+								(retrieve_from_entity (current_value 1) (append features goal_dependent_features))
+							)
 						custom_extra_filtering_queries (append query_conditions (query_not_in_entity_list [(current_value 2)]))
 					)
+
+					;robustly select a set of features to use as contexts for the goal-optimized sample
+					(declare (assoc
+						context_features
+							(append
+								goal_dependent_features
+								(filter
+									(lambda (> 0.5 (rand)))
+									features
+								)
+							)
+					))
+					;loop to make sure at least one feature is selected
+					(while (not (size context_features))
+						(assign (assoc
+							context_features
+								(append
+									goal_dependent_features
+									(filter
+										(lambda (> 0.5 (rand)))
+										features
+									)
+								)
+						))
+					)
+
+					(declare (assoc
+						context_values (unzip context_map context_features)
+					))
 
 					(declare (assoc
 						inf_cases_map
@@ -116,7 +152,7 @@
 								(query_exists !internalLabelSession)
 								custom_extra_filtering_queries
 								(query_nearest_generalized_distance
-									15; 30
+									(get hyperparam_map "k")
 									context_features
 									context_values
 									feature_weights

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -167,7 +167,7 @@
 					))
 
 					(assign (assoc
-						inf_cases_map
+						similar_cases_map
 							(call !UpdateLocalInfluencesForGoals (assoc
 								case_ids (append (indices similar_cases_map) case_id)
 								feature_weights feature_weights

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -40,9 +40,6 @@
 	; rand_seed: optional random seed
 	; case_weight_feature: optional, if provided will use this feature to do case weighted sampling
 	; query_conditions: a set of queries that can limits the available cases for sampling
-	; goal_features_map: the standard goal features map. When specified, will compute an extra query for
-	;	each originally sampled case which will select it's nearest case that optimizes the goal. Leaving
-	;	the number of desired cases that maximizes the goal but still is sampled randomly from the model.
 	#!SampleCases
 	(declare
 		(assoc
@@ -50,7 +47,6 @@
 			rand_seed (null)
 			case_weight_feature (null)
 			query_conditions (list)
-			goal_features_map (assoc)
 		)
 		(if (!= (null) num)
 			(contained_entities (append

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1450,13 +1450,17 @@
 		))
 
 		(if goal_features
-			(call !UpdateLocalInfluencesForGoals (assoc
-				feature_weights feature_weights
-				context_features context_features
-				context_values context_values
-				custom_extra_filtering_queries custom_extra_filtering_queries
-				dt_parameter (get hyperparam_map "dt")
-				query_label "!ReactionQuery"
+			(assign (assoc
+				local_data_cases_tuple
+					(call !UpdateLocalInfluencesForGoals (assoc
+						case_ids (first local_data_cases_tuple)
+						feature_weights feature_weights
+						context_features context_features
+						context_values context_values
+						custom_extra_filtering_queries custom_extra_filtering_queries
+						dt_parameter (get hyperparam_map "dt")
+						query_label "!ReactionQuery"
+					))
 			))
 		)
 

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -38,17 +38,20 @@
 			; assoc of :
 			;		{ feature : { "goal" : "min"/"max", "value" : value }}
 			;		A mapping of feature name to the goals for the feature, which will be used to bias the sampling of cases used to compute
-			;		the desired metrics.  This is useful for conditioning responses when it is challenging or impossible to know appropriate
-			;		values ahead of time, such as maximizing the reward or minimizing cost for reinforcement learning, or conditioning a
-			;		forecast based on attempting to achieve some value.  Goal features will reevaluate the inference for the given context
-			;		optimizing for the specified goals. Valid keys in the map are:
+			;		the desired metrics. A series of cases are sampled, the for each case it's most similar cases are found and the case that
+			;		optimizes the goal is selected, building a collection of cases that are still randomly selected from the model with a bias
+			;		towards the goal specified.
+			;
+			;		Valid keys in the map are:
 			;		"goal": "min" or "max", will make a prediction while minimizing or maximizing the value for the feature or
 			;		"value" : value, will make a prediction while approaching the specified value
 			;	note: nominal features only support 'value', 'goal' is ignored.
 			;		  for non-nominals, if both are provided, only 'goal' is considered.
 			goal_features_map (assoc)
 			;{type "list" values "string"}
-			;a list of features that will be constrained while the goals are optimized in sampling
+			;a list of features that will not be ignored in the goal-biased sampling process. Specifically, when the cases ranked by how much they
+			;optimize the goal, the features specified here will be included in the function to bias selection towards cases that maintain the values
+			;of the originally sampled case.
 			goal_dependent_features (list)
 			;{type "list" values "string"}
 			;full path for hyperparameters to use for computation.
@@ -524,7 +527,7 @@
 							goal_features_map goal_features_map
 							goal_dependent_features goal_dependent_features
 							query_conditions action_condition_filter_query
-							context_features context_features
+							features context_features
 						))
 					)
 				robust_residual_case_ids
@@ -534,7 +537,7 @@
 							goal_features_map goal_features_map
 							goal_dependent_features goal_dependent_features
 							query_conditions action_condition_filter_query
-							context_features context_features
+							features context_features
 						))
 					)
 				robust_influence_case_ids
@@ -544,7 +547,7 @@
 							goal_features_map goal_features_map
 							goal_dependent_features goal_dependent_features
 							query_conditions action_condition_filter_query
-							context_features context_features
+							features context_features
 						))
 					)
 			))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -34,6 +34,19 @@
 			;value 0.0 - 1.0, percent of model to use in sampling (using sampling without replacement).
     		;	Applicable only to non-robust computation. Ignored if num_samples is specified.
 			sample_model_fraction (null)
+			;{type "assoc" additional_indices {ref "GoalFeatures"}}
+			; assoc of :
+			;		{ feature : { "goal" : "min"/"max", "value" : value }}
+			;		A mapping of feature name to the goals for the feature, which will be used to bias the sampling of cases used to compute
+			;		the desired metrics.  This is useful for conditioning responses when it is challenging or impossible to know appropriate
+			;		values ahead of time, such as maximizing the reward or minimizing cost for reinforcement learning, or conditioning a
+			;		forecast based on attempting to achieve some value.  Goal features will reevaluate the inference for the given context
+			;		optimizing for the specified goals. Valid keys in the map are:
+			;		"goal": "min" or "max", will make a prediction while minimizing or maximizing the value for the feature or
+			;		"value" : value, will make a prediction while approaching the specified value
+			;	note: nominal features only support 'value', 'goal' is ignored.
+			;		  for non-nominals, if both are provided, only 'goal' is considered.
+			goal_features_map (assoc)
 			;{type "list" values "string"}
 			;full path for hyperparameters to use for computation.
     		;	If specified for any residual computations, takes precendence over action_feature parameter.
@@ -364,6 +377,22 @@
 					))
 					(list)
 				)
+			computing_robust_influences
+				(apply "or"
+					(unzip
+						details
+						["feature_robust_prediction_contributions" "feature_robust_accuracy_contributions" "feature_robust_accuracy_contributions_permutation"]
+					)
+				)
+			computing_full_details
+				(apply "or"
+					(unzip
+						details
+						["prediction_stats" "feature_full_residuals" "feature_full_accuracy_contributions_permutation"
+						 "feature_full_accuracy_contributions" "feature_full_prediction_contributions" "feature_deviations"]
+					)
+				)
+			computing_robust_residuals (get details "feature_robust_residuals")
 		))
 
 		;if num_samples was explicitly specified, use that many, even if it means
@@ -371,60 +400,82 @@
 		;and by default sample 1000 out of the full model if num_samples wasn't specified
 		(declare (assoc
 			case_ids
-				(if num_samples
-					(call !SampleCases (assoc
-						num num_samples
-						case_weight_feature (if valid_weight_feature weight_feature)
-						query_conditions action_condition_filter_query
-					))
-
-					(> sample_model_fraction 0)
-					(call !AllCases (assoc
-						num (* sample_model_fraction num_training_cases)
-						query_conditions action_condition_filter_query
-						rand_seed (rand)
-					))
-
-					;otherwise sample 1000 or the whole model
-					(if (> num_training_cases 1000)
-						;if more than 1000 cases, sample 1000
+				(if computing_full_details
+					(if num_samples
 						(call !SampleCases (assoc
-							num 1000
+							num num_samples
 							case_weight_feature (if valid_weight_feature weight_feature)
 							query_conditions action_condition_filter_query
 						))
 
-						;otherwise just use all the cases
+						(> sample_model_fraction 0)
 						(call !AllCases (assoc
+							num (* sample_model_fraction num_training_cases)
 							query_conditions action_condition_filter_query
 							rand_seed (rand)
 						))
+
+						;otherwise sample 1000 or the whole model
+						(if (> num_training_cases 1000)
+							;if more than 1000 cases, sample 1000
+							(call !SampleCases (assoc
+								num 1000
+								case_weight_feature (if valid_weight_feature weight_feature)
+								query_conditions action_condition_filter_query
+							))
+
+							;otherwise just use all the cases
+							(call !AllCases (assoc
+								query_conditions action_condition_filter_query
+								rand_seed (rand)
+							))
+						)
 					)
 				)
 			robust_residual_case_ids
-				(call !SampleCases (assoc
-					num
-						(if num_robust_residual_samples
-							num_robust_residual_samples
+				(if computing_robust_residuals
+					(call !SampleCases (assoc
+						num
+							(if num_robust_residual_samples
+								num_robust_residual_samples
 
-							(* 1000 (+ 1 (log (size context_features))))
-						)
-					case_weight_feature (if valid_weight_feature weight_feature)
-					query_conditions action_condition_filter_query
-				))
+								(* 1000 (+ 1 (log (size context_features))))
+							)
+						case_weight_feature (if valid_weight_feature weight_feature)
+						query_conditions action_condition_filter_query
+					))
+				)
 			robust_influence_case_ids
-				(call !SampleCases (assoc
-					num
-						(if num_robust_influence_samples
-							num_robust_influence_samples
+				(if computing_robust_influences
+					(call !SampleCases (assoc
+						num
+							(if num_robust_influence_samples
+								num_robust_influence_samples
 
-							;Ideally this would be larger, but performance is of significant concern here.
-							300
-						)
-					case_weight_feature (if valid_weight_feature weight_feature)
-					query_conditions action_condition_filter_query
-				))
+								;Ideally this would be larger, but performance is of significant concern here.
+								300
+							)
+						case_weight_feature (if valid_weight_feature weight_feature)
+						query_conditions action_condition_filter_query
+					))
+				)
 		))
+
+		;update sampled cases to select the goal-optimizing influential case of each sampled case
+		(if (size goal_features_map)
+			(assign (assoc
+				case_ids
+					(if case_ids
+
+					)
+				robust_residual_case_ids
+					(if robust_residual_case_ids
+					)
+				robust_influence_case_ids
+					(if robust_influence_case_ids
+					)
+			))
+		)
 
 
 		;calculates prediction stats

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -48,6 +48,9 @@
 			;		  for non-nominals, if both are provided, only 'goal' is considered.
 			goal_features_map (assoc)
 			;{type "list" values "string"}
+			;a list of features that will be constrained while the goals are optimized in sampling
+			goal_dependent_features (list)
+			;{type "list" values "string"}
 			;full path for hyperparameters to use for computation.
     		;	If specified for any residual computations, takes precendence over action_feature parameter.
 			hyperparameter_param_path (null)
@@ -516,13 +519,33 @@
 			(assign (assoc
 				case_ids
 					(if case_ids
-
+						(call !SampleCasesForGoals (assoc
+							case_ids case_ids
+							goal_features_map goal_features_map
+							goal_dependent_features goal_dependent_features
+							query_conditions action_condition_filter_query
+							context_features context_features
+						))
 					)
 				robust_residual_case_ids
 					(if robust_residual_case_ids
+						(call !SampleCasesForGoals (assoc
+							case_ids robust_residual_case_ids
+							goal_features_map goal_features_map
+							goal_dependent_features goal_dependent_features
+							query_conditions action_condition_filter_query
+							context_features context_features
+						))
 					)
 				robust_influence_case_ids
 					(if robust_influence_case_ids
+						(call !SampleCasesForGoals (assoc
+							case_ids robust_influence_case_ids
+							goal_features_map goal_features_map
+							goal_dependent_features goal_dependent_features
+							query_conditions action_condition_filter_query
+							context_features context_features
+						))
 					)
 			))
 		)

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -898,7 +898,7 @@
 			feature_weights
 				(map
 					(lambda
-						(if (contains_index goal_features_map (current_index))
+						(if (or (contains_index goal_features_map (current_index)) (contains_value goal_dependent_features (current_index)))
 							;for non-surprisal space, use the provided weight as-is, otherwise set all goal feature weights to 1
 							(if (and (!= "suprisal_to_prob" dt_parameter) feature_weights)
 								(current_value)
@@ -924,80 +924,89 @@
 						(zip (append context_features goal_features))
 					)
 				)
-
-			context_features (append context_features goal_features)
-
-			;set goal to max/min/specified value in local space
-			context_values
-				(append
-					context_values
-					(map
-						(lambda (let
-							(assoc
-								goal_feature (current_value 1)
-								not_nominal (not (contains_index !nominalsMap (current_value 1)))
-							)
-
-							(if (and not_nominal (= "max" (get goal_features_map [goal_feature "goal"])) )
-								(get
-									(first
-										(compute_on_contained_entities [
-											(query_in_entity_list (first local_data_cases_tuple))
-											(query_max goal_feature 1)
-											(query_exists goal_feature)
-										])
-									)
-									goal_feature
-								)
-
-								(and not_nominal (= "min" (get goal_features_map [goal_feature "goal"])) )
-								(get
-									(first
-										(compute_on_contained_entities [
-											(query_in_entity_list (first local_data_cases_tuple))
-											(query_min goal_feature 1)
-											(query_exists goal_feature)
-										])
-									)
-									goal_feature
-								)
-
-								;else approach specified value
-								(let
-									(assoc
-										goal_value (get goal_features_map [goal_feature "value"])
-										local_goal_values
-											(map
-												(lambda (retrieve_from_entity (current_value) goal_feature))
-												(first local_data_cases_tuple)
-											)
-									)
-									(declare (assoc local_max (apply "max" local_goal_values) ))
-									(if (>= goal_value local_max) (conclude local_max) )
-
-									(declare (assoc local_min (apply "min" local_goal_values) ))
-									(if (<= goal_value local_min)
-										local_min
-
-										;else goal value is within the local space, use it as-is
-										goal_value
-									)
-								)
-							)
-						))
-						goal_features
-					)
-				)
-
+			context_map (zip context_features context_values)
 			;limit the secondary goal-oriented query to only run on cases in this local space
 			custom_extra_filtering_queries
 				(if custom_extra_filtering_queries
-					(append custom_extra_filtering_queries (query_in_entity_list (first local_data_cases_tuple)) )
-					(query_in_entity_list (first local_data_cases_tuple))
+					(append custom_extra_filtering_queries (query_in_entity_list case_ids) )
+					(query_in_entity_list case_ids)
+				)
+		))
+
+		(assign (assoc
+			;these could overlap
+			context_features (indices (zip (append context_features goal_features)))
+		))
+
+		(assign (assoc
+			;set goal to max/min/specified value in local space
+			context_values
+				(map
+					(lambda
+						(if (contains_value goal_features (current_value))
+							;if goal feature, use the goal feature logic to determine context value
+							(let
+								(assoc
+									goal_feature (current_value 1)
+									not_nominal (not (contains_index !nominalsMap (current_value 1)))
+								)
+
+								(if (and not_nominal (= "max" (get goal_features_map [goal_feature "goal"])) )
+									(get
+										(first
+											(compute_on_contained_entities [
+												(query_in_entity_list case_ids)
+												(query_max goal_feature 1)
+												(query_exists goal_feature)
+											])
+										)
+										goal_feature
+									)
+
+									(and not_nominal (= "min" (get goal_features_map [goal_feature "goal"])) )
+									(get
+										(first
+											(compute_on_contained_entities [
+												(query_in_entity_list case_ids)
+												(query_min goal_feature 1)
+												(query_exists goal_feature)
+											])
+										)
+										goal_feature
+									)
+
+									;else approach specified value
+									(let
+										(assoc
+											goal_value (get goal_features_map [goal_feature "value"])
+											local_goal_values
+												(map
+													(lambda (retrieve_from_entity (current_value) goal_feature))
+													case_ids
+												)
+										)
+										(declare (assoc local_max (apply "max" local_goal_values) ))
+										(if (>= goal_value local_max) (conclude local_max) )
+
+										(declare (assoc local_min (apply "min" local_goal_values) ))
+										(if (<= goal_value local_min)
+											local_min
+
+											;else goal value is within the local space, use it as-is
+											goal_value
+										)
+									)
+								)
+							)
+
+							(get context_map (current_value))
+						)
+					)
+					context_features
 				)
 		))
 
 		;call the react query again with the goal-oriented contexts and weights
-		(assign (assoc local_data_cases_tuple (call (retrieve_from_entity query_label)) ))
+		(call (retrieve_from_entity query_label))
 	)
 )

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -999,6 +999,7 @@
 								)
 							)
 
+							;otherwise pull the context value from the existing context map for the case
 							(get context_map (current_value))
 						)
 					)

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -898,7 +898,7 @@
 			feature_weights
 				(map
 					(lambda
-						(if (or (contains_index goal_features_map (current_index)) (contains_value goal_dependent_features (current_index)))
+						(if (or (contains_index goal_features_map (current_index)) (contains_index goal_dependent_features_set (current_index)))
 							;for non-surprisal space, use the provided weight as-is, otherwise set all goal feature weights to 1
 							(if (and (!= "suprisal_to_prob" dt_parameter) feature_weights)
 								(current_value)

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -661,13 +661,17 @@
 		))
 
 		(if goal_features
-			(call !UpdateLocalInfluencesForGoals (assoc
-				feature_weights feature_weights
-				context_features context_features
-				context_values context_values
-				custom_extra_filtering_queries custom_extra_filtering_queries
-				dt_parameter (get hyperparam_map "dt")
-				query_label "!NearestRegionalCasesQuery"
+			(assign (assoc
+				local_data_cases_tuple
+					(call !UpdateLocalInfluencesForGoals (assoc
+						case_ids (first local_data_cases_tuple)
+						feature_weights feature_weights
+						context_features context_features
+						context_values context_values
+						custom_extra_filtering_queries custom_extra_filtering_queries
+						dt_parameter (get hyperparam_map "dt")
+						query_label "!NearestRegionalCasesQuery"
+					))
 			))
 		)
 

--- a/unit_tests/unit_test_data/fake_housing.csv
+++ b/unit_tests/unit_test_data/fake_housing.csv
@@ -1,0 +1,301 @@
+city,price,sold,country_clubs,grocery_stores,public_transportation,wine_cellar,upper
+New York City,6861.432660235954,no,0,2,no,yes,no
+New York City,10710.950191334232,no,0,2,yes,yes,no
+New York City,11909.236815104494,no,0,3,no,no,no
+New York City,14541.729298138864,yes,3,5,no,no,yes
+New York City,12497.504027964378,no,2,2,yes,yes,no
+New York City,15230.814514756335,yes,3,5,yes,no,yes
+New York City,13456.25784115302,yes,3,2,yes,no,yes
+New York City,7067.840700443051,no,0,2,yes,no,no
+New York City,6411.608619737155,no,2,4,no,no,no
+New York City,9980.289102529083,no,0,1,no,no,no
+New York City,13263.809959996732,no,1,3,no,no,yes
+New York City,12028.244785353714,no,0,2,yes,no,no
+New York City,12351.845200218595,no,2,2,no,no,no
+New York City,12398.722848752861,no,0,2,yes,no,no
+New York City,10431.082583614161,no,1,4,no,no,no
+New York City,11191.686900284541,no,3,4,no,yes,no
+New York City,12974.572265683199,yes,3,3,yes,no,no
+New York City,11457.661638522923,yes,3,3,yes,no,no
+New York City,10346.18103621142,yes,0,3,yes,yes,no
+New York City,14773.599146431268,no,0,2,yes,no,yes
+New York City,10783.225395329982,no,0,3,no,no,no
+New York City,10506.243992917533,yes,0,3,yes,no,no
+New York City,14917.782808220178,no,1,5,no,no,yes
+New York City,9336.4265269782,yes,0,3,yes,no,no
+New York City,13197.755425853838,no,3,4,no,yes,no
+New York City,16522.153824255132,no,0,3,yes,no,yes
+New York City,18247.557349312214,no,0,3,yes,no,yes
+New York City,15243.839046159872,no,1,2,no,no,yes
+New York City,13912.954220668671,no,0,3,yes,no,yes
+New York City,12858.161105384539,no,2,1,no,no,no
+New York City,10374.459248752777,no,1,2,yes,no,no
+New York City,8699.270547817498,yes,2,4,yes,no,no
+New York City,11152.148440173263,yes,1,3,yes,yes,no
+New York City,9838.336182047322,no,2,2,yes,yes,no
+New York City,13740.210175148215,no,0,4,yes,yes,yes
+New York City,8660.162190164045,no,1,2,yes,no,no
+New York City,12849.452069763272,no,1,2,yes,no,no
+New York City,13204.52987330641,no,0,3,yes,no,yes
+New York City,13156.390529048796,no,0,3,no,no,no
+New York City,12769.621807709456,no,0,2,yes,no,no
+New York City,15366.906392042783,yes,2,3,yes,no,yes
+New York City,14398.886623505228,yes,2,4,yes,yes,yes
+New York City,10185.873677174463,no,0,2,yes,yes,no
+New York City,12504.021301115461,yes,3,3,yes,no,no
+New York City,13955.236674962856,yes,2,1,no,no,yes
+New York City,15723.90469497016,yes,1,5,yes,yes,yes
+New York City,10280.536560593417,yes,0,4,yes,no,no
+New York City,9526.357742732092,yes,1,3,yes,no,no
+New York City,11368.246958422429,yes,0,3,yes,yes,no
+New York City,11036.482273126869,no,0,3,no,no,no
+Raleigh,7287.017906884281,no,0,2,yes,yes,yes
+Raleigh,4675.935929753552,no,3,1,yes,yes,no
+Raleigh,4585.608303853407,no,0,3,no,no,no
+Raleigh,6900.676391158137,no,0,1,yes,yes,yes
+Raleigh,6492.602636200674,no,0,2,no,yes,no
+Raleigh,5819.739133646181,yes,3,4,yes,no,no
+Raleigh,5538.853923176715,yes,1,4,yes,no,no
+Raleigh,6584.949678432359,no,1,2,yes,no,no
+Raleigh,5876.139760191705,yes,1,3,yes,no,no
+Raleigh,7467.322289859985,no,0,3,yes,no,yes
+Raleigh,5400.713337566697,no,1,2,no,no,no
+Raleigh,4981.1280702460335,no,2,1,yes,no,no
+Raleigh,6433.013053887917,no,1,2,yes,yes,no
+Raleigh,6777.524916016806,yes,3,5,yes,no,yes
+Raleigh,6285.618597756295,no,2,1,yes,yes,no
+Raleigh,7392.842054596336,no,0,3,yes,yes,yes
+Raleigh,5838.463110979006,yes,3,4,yes,no,no
+Raleigh,8363.63640438593,yes,2,4,yes,no,yes
+Raleigh,7330.981074332349,no,0,3,yes,no,yes
+Raleigh,7003.021874903119,no,0,2,yes,no,yes
+Raleigh,6085.846221102204,no,0,2,no,no,no
+Raleigh,6039.32532813561,yes,0,3,yes,yes,no
+Raleigh,7346.012466402999,yes,2,3,no,no,yes
+Raleigh,9099.01423960814,yes,2,3,yes,no,yes
+Raleigh,7417.561791696571,yes,3,2,yes,no,yes
+Raleigh,5506.7937667517845,yes,0,4,yes,yes,no
+Raleigh,5135.075278140184,no,2,3,no,no,no
+Raleigh,6157.828265985512,yes,0,5,yes,no,no
+Raleigh,5142.567821186528,no,0,3,no,no,no
+Raleigh,3853.611956632611,no,0,1,no,no,no
+Raleigh,6087.323774442017,no,2,2,no,yes,no
+Raleigh,5699.9793268984495,yes,1,5,yes,yes,no
+Raleigh,4662.370915792038,yes,3,5,yes,no,no
+Raleigh,6342.69361651089,no,1,3,no,yes,no
+Raleigh,5010.517171706446,no,0,2,yes,no,no
+Raleigh,3691.071594912463,yes,2,5,yes,no,no
+Raleigh,7506.921186523083,no,0,5,yes,no,yes
+Raleigh,7084.25497417508,yes,3,1,yes,yes,yes
+Raleigh,5457.836091376231,yes,0,5,yes,no,no
+Raleigh,6343.494557499644,no,0,1,yes,no,no
+Raleigh,8101.134107032884,no,0,3,yes,no,yes
+Raleigh,6031.409574621069,no,2,2,no,no,no
+Raleigh,4768.759722941666,no,0,4,no,yes,no
+Raleigh,9833.392286457438,no,1,3,yes,no,yes
+Raleigh,5729.245364425571,yes,0,4,yes,no,no
+Raleigh,4528.620342027173,yes,0,5,yes,no,no
+Raleigh,6518.701532456535,yes,0,4,yes,no,no
+Raleigh,6097.425406267798,yes,0,3,yes,yes,no
+Raleigh,5554.735612811808,no,2,2,no,yes,no
+Raleigh,7687.654807846939,yes,3,3,yes,no,yes
+Jacksonville,1840.8858294264996,yes,1,3,yes,yes,no
+Jacksonville,2787.585387821216,yes,3,4,no,no,yes
+Jacksonville,2825.905973639763,no,1,3,yes,no,yes
+Jacksonville,1731.4869540509555,no,1,4,no,no,no
+Jacksonville,2241.5120795029775,no,0,4,no,no,yes
+Jacksonville,1629.2219422308865,no,1,3,no,no,no
+Jacksonville,1809.6747818499987,yes,2,4,yes,no,no
+Jacksonville,1843.872552688931,no,0,2,yes,no,no
+Jacksonville,1427.3960019409521,no,2,4,no,yes,no
+Jacksonville,2605.282067790356,no,0,2,yes,no,yes
+Jacksonville,1798.2335753436305,yes,2,5,yes,no,no
+Jacksonville,2130.8497542641953,yes,0,3,yes,no,no
+Jacksonville,1712.4872902650739,no,2,3,no,no,no
+Jacksonville,1916.7983446789035,yes,0,3,yes,no,no
+Jacksonville,2636.1808725776928,no,0,3,no,no,yes
+Jacksonville,1940.936169088083,no,3,1,yes,no,no
+Jacksonville,2552.501895849457,no,1,4,yes,no,yes
+Jacksonville,2326.9046103043365,yes,3,3,yes,no,yes
+Jacksonville,2158.0279165825223,yes,1,4,yes,no,no
+Jacksonville,1699.6978623112245,no,2,4,no,yes,no
+Jacksonville,2197.844506508538,no,0,2,yes,no,no
+Jacksonville,2159.811271729718,no,2,5,no,no,no
+Jacksonville,1960.5142699143762,no,0,3,no,no,no
+Jacksonville,2214.6712501391503,yes,3,1,no,yes,yes
+Jacksonville,2022.717022164563,yes,0,4,yes,yes,no
+Jacksonville,1781.0131167138672,no,3,4,no,no,no
+Jacksonville,1757.3445259659093,yes,0,5,yes,no,no
+Jacksonville,1996.4591761685372,no,2,1,yes,no,no
+Jacksonville,1796.1548838532367,yes,3,3,yes,no,no
+Jacksonville,1818.8842631615976,yes,1,3,yes,no,no
+Jacksonville,1945.340608852513,no,0,4,no,yes,no
+Jacksonville,2263.887826403218,yes,1,2,no,yes,yes
+Jacksonville,2453.66587866024,yes,2,3,no,no,yes
+Jacksonville,2171.124374311595,no,3,2,yes,no,no
+Jacksonville,1669.4955065364304,no,0,4,no,no,no
+Jacksonville,2116.506605846991,no,3,1,no,no,no
+Jacksonville,2349.5009405032083,yes,1,4,yes,yes,yes
+Jacksonville,2060.27101627392,no,2,2,yes,no,no
+Jacksonville,2852.4424218141485,yes,2,3,no,no,yes
+Jacksonville,980.2937596531734,no,3,2,yes,no,no
+Jacksonville,1871.0091248962935,yes,1,3,yes,no,no
+Jacksonville,1962.1162763268972,yes,0,4,yes,no,no
+Jacksonville,2511.3746901761715,no,1,4,yes,no,yes
+Jacksonville,2518.400448827117,no,0,3,no,yes,yes
+Jacksonville,2210.615198161335,no,1,2,yes,no,yes
+Jacksonville,1769.301145449932,no,3,1,yes,no,no
+Jacksonville,1903.310675768822,yes,0,3,yes,yes,no
+Jacksonville,1476.5416788688049,no,3,2,no,no,no
+Jacksonville,1294.0153701482577,no,0,2,yes,yes,no
+Jacksonville,2541.0219240153247,yes,2,3,yes,yes,yes
+Cary,6112.69151104389,yes,1,4,no,yes,yes
+Cary,3937.5699860775076,no,1,5,no,no,no
+Cary,6349.138936463769,no,0,5,no,no,yes
+Cary,4512.131636536387,no,1,5,no,no,no
+Cary,5448.070955665928,yes,1,3,yes,no,no
+Cary,4285.346797389738,no,3,1,yes,no,no
+Cary,4546.0228959477445,no,1,2,no,yes,no
+Cary,4661.857118645017,yes,0,5,yes,yes,no
+Cary,5605.63807276574,yes,1,3,yes,yes,yes
+Cary,4139.903625067851,yes,3,3,yes,no,no
+Cary,5018.755272673997,no,0,3,no,no,no
+Cary,5263.505280233518,no,0,2,no,no,no
+Cary,4710.390326668292,yes,0,4,yes,no,no
+Cary,5401.39858572914,no,3,4,no,yes,no
+Cary,4360.530930829508,yes,3,4,yes,yes,no
+Cary,4239.164660842671,yes,0,3,yes,no,no
+Cary,5699.518635690733,no,0,1,yes,no,yes
+Cary,5961.821628604841,no,0,3,no,no,yes
+Cary,5416.431748051563,yes,0,3,yes,no,no
+Cary,3516.0587260701877,no,0,1,yes,yes,no
+Cary,6019.427520492,yes,3,2,yes,no,yes
+Cary,4977.294000178972,no,3,1,yes,no,no
+Cary,5552.40437039753,yes,2,1,yes,no,yes
+Cary,4416.627890421867,no,3,3,no,no,no
+Cary,5585.012813303476,yes,3,2,yes,yes,yes
+Cary,3890.7622577307984,yes,2,3,yes,no,no
+Cary,5970.193163502394,no,0,2,yes,no,yes
+Cary,4939.551302774141,yes,2,4,yes,yes,no
+Cary,4832.870972123288,no,0,2,no,no,no
+Cary,4980.46847568219,no,0,3,no,no,no
+Cary,5873.057262149385,yes,1,1,no,yes,yes
+Cary,5257.658979437489,no,0,3,no,yes,no
+Cary,5437.504814989444,yes,2,5,yes,no,no
+Cary,6975.101878252567,no,0,4,yes,no,yes
+Cary,4869.759602085706,no,2,1,yes,yes,no
+Cary,6978.7740390825,no,1,3,no,no,yes
+Cary,4258.97701491511,yes,1,3,yes,no,no
+Cary,5631.4446750175275,yes,3,3,yes,no,yes
+Cary,5923.563861336924,yes,3,3,yes,yes,yes
+Cary,4685.197870541935,no,3,4,no,no,no
+Cary,5887.912003474829,yes,3,3,no,no,yes
+Cary,5109.031676255745,no,0,1,yes,no,no
+Cary,5188.3779405123105,no,0,1,yes,yes,no
+Cary,5845.403893789689,yes,1,2,no,yes,yes
+Cary,5568.595783018031,no,0,3,yes,no,yes
+Cary,5623.293005272594,yes,2,2,yes,yes,yes
+Cary,5627.4291080202975,yes,3,2,no,no,yes
+Cary,4404.14418666002,no,2,2,no,no,no
+Cary,6538.187438402188,no,1,3,yes,no,yes
+Cary,4895.327946447525,yes,0,3,yes,no,no
+Apex,2381.268259471325,yes,1,5,yes,no,no
+Apex,2982.792635013756,no,3,1,yes,no,no
+Apex,3927.510678006838,yes,1,4,yes,no,no
+Apex,4648.45655378834,no,0,2,yes,no,yes
+Apex,3359.1064228168148,yes,2,3,yes,no,no
+Apex,4007.302901218217,no,2,2,yes,no,no
+Apex,4556.884970122809,yes,2,3,no,no,yes
+Apex,2753.3773494111674,yes,0,3,yes,no,no
+Apex,4147.706532888995,no,3,3,no,no,no
+Apex,3985.314374385478,no,1,2,yes,yes,no
+Apex,3942.6273472346784,no,3,3,no,yes,no
+Apex,4565.373894797719,no,0,3,no,no,yes
+Apex,4483.379206857147,no,1,3,yes,no,yes
+Apex,6275.4992802375245,no,0,2,no,no,yes
+Apex,1807.9879728883157,no,3,2,no,no,no
+Apex,3751.07238459145,yes,0,3,yes,yes,no
+Apex,4211.8947073238105,no,0,3,no,yes,no
+Apex,4873.844300129178,no,0,3,no,yes,yes
+Apex,4477.718601542827,no,0,3,no,yes,yes
+Apex,3553.5735029852044,yes,0,3,yes,no,no
+Apex,2509.4858669966798,no,2,4,no,no,no
+Apex,3849.2574192551833,no,0,4,no,no,no
+Apex,4105.3721871883245,no,3,3,no,yes,no
+Apex,3508.739840368597,yes,2,4,yes,no,no
+Apex,4395.824467317188,yes,2,4,yes,no,no
+Apex,3913.770746077791,yes,3,4,yes,no,no
+Apex,3872.129073639291,no,1,1,yes,no,no
+Apex,3902.2708885548886,no,2,4,no,no,no
+Apex,3806.9704736847875,no,0,2,no,no,no
+Apex,4567.986395785431,no,0,2,yes,no,yes
+Apex,4748.723878111256,no,1,3,yes,no,yes
+Apex,4938.55823623203,yes,2,3,no,yes,yes
+Apex,3977.374645495014,no,0,2,no,no,no
+Apex,3562.444083224926,no,2,1,yes,no,no
+Apex,2626.684560234487,no,0,2,no,yes,no
+Apex,3792.65563078674,no,2,5,no,no,no
+Apex,3143.8340998615113,yes,1,3,yes,yes,no
+Apex,4746.910602208058,no,0,5,yes,no,yes
+Apex,3594.127182741798,yes,2,3,yes,no,no
+Apex,4941.883444621315,yes,2,3,yes,yes,yes
+Apex,3373.6131082359075,no,1,2,yes,no,no
+Apex,4105.145429940038,no,0,3,no,no,no
+Apex,3397.0285441721467,yes,3,4,yes,no,no
+Apex,3107.280595283888,no,0,2,yes,yes,no
+Apex,5200.140901126242,no,0,3,no,no,yes
+Apex,4680.031250980891,no,1,3,yes,no,yes
+Apex,4696.627223230031,no,0,3,yes,no,yes
+Apex,5170.589234244017,no,0,2,no,no,yes
+Apex,4094.495948036351,yes,2,3,yes,no,no
+Apex,5466.705308582269,yes,1,4,yes,yes,yes
+Gotham,7605.194998728119,yes,1,3,yes,no,no
+Gotham,7608.1291733359885,no,1,2,no,yes,no
+Gotham,8294.926037859732,no,0,5,no,yes,yes
+Gotham,7811.118805092441,no,0,3,no,no,yes
+Gotham,5608.422983104395,no,0,1,no,no,no
+Gotham,5401.1756570231355,no,0,3,no,no,no
+Gotham,6720.0438736116785,yes,0,3,yes,no,no
+Gotham,7350.555856975399,no,3,5,no,no,no
+Gotham,8374.674927208838,yes,3,2,no,no,yes
+Gotham,10320.06589766948,yes,2,2,no,no,yes
+Gotham,9516.750653273124,no,0,2,yes,no,yes
+Gotham,8017.489066424528,no,0,2,no,yes,yes
+Gotham,6755.719098637944,yes,0,3,yes,no,no
+Gotham,7478.684370179939,no,0,4,no,no,no
+Gotham,5193.282634735948,yes,3,3,yes,yes,no
+Gotham,6108.633753917226,no,2,1,yes,no,no
+Gotham,4921.140110797214,no,1,4,no,no,no
+Gotham,3619.119824879317,yes,2,3,yes,no,no
+Gotham,6954.316296931969,no,1,3,no,no,no
+Gotham,6480.478763688172,yes,0,4,yes,no,no
+Gotham,6758.07070144624,no,0,3,no,no,no
+Gotham,5285.521914130146,yes,2,3,yes,no,no
+Gotham,9276.435267241111,yes,3,3,no,no,yes
+Gotham,5911.010562656729,no,0,1,no,no,no
+Gotham,6518.579751016081,no,0,2,yes,no,no
+Gotham,9394.128419906552,no,0,2,no,yes,yes
+Gotham,6329.927217280698,no,3,1,yes,no,no
+Gotham,6421.351738121428,no,0,2,yes,yes,no
+Gotham,5442.4900264094085,yes,1,4,yes,no,no
+Gotham,9324.120601992363,yes,3,3,no,yes,yes
+Gotham,5898.7849580673665,yes,0,5,yes,no,no
+Gotham,9256.964454806886,yes,2,4,yes,no,yes
+Gotham,6360.443152210089,no,0,2,yes,yes,no
+Gotham,8349.340263354523,no,0,1,no,no,yes
+Gotham,5015.794888794097,yes,0,3,yes,no,no
+Gotham,3782.374313183021,no,1,1,no,no,no
+Gotham,6096.431652887802,no,0,5,no,yes,no
+Gotham,7059.4576514838,no,3,4,no,no,no
+Gotham,9875.368761967204,yes,2,3,no,no,yes
+Gotham,4166.573434997312,no,1,4,no,no,no
+Gotham,5222.681555260539,no,1,1,no,no,no
+Gotham,5246.766987356534,no,3,1,no,yes,no
+Gotham,8643.396496901332,no,0,3,no,no,yes
+Gotham,6251.364561629536,yes,0,5,yes,no,no
+Gotham,7271.647418541542,no,2,2,yes,no,no
+Gotham,4794.995627203698,yes,0,3,yes,no,no
+Gotham,6918.692966582623,yes,1,4,yes,no,no
+Gotham,9191.73701824587,no,0,2,yes,no,yes
+Gotham,8202.428388605633,yes,2,4,yes,yes,yes
+Gotham,6329.1728317918105,no,0,2,no,no,no

--- a/unit_tests/ut_h_anomaly.amlg
+++ b/unit_tests/ut_h_anomaly.amlg
@@ -13,8 +13,6 @@
 	))
 	(declare (assoc action_features (list (last features))))
 
-	(assign_to_entities "howso" (assoc trainee "model"))
-
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes (assoc "target" (assoc "type" "nominal") )
 	))

--- a/unit_tests/ut_h_goal_features.amlg
+++ b/unit_tests/ut_h_goal_features.amlg
@@ -13,8 +13,6 @@
 	))
 	(declare (assoc action_features (list (last features))))
 
-	(assign_to_entities "howso" (assoc trainee "model"))
-
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes (assoc "target" (assoc "type" "nominal" "data_type" "number") )
 	))

--- a/unit_tests/ut_h_goal_features_agg.amlg
+++ b/unit_tests/ut_h_goal_features_agg.amlg
@@ -22,8 +22,6 @@
 		features (first model_data)
 	))
 
-	(assign_to_entities "howso" (assoc trainee "model"))
-
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes
 			(assoc

--- a/unit_tests/ut_h_goal_features_agg.amlg
+++ b/unit_tests/ut_h_goal_features_agg.amlg
@@ -1,10 +1,22 @@
 (seq
 	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
-	(call (load "unit_test_howso.amlg") (assoc name "ut_h_goal_features_agg.amlg"))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_goal_features_agg.amlg" retries 1))
 
 	(declare (assoc
 		model_data (load "unit_test_data/fake_housing.csv")
 	))
+	;This dataset is a toy dataset describing residential real estate and whether each
+	;house sold. Houses that have "upper" = "yes" represent higher-class houses and
+	;they are sold if they have enough country clubs near them or a wine cellar.
+	;In contrast, houses with "upper" = "no" do not depend on those features at
+	;all for whether they sell, they depend on public transportation and grocery
+	;stores.
+	;
+	;The motivation here is that when goal features are specified in react_aggregate,
+	;to evaluate what features are important to sell a house while maximizing price,
+	;the engine accurately reports that wine cellars and country clubs are more important.
+	;Conversely, when the goal features are not specified, we should see these features be
+	;not nearly as important (there are far less "upper"="yes" homes than not).
 	(declare (assoc
 		data (tail model_data)
 		features (first model_data)
@@ -68,8 +80,9 @@
 		"UnGoaled: " (get ungoaled_results "country_clubs") "\n"
 	)
 
+	(print "Goaled RAC is larger: ")
 	(call assert_true (assoc
-		obs (> (get goaled_results "country_clubs") (* 1.5 (get ungoaled_results "country_clubs")) )
+		obs (> (get goaled_results "country_clubs") (* 2.0 (get ungoaled_results "country_clubs")) )
 	))
 
 	(call exit_if_failures (assoc msg "Aggregate with goal features."))

--- a/unit_tests/ut_h_goal_features_agg.amlg
+++ b/unit_tests/ut_h_goal_features_agg.amlg
@@ -1,0 +1,78 @@
+(seq
+	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_goal_features_agg.amlg"))
+
+	(declare (assoc
+		model_data (load "unit_test_data/fake_housing.csv")
+	))
+	(declare (assoc
+		data (tail model_data)
+		features (first model_data)
+	))
+
+	(assign_to_entities "howso" (assoc trainee "model"))
+
+	(call_entity "howso" "set_feature_attributes" (assoc
+		feature_attributes
+			(assoc
+				"city" (assoc "type" "nominal")
+				"sold" (assoc "type" "nominal")
+				"public_transportation" (assoc "type" "nominal")
+				"wine_cellar" (assoc "type" "nominal")
+				"upper" (assoc "type" "nominal")
+			)
+	))
+
+	(call_entity "howso" "train" (assoc
+		cases data
+		features features
+		session "session1"
+	))
+
+	(call_entity "howso" "analyze")
+
+	(declare (assoc
+		ungoaled_results
+			(get
+				(call_entity "howso" "react_aggregate" (assoc
+					action_feature "sold"
+					context_features ["city" "price" "country_clubs" "grocery_stores" "public_transportation" "wine_cellar"]
+					details {
+						"feature_robust_accuracy_contributions" (true)
+					}
+					num_robust_influence_samples 2000
+				))
+				[1 "payload" "feature_robust_accuracy_contributions"]
+			)
+	))
+
+	(declare (assoc
+		goaled_results
+			(get
+				(call_entity "howso" "react_aggregate" (assoc
+					action_feature "sold"
+					context_features ["city" "price" "country_clubs" "grocery_stores" "public_transportation" "wine_cellar"]
+					details {
+						"feature_robust_accuracy_contributions" (true)
+					}
+					num_robust_influence_samples 2000
+					goal_features_map {"price" {"goal" "max"}}
+					goal_dependent_features ["city"]
+				))
+				[1 "payload" "feature_robust_accuracy_contributions"]
+			)
+	))
+
+	(print
+		"Goaled: " (get goaled_results "country_clubs") "\n"
+		"UnGoaled: " (get ungoaled_results "country_clubs") "\n"
+	)
+
+	(call assert_true (assoc
+		obs (> (get goaled_results "country_clubs") (* 1.5 (get ungoaled_results "country_clubs")) )
+	))
+
+	(call exit_if_failures (assoc msg "Aggregate with goal features."))
+
+	(call exit_if_failures (assoc msg unit_test_name))
+)

--- a/unit_tests/ut_howso.amlg
+++ b/unit_tests/ut_howso.amlg
@@ -75,6 +75,7 @@
 				"ut_h_weighted_residuals_cont.amlg"
 				"ut_h_weighted_residuals_nom.amlg"
 				"ut_h_goal_features.amlg"
+				"ut_h_goal_features_agg.amlg"
 
 				;should always be last
 				"ut_h_migration.amlg"


### PR DESCRIPTION
Adds two parameters to `react_aggregate` which allow users to specify goals that will bias the sampling of cases that will be used to compute the desired metrics.

`goal_features_map` takes a map of feature names to goals (just like the `react` equivalent). Instead of changing the logic of predictions though, these specified goals instead alter the behavior of how the cases are sampled to compute each metric. Cases are sampled in a way that will still randomly select from the trained data, but will still bias towards optimizing the defined goals for each sampled region of the data.

`goal_dependent_features` takes a list of features and can be used to specify features that will not be ignored while optimizing the goal in the sampling process within each subregion of the data.