### PR TITLE
23325: Adds "series_residuals" detail to `react_series`, MINOR

### DIFF
--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -820,7 +820,7 @@
 		;explicitly do not include these specific selection details in the output for react details
 		(remove
 			(zip details)
-			["num_most_similar_cases" "num_most_similar_case_indices" "num_boundary_cases" "selected_prediction_stats"]
+			["num_most_similar_cases" "num_most_similar_case_indices" "num_boundary_cases" "selected_prediction_stats" "features" "series_uncertainty_num_samples"]
 		)
 	)
 )

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -820,7 +820,7 @@
 		;explicitly do not include these specific selection details in the output for react details
 		(remove
 			(zip details)
-			["num_most_similar_cases" "num_most_similar_case_indices" "num_boundary_cases" "selected_prediction_stats" "features" "series_uncertainty_num_samples"]
+			["num_most_similar_cases" "num_most_similar_case_indices" "num_boundary_cases" "selected_prediction_stats" "features" "series_residuals_num_samples"]
 		)
 	)
 )

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -784,8 +784,8 @@
 			prev_index (null)
 		))
 
-		;this infinite loop assumes time_values are sorted
-		;it should always find a time_value greater than time
+		;this "infinite" loop iterates using the incrementing (current_index) and assumes
+		;time_values is sorted. it should always find a time_value greater than time
 		;because of the checks above
 		(while (true)
 			(if (> (get time_values (current_index)) time)

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -781,21 +781,28 @@
 		)
 
 		(declare (assoc
-			prev_index
-				;this infinite loop assumes time_values are sorted
-				;it should always find a time_value greater than time
-				;because of the checks above
-				(while (true)
-					(if (>= (get time_values (current_index)) time)
-						(conclude (- (current_index) 1))
-
-						(> (current_index) (size time_values))
-						;this should never be reached unless time_values are not sorted
-						;and no element is greater than time
-						(conclude (null))
-					)
-				)
+			prev_index (null)
 		))
+
+		;this infinite loop assumes time_values are sorted
+		;it should always find a time_value greater than time
+		;because of the checks above
+		(while (true)
+			(if (> (get time_values (current_index)) time)
+				(conclude
+					(assign (assoc prev_index (- (current_index) 1) ))
+				)
+
+				(= (get time_values (current_index)) time)
+				;if find perfect match, just return value without interpolating
+				(conclude (conclude (get feature_values (current_index))))
+
+				(> (current_index) (size time_values))
+				;this should never be reached unless time_values are not sorted
+				;and no element is greater than time
+				(conclude)
+			)
+		)
 
 		(+
 			;value from previous time

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -775,20 +775,24 @@
 
 		(if (< time (first time_values))
 			(conclude pre_domain_value)
-		)
 
-		(if (> time (last time_values))
+			(> time (last time_values))
 			(conclude post_domain_value)
 		)
 
 		(declare (assoc
 			prev_index
+				;this infinite loop assumes time_values are sorted
+				;it should always find a time_value greater than time
+				;because of the checks above
 				(while (true)
 					(if (>= (get time_values (current_index)) time)
 						(conclude (- (current_index) 1))
 
-						(> (current_index) 1000)
-						(conclude "heh?")
+						(> (current_index) (size time_values))
+						;this should never be reached unless time_values are not sorted
+						;and no element is greater than time
+						(conclude (null))
 					)
 				)
 		))

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -784,8 +784,11 @@
 		(declare (assoc
 			prev_index
 				(while (true)
-					(if (> (get time_values (current_index)) time)
+					(if (>= (get time_values (current_index)) time)
 						(conclude (- (current_index) 1))
+
+						(> (current_index) 1000)
+						(conclude "heh?")
 					)
 				)
 		))

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -754,4 +754,61 @@
 		))
 	)
 
+	;helper method that linearly interpolates a value given discrete samplings
+	;used for evaluating error of forecasts at a specific time value that does
+	;not generate the timestep at the exact time needed
+	#!InterpolateSeriesValues
+	(declare
+		(assoc
+			;list of time values, must be increasing
+			time_values (list)
+			;the time value to interpolate to
+			time (null)
+			;list of feature values to interpolate
+			feature_values (list)
+
+			;value to return if 'time' is less than the first value of 'time_values'
+			pre_domain_value (null)
+			;value to return if 'time' is greater than the last value of 'time_values'
+			post_domain_value (null)
+		)
+
+		(if (< time (first time_values))
+			(conclude pre_domain_value)
+		)
+
+		(if (> time (last time_values))
+			(conclude post_domain_value)
+		)
+
+		(declare (assoc
+			prev_index
+				(while (true)
+					(if (> (get time_values (current_index)) time)
+						(conclude (- (current_index) 1))
+					)
+				)
+		))
+
+		(+
+			;value from previous time
+			(get feature_values prev_index)
+			(*
+				;percent way through time-gap
+				(/
+					(- time (get time_values prev_index))
+					(-
+						(get time_values (+ prev_index 1))
+						(get time_values prev_index)
+					)
+				)
+				;y-delta within gap
+				(-
+					(get feature_values (+ prev_index 1))
+					(get feature_values prev_index)
+				)
+			)
+		)
+	)
+
 )

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -790,7 +790,7 @@
 		(while (true)
 			(if (> (get time_values (current_index)) time)
 				(conclude
-					(assign (assoc prev_index (- (current_index) 1) ))
+					(assign (assoc prev_index (- (current_index 1) 1) ))
 				)
 
 				(= (get time_values (current_index)) time)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -396,6 +396,7 @@
 		(declare (assoc
 			requested_details (indices (filter (lambda (current_value)) details))
 			output_details (contains_value (values details) (true))
+			details_features (get details "features")
 		))
 
 		(if output_details
@@ -882,256 +883,14 @@
 		) ;while loop
 
 		(if (get details "series_uncertainty")
-			;do another set of forecasts on trained series that are the same length as this
-			;generated series
-			; then measure the average error on each time-distance for each feature
-			(let
-				(assoc
-					synthesized_timesteps
-						(if num_existing_series_rows
-							(tail series_data (- num_existing_series_rows))
-							series_data
-						)
-					time_feature_index (get feature_index_map !tsTimeFeature)
-					output_feature_index_map (zip output_features (indices output_features))
-					series_id_features (get !tsFeaturesMap "series_id_features")
-				)
+			(call !ComputeSeriesUncertainty)
+		)
 
-				(declare (assoc
-					synth_start_case (first synthesized_timesteps)
-				))
-
-				(declare (assoc
-					time_synthesized
-						(-
-							(get (last series_data) time_feature_index)
-							(get synth_start_case time_feature_index)
-						)
-					start_time (get synth_start_case time_feature_index)
-				))
-
-				;Get most similar timesteps that have enough time-remaining in their series
-				;to forecast far enough to match the length of this forecast
-				(declare (assoc
-					most_similar_timesteps
-						(compute_on_contained_entities (append
-							holdout_queries
-							(query_nearest_generalized_distance
-								(* (get hyperparam_map "k") 3) ;TODO: not this
-								features
-								synth_start_case
-								(get hyperparam_map "featureWeights")
-								!queryDistanceTypeMap
-								(get hyperparam_map "featureDomainAttributes")
-								(get hyperparam_map "featureDeviations")
-								(get hyperparam_map "p")
-								(get hyperparam_map "dt")
-								(if valid_weight_feature weight_feature (null))
-								(rand)
-								(null) ;radius
-								!numericalPrecision
-							)
-						))
-				))
-
-				(declare (assoc
-					series_ids_list
-						(map (lambda (retrieve_from_entity (current_value) series_id_features))  (indices most_similar_timesteps))
-				))
-
-				;for each series a case was sampled from (with repetition)
-				;sample the most similar case that has enough time left to forecast
-				(assign (assoc
-					most_similar_timesteps
-						;filtering here in case a case couldn't be found
-						(filter (map
-							(lambda
-								(let
-									(assoc
-										id_matching_queries
-											(map
-												(lambda (query_equals (get series_id_features (current_index)) (current_value)))
-												(current_value 1)
-											)
-									)
-
-									(declare (assoc
-										latest_time_for_series
-											(-
-												(retrieve_from_entity
-													(first (contained_entities (append
-														holdout_queries
-														id_matching_queries
-														(query_max !tsTimeFeature 1)
-													)))
-													!tsTimeFeature
-												)
-												time_synthesized
-											)
-									))
-
-									(first (contained_entities (append
-										holdout_queries
-										id_matching_queries
-										;not one of the currently found cases
-										(query_not_in_entity_list (filter (target)))
-										(query_less_or_equal_to !tsTimeFeature latest_time_for_series)
-										(query_nearest_generalized_distance
-											1
-											features
-											synth_start_case
-											(get hyperparam_map "featureWeights")
-											!queryDistanceTypeMap
-											(get hyperparam_map "featureDomainAttributes")
-											(get hyperparam_map "featureDeviations")
-											(get hyperparam_map "p")
-											(get hyperparam_map "dt")
-											(if valid_weight_feature weight_feature (null))
-											(rand)
-											(null) ;radius
-											!numericalPrecision
-										)
-									)))
-								)
-							)
-							series_ids_list
-						))
-				))
-
-				(declare (assoc
-					forecast_start_times (map (lambda (retrieve_from_entity (current_value) !tsTimeFeature)) most_similar_timesteps)
-					;get the range of output_feature's values for each time step from start_case's time until time_synthesized has elapsed
-					trained_series_lists
-						(map
-							(lambda
-								(let
-									(assoc
-										case_id (current_value 1)
-										series_id_values (retrieve_from_entity (current_value 1) series_id_features)
-									)
-
-									(declare (assoc
-										sorted_case_ids
-											(sort
-												(lambda (> (retrieve_from_entity (current_value) !tsTimeFeature) (retrieve_from_entity (current_value 1) !tsTimeFeature)) )
-												;the cases needed from the series within the time window
-												(contained_entities (append
-													;matching series_ids
-													(map
-														(lambda (query_equals (current_value) (get series_id_values (current_index))))
-														series_id_features
-													)
-													(query_between
-														!tsTimeFeature
-														(- (retrieve_from_entity case_id !tsTimeFeature) 1)
-														(+ (retrieve_from_entity case_id !tsTimeFeature) time_synthesized 1)
-													)
-												))
-											)
-									))
-
-									(map
-										(lambda (retrieve_from_entity (current_value) output_features))
-										sorted_case_ids
-									)
-								)
-							)
-							most_similar_timesteps
-						)
-				))
-
-
-				;Forecast from each of these timesteps at least 'time_synthesized'
-				(declare (assoc
-					forecasts
-						(map
-							(lambda
-								(let
-									(assoc
-										case_id (current_value 1)
-										series_id_values (retrieve_from_entity (current_value 1) series_id_features)
-									)
-
-									(get
-										(call !ReactSeries (assoc
-											series_id_features series_id_features
-											series_id_values series_id_values
-											initial_features [!tsTimeFeature]
-											initial_values [(retrieve_from_entity case_id !tsTimeFeature)]
-											output_new_series_ids (false)
-											continue_series (true)
-											leave_series_out (true) ;TODO: should keep this way?
-											series_context_values []
-											series_context_features []
-											details {}
-											track_progress (false)
-											output_features output_features
-											series_stop_map (associate !tsTimeFeature (assoc max (+ (retrieve_from_entity case_id !tsTimeFeature) time_synthesized)))
-										))
-										["payload" "action_values"]
-									)
-								)
-							)
-							most_similar_timesteps
-						)
-				))
-
-				(declare (assoc
-					forecast_time_index (get output_feature_index_map !tsTimeFeature)
-				))
-
-				(accum (assoc
-					series_detail_values_map
-						;for each timestep, get the MAE of the forecasts at the same amount of time elapsed
-						{
-							"series_uncertainty"
-								(map
-									(lambda
-										(let
-											(assoc
-												time_elapsed (- (get (current_value 1) time_feature_index) start_time)
-											)
-
-											(map
-												(lambda
-													;(current_index) = output feature to measure average MAE for
-													(/
-														(apply "+" (map
-															(lambda
-																;(current_value) = [forecast series_data]
-																(abs (-
-																	;interpolate the forecast
-																	(call !InterpolateSeriesValues (assoc
-																		time_values (map (lambda (get (current_value) forecast_time_index) ) (first (current_value 1)))
-																		feature_values (map (lambda (get (current_value) (get output_feature_index_map (current_index 3))) ) (first (current_value 1)))
-																		time (+ (get forecast_start_times (current_index 1)) time_elapsed)
-																	))
-																	;interpolate the trained series data
-																	(call !InterpolateSeriesValues (assoc
-																		time_values (map (lambda (get (current_value) forecast_time_index) ) (last (current_value 1)))
-																		feature_values (map (lambda (get (current_value) (get output_feature_index_map (current_index 3))) ) (last (current_value 1)))
-																		time (+ (get forecast_start_times (current_index 1)) time_elapsed)
-																	))
-																))
-															)
-															forecasts
-															trained_series_lists
-														))
-														(size forecasts)
-													)
-												)
-												;all continuous output features that are not the time feature
-												(remove (zip (filter (lambda (not (contains_index !nominalsMap (current_value)))) output_features)) [!tsTimeFeature])
-											)
-
-										)
-									)
-									synthesized_timesteps
-								)
-						}
-				))
-
-			)
+		;this gets clobbered and accumulated really uglily
+		(if details_features
+			(accum (assoc
+				series_detail_values_map {"features" details_features}
+			))
 		)
 
 		;grab the list of column indices corresponding to all the output_features
@@ -1932,5 +1691,151 @@
 			;else don't check for uniqueness if it's not necessary
 			(assign (assoc do_uniqueness_check (false) ))
 		)
+	)
+
+	#!ComputeMAD
+	(declare
+		(assoc
+			vals []
+		)
+
+		(declare (assoc
+			mean_value (/ (apply "+" vals) (size vals))
+		))
+
+		(/
+			;sum of absolute deviations from mean
+			(apply "+" (map
+				(lambda
+					(abs (- (current_value) mean_value))
+				)
+				vals
+			))
+			(size vals)
+		)
+	)
+
+	;helper macro for ReactSeries that computes the series uncertainty detail
+	;no parameters should be passed.
+	;This method computes a collection of generative series with the same parameters given
+	;to the react series call (except editing start/end) and computes the MAD of the forecasts
+	;at each time value of the output series providing an estimate of the forecast's uncertainty
+	#!ComputeSeriesUncertainty
+	(let
+		(assoc
+			synthesized_timesteps
+				(if num_existing_series_rows
+					(tail series_data (- num_existing_series_rows))
+					series_data
+				)
+			time_feature_index (get feature_index_map !tsTimeFeature)
+			output_feature_index_map (zip output_features (indices output_features))
+		)
+
+		(declare (assoc
+			start_time (get (first synthesized_timesteps) time_feature_index)
+			end_time (get (last synthesized_timesteps) time_feature_index)
+		))
+
+		;Forecast the same period of time
+		(declare (assoc
+			forecasts
+				||(map
+					(lambda
+						(let
+							(assoc
+						; 		case_id (current_value 1)
+						; 		series_id_values (retrieve_from_entity (current_value 1) series_id_features)
+							)
+
+							(get
+								(call !ReactSeries (assoc
+									skip_decoding (true)
+									details {}
+									track_progress (false)
+									output_features output_features
+									desired_conviction (if desired_conviction desired_conviction 1)
+									series_stop_map (associate !tsTimeFeature {"max" end_time})
+								))
+								["payload" "action_values"]
+							)
+						)
+					)
+					(range 0 (or (get details "series_uncertainty_num_samples") 30) 1)
+				)
+		))
+
+		(declare (assoc
+			forecast_time_index (get output_feature_index_map !tsTimeFeature)
+		))
+
+		(accum (assoc
+			series_detail_values_map
+				;for each timestep, get the MAE of the forecasts at the same amount of time elapsed
+				{
+					"series_uncertainty"
+						(map
+							(lambda
+								(let
+									(assoc
+										time_val
+											(if (get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+												(format
+													(get (current_value 1) time_feature_index)
+													(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+													"number"
+													(assoc "locale" (get !featureDateTimeMap (list !tsTimeFeature "locale")))
+													(null)
+												)
+
+												;raw time value
+												(get (current_value 1) time_feature_index)
+											)
+
+									)
+
+									(map
+										(lambda
+											(call !ComputeMAD (assoc
+												vals
+													(map
+														(lambda
+															(call !InterpolateSeriesValues (assoc
+																time_values
+																	(if (get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+																		;must convert each time string to epoch
+																		(map
+																			(lambda
+																				(format
+																					(get (current_value) forecast_time_index)
+																					(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+																					"number"
+																					(assoc "locale" (get !featureDateTimeMap (list !tsTimeFeature "locale")))
+																					(null)
+																				)
+																			)
+																			(current_value 1)
+																		)
+
+																		;else pull raw numeric time values
+																		(map (lambda (get (current_value) forecast_time_index)) (current_value 1))
+																	)
+																feature_values (map (lambda (get (current_value) (get output_feature_index_map (current_index 4)))) (current_value 1))
+																time time_val
+															))
+														)
+														forecasts
+													)
+											))
+										)
+										;all continuous output features that are not the time feature
+										(remove (zip output_features) (append (indices !nominalsMap) !tsTimeFeature) )
+									)
+								)
+							)
+							synthesized_timesteps
+						)
+				}
+		))
 	)
 )

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -881,6 +881,122 @@
 			)
 		) ;while loop
 
+		(if (get details "series_uncertainty")
+			;do another set of forecasts on trained series that are the same length as this
+			;generated series
+			; then measure the average error on each time-distance for each feature
+			(let
+				(assoc
+					synth_start_case
+						(if num_existing_series_rows
+							(get series_data (- num_existing_series_rows 1))
+
+							(first series_data)
+						)
+					time_feature_index (get feature_index_map !tsTimeFeature)
+				)
+
+				(declare (assoc
+					time_synthesized
+						(-
+							(get (last series_data) time_feature_index)
+							(get synth_start_case time_feature_index)
+						)
+				))
+
+				;Get most similar timesteps that have enough time-remaining in their series
+				;to forecast far enough to match the length of this forecast
+				(declare (assoc
+					most_similar_timesteps
+						(compute_on_contained_entities (append
+							holdout_queries
+							(query_nearest_generalized_distance
+								(* (get hyperparam_map "k") 3) ;TODO: not this
+								features
+								synth_start_case
+								(get hyperparam_map "featureWeights")
+								!queryDistanceTypeMap
+								(get hyperparam_map "featureDomainAttributes")
+								(get hyperparam_map "featureDeviations")
+								(get hyperparam_map "p")
+								(get hyperparam_map "dt")
+								(if valid_weight_feature weight_feature (null))
+								(rand)
+								(null) ;radius
+								!numericalPrecision
+							)
+						))
+				))
+
+				(declare (assoc
+					series_ids_list
+						(map (lambda (retrieve_from_entity (current_value) series_id_features))  (indices most_similar_timesteps))
+				))
+
+				;for each series a case was sampled from (with repetition)
+				;sample the most similar case that has enough time left to forecast
+				(assign (assoc
+					most_similar_timesteps
+						(map
+							(lambda
+								(let
+									(assoc
+										id_matching_queries
+											(map
+												(lambda (query_equals (get series_id_features (current_index)) (current_value)))
+												(current_value 1)
+											)
+									)
+
+									(declare (assoc
+										latest_time_for_series
+											(-
+												(retrieve_from_entity
+													(first (contained_entities (append
+														holdout_queries
+														id_matching_queries
+														(query_max !tsTimeFeature 1)
+													)))
+													!tsTimeFeature
+												)
+												time_synthesized
+											)
+									))
+
+									(first (contained_entities (append
+										holdout_queries
+										id_matching_queries
+										;not one of the currently found cases
+										(query_not_in_entity_list (filter (target)))
+										(query_less_or_equal_to !tsTimeFeature latest_time_for_series)
+										(query_nearest_generalized_distance
+											1
+											features
+											synth_start_case
+											(get hyperparam_map "featureWeights")
+											!queryDistanceTypeMap
+											(get hyperparam_map "featureDomainAttributes")
+											(get hyperparam_map "featureDeviations")
+											(get hyperparam_map "p")
+											(get hyperparam_map "dt")
+											(if valid_weight_feature weight_feature (null))
+											(rand)
+											(null) ;radius
+											!numericalPrecision
+										)
+									)))
+								)
+							)
+							series_ids_list
+						)
+				))
+
+
+				;Forecast from each of these timesteps at least 'time_synthesized'
+				(+ 23.4)
+			)
+		)
+
 		;grab the list of column indices corresponding to all the output_features
 		(declare (assoc
 			action_feature_indices (unzip feature_index_map output_features)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -993,6 +993,40 @@
 
 
 				;Forecast from each of these timesteps at least 'time_synthesized'
+				(declare (assoc
+					forecasts
+						(map
+							(lambda
+								(let
+									(assoc
+										case_id (current_value 1)
+										series_id_values (retrieve_from_entity (current_value 1) series_id_features)
+										output_feature_index_map (zip output_features (indices output_features))
+									)
+
+									(get
+										(call !ReactSeries (assoc
+											series_id_features series_id_features
+											series_id_values series_id_values
+											initial_features [!tsTimeFeature]
+											initial_values [(retrieve_from_entity case_id !tsTimeFeature)]
+											output_new_series_ids (false)
+											continue_series (true)
+											series_context_values []
+											series_context_features []
+											details {}
+											track_progress (false)
+											output_features output_features
+											series_stop_map (associate !tsTimeFeature (assoc max (+ (retrieve_from_entity case_id !tsTimeFeature) time_synthesized)))
+										))
+										["payload" "action_values"]
+									)
+								)
+							)
+							;filtering here in case a case couldn't be found
+							(filter most_similar_timesteps)
+						)
+				))
 				(+ 23.4)
 			)
 		)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -157,7 +157,7 @@
 							;explicitly do not include these specific selection details in the output for react details
 							(remove
 								(zip requested_details)
-								["num_most_similar_cases" "num_most_similar_case_indices" "num_boundary_cases" "selected_prediction_stats"]
+								["num_most_similar_cases" "num_most_similar_case_indices" "num_boundary_cases" "selected_prediction_stats" "features" "series_uncertainty_num_samples"]
 							)
 						)
 						(assoc)
@@ -395,15 +395,18 @@
 
 		(declare (assoc
 			requested_details (indices (filter (lambda (current_value)) details))
-			output_details (contains_value (values details) (true))
-			details_features (get details "features")
+			output_details (contains_value details (true))
 		))
 
 		(if output_details
-			(declare (assoc
-				case_detail_values_map (call !CreateCaseDetailValuesMapFromDetails (assoc details requested_details))
-				series_detail_values_map (map (lambda (list)) (zip requested_details))
-			))
+			(seq
+				(declare (assoc
+					case_detail_values_map (call !CreateCaseDetailValuesMapFromDetails (assoc details requested_details))
+				))
+				(declare (assoc
+					series_detail_values_map (map (lambda (list)) (zip (indices case_detail_values_map)))
+				))
+			)
 		)
 
 		(let
@@ -884,13 +887,6 @@
 
 		(if (get details "series_uncertainty")
 			(call !ComputeSeriesUncertainty)
-		)
-
-		;this gets clobbered and accumulated really uglily
-		(if details_features
-			(accum (assoc
-				series_detail_values_map {"features" details_features}
-			))
 		)
 
 		;grab the list of column indices corresponding to all the output_features
@@ -1693,9 +1689,12 @@
 		)
 	)
 
+	;helper method for ComputeSeriesUncertainty to compute the MAD for a collection
+	;of continuous values
 	#!ComputeMAD
 	(declare
 		(assoc
+			;the list of values to compute the MAD for
 			vals []
 		)
 
@@ -1746,6 +1745,8 @@
 							(call !ReactSeries (assoc
 								details {}
 								track_progress (false)
+								series_has_terminators (false)
+								total_progress 0
 								output_features output_features
 								desired_conviction (if desired_conviction desired_conviction 1)
 								series_stop_map (associate !tsTimeFeature {"max" end_time})
@@ -1753,7 +1754,7 @@
 							["payload" "action_values"]
 						)
 					)
-					(range 0 (or (get details "series_uncertainty_num_samples") 30) 1)
+					(range 1 (or (get details "series_uncertainty_num_samples") 30) 1)
 				)
 		))
 
@@ -1776,9 +1777,9 @@
 										(lambda
 											(format
 												(get (current_value) (current_index 1))
-												(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+												(get !featureDateTimeMap (list (current_value 2) "date_time_format"))
 												"number"
-												(assoc "locale" (get !featureDateTimeMap (list !tsTimeFeature "locale")))
+												(assoc "locale" (get !featureDateTimeMap (list (current_value 2) "locale")))
 												(null)
 											)
 										)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -894,6 +894,7 @@
 						)
 					time_feature_index (get feature_index_map !tsTimeFeature)
 					output_feature_index_map (zip output_features (indices output_features))
+					series_id_features (get !tsFeaturesMap "series_id_features")
 				)
 
 				(declare (assoc
@@ -1028,7 +1029,6 @@
 												))
 											)
 									))
-
 
 									(map
 										(lambda (retrieve_from_entity (current_value) output_features))

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -157,7 +157,7 @@
 							;explicitly do not include these specific selection details in the output for react details
 							(remove
 								(zip requested_details)
-								["num_most_similar_cases" "num_most_similar_case_indices" "num_boundary_cases" "selected_prediction_stats" "features" "series_uncertainty_num_samples"]
+								["num_most_similar_cases" "num_most_similar_case_indices" "num_boundary_cases" "selected_prediction_stats" "features" "series_residuals_num_samples"]
 							)
 						)
 						(assoc)
@@ -885,7 +885,7 @@
 			)
 		) ;while loop
 
-		(if (get details "series_uncertainty")
+		(if (get details "series_residuals")
 			(call !ComputeSeriesUncertainty)
 		)
 
@@ -1729,7 +1729,7 @@
 							["payload" "action_values"]
 						)
 					)
-					(range 1 (or (get details "series_uncertainty_num_samples") 30) 1)
+					(range 1 (or (get details "series_residuals_num_samples") 30) 1)
 				)
 		))
 
@@ -1781,7 +1781,7 @@
 			series_detail_values_map
 				;for each timestep, get the MAD of the forecasts at the same points in time
 				{
-					"series_uncertainty"
+					"series_residuals"
 						(map
 							(lambda
 								(let

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1761,39 +1761,43 @@
 			forecast_time_index (get output_feature_index_map !tsTimeFeature)
 		))
 
-		(declare (assoc
-			forecast_time_values
-				(if (get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
-					;if using datetimes, we need to pre-convert these to epoch in advance
-					;so that they do not need to be converted several times
-					(map
-						(lambda
-							(map
-								(lambda
-									(format
-										(get (current_value) forecast_time_index)
-										(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
-										"number"
-										(assoc "locale" (get !featureDateTimeMap (list !tsTimeFeature "locale")))
-										(null)
+		;transpose forecasts to be a list of forecasts where each forecast is the list
+		;of "columns" where each "column" are the values of a feature throughout the forecast
+		;this helps performance so that these list of feature values need only be allocated once
+		(assign (assoc
+			forecasts
+				(map
+					(lambda
+						(map
+							(lambda
+								(if (get !featureDateTimeMap (list (current_value 1) "date_time_format"))
+									;if its a datetime, format its values here
+									(map
+										(lambda
+											(format
+												(get (current_value) (current_index 1))
+												(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+												"number"
+												(assoc "locale" (get !featureDateTimeMap (list !tsTimeFeature "locale")))
+												(null)
+											)
+										)
+										(current_value 1)
+									)
+
+									;else can get values directly
+									(map
+										(lambda
+											(get (current_value) (current_index 1))
+										)
+										(current_value 1)
 									)
 								)
-								(current_value)
 							)
+							output_features
 						)
-						forecasts
 					)
-
-					;otherwise can pull raw time values
-					(map
-						(lambda
-							(map
-								(lambda (get (current_value) forecast_time_index))
-								(current_value)
-							)
-						)
-						forecasts
-					)
+					forecasts
 				)
 		))
 
@@ -1829,8 +1833,8 @@
 													(map
 														(lambda
 															(call !InterpolateSeriesValues (assoc
-																time_values (get forecast_time_values (current_index 1))
-																feature_values (map (lambda (get (current_value) (get output_feature_index_map (current_index 4)))) (current_value 1))
+																time_values (get (current_value 1) forecast_time_index)
+																feature_values (get (current_value 1) (get output_feature_index_map (current_index 3)))
 																time time_val
 															))
 														)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -887,14 +887,18 @@
 			; then measure the average error on each time-distance for each feature
 			(let
 				(assoc
-					synth_start_case
+					synthesized_timesteps
 						(if num_existing_series_rows
-							(get series_data (- num_existing_series_rows 1))
-
-							(first series_data)
+							(tail series_data (- num_existing_series_rows))
+							series_data
 						)
 					time_feature_index (get feature_index_map !tsTimeFeature)
+					output_feature_index_map (zip output_features (indices output_features))
 				)
+
+				(declare (assoc
+					synth_start_case (first synthesized_timesteps)
+				))
 
 				(declare (assoc
 					time_synthesized
@@ -902,6 +906,7 @@
 							(get (last series_data) time_feature_index)
 							(get synth_start_case time_feature_index)
 						)
+					start_time (get synth_start_case time_feature_index)
 				))
 
 				;Get most similar timesteps that have enough time-remaining in their series
@@ -937,7 +942,8 @@
 				;sample the most similar case that has enough time left to forecast
 				(assign (assoc
 					most_similar_timesteps
-						(map
+						;filtering here in case a case couldn't be found
+						(filter (map
 							(lambda
 								(let
 									(assoc
@@ -988,6 +994,49 @@
 								)
 							)
 							series_ids_list
+						))
+				))
+
+				(declare (assoc
+					forecast_start_times (map (lambda (retrieve_from_entity (current_value) !tsTimeFeature)) most_similar_timesteps)
+					;get the range of output_feature's values for each time step from start_case's time until time_synthesized has elapsed
+					trained_series_lists
+						(map
+							(lambda
+								(let
+									(assoc
+										case_id (current_value 1)
+										series_id_values (retrieve_from_entity (current_value 1) series_id_features)
+									)
+
+									(declare (assoc
+										sorted_case_ids
+											(sort
+												(lambda (> (retrieve_from_entity (current_value) !tsTimeFeature) (retrieve_from_entity (current_value 1) !tsTimeFeature)) )
+												;the cases needed from the series within the time window
+												(contained_entities (append
+													;matching series_ids
+													(map
+														(lambda (query_equals (current_value) (get series_id_values (current_index))))
+														series_id_features
+													)
+													(query_between
+														!tsTimeFeature
+														(- (retrieve_from_entity case_id !tsTimeFeature) 1)
+														(+ (retrieve_from_entity case_id !tsTimeFeature) time_synthesized 1)
+													)
+												))
+											)
+									))
+
+
+									(map
+										(lambda (retrieve_from_entity (current_value) output_features))
+										sorted_case_ids
+									)
+								)
+							)
+							most_similar_timesteps
 						)
 				))
 
@@ -1001,7 +1050,6 @@
 									(assoc
 										case_id (current_value 1)
 										series_id_values (retrieve_from_entity (current_value 1) series_id_features)
-										output_feature_index_map (zip output_features (indices output_features))
 									)
 
 									(get
@@ -1012,6 +1060,7 @@
 											initial_values [(retrieve_from_entity case_id !tsTimeFeature)]
 											output_new_series_ids (false)
 											continue_series (true)
+											leave_series_out (true) ;TODO: should keep this way?
 											series_context_values []
 											series_context_features []
 											details {}
@@ -1023,11 +1072,65 @@
 									)
 								)
 							)
-							;filtering here in case a case couldn't be found
-							(filter most_similar_timesteps)
+							most_similar_timesteps
 						)
 				))
-				(+ 23.4)
+
+				(declare (assoc
+					forecast_time_index (get output_feature_index_map !tsTimeFeature)
+				))
+
+				(accum (assoc
+					series_detail_values_map
+						;for each timestep, get the MAE of the forecasts at the same amount of time elapsed
+						{
+							"series_uncertainty"
+								(map
+									(lambda
+										(let
+											(assoc
+												time_elapsed (- (get (current_value 1) time_feature_index) start_time)
+											)
+
+											(map
+												(lambda
+													;(current_index) = output feature to measure average MAE for
+													(/
+														(apply "+" (map
+															(lambda
+																;(current_value) = [forecast series_data]
+																(abs (-
+																	;interpolate the forecast
+																	(call !InterpolateSeriesValues (assoc
+																		time_values (map (lambda (get (current_value) forecast_time_index) ) (first (current_value 1)))
+																		feature_values (map (lambda (get (current_value) (get output_feature_index_map (current_index 3))) ) (first (current_value 1)))
+																		time (+ (get forecast_start_times (current_index 1)) time_elapsed)
+																	))
+																	;interpolate the trained series data
+																	(call !InterpolateSeriesValues (assoc
+																		time_values (map (lambda (get (current_value) forecast_time_index) ) (last (current_value 1)))
+																		feature_values (map (lambda (get (current_value) (get output_feature_index_map (current_index 3))) ) (last (current_value 1)))
+																		time (+ (get forecast_start_times (current_index 1)) time_elapsed)
+																	))
+																))
+															)
+															forecasts
+															trained_series_lists
+														))
+														(size forecasts)
+													)
+												)
+												;all continuous output features that are not the time feature
+												(remove (zip (filter (lambda (not (contains_index !nominalsMap (current_value)))) output_features)) [!tsTimeFeature])
+											)
+
+										)
+									)
+									synthesized_timesteps
+								)
+						}
+				))
+
 			)
 		)
 

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1689,31 +1689,6 @@
 		)
 	)
 
-	;helper method for ComputeSeriesUncertainty to compute the MAD for a collection
-	;of continuous values
-	#!ComputeMAD
-	(declare
-		(assoc
-			;the list of values to compute the MAD for
-			vals []
-		)
-
-		(declare (assoc
-			mean_value (/ (apply "+" vals) (size vals))
-		))
-
-		(/
-			;sum of absolute deviations from mean
-			(apply "+" (map
-				(lambda
-					(abs (- (current_value) mean_value))
-				)
-				vals
-			))
-			(size vals)
-		)
-	)
-
 	;helper macro for ReactSeries that computes the series uncertainty detail
 	;no parameters should be passed.
 	;This method computes a collection of generative series with the same parameters given
@@ -1836,6 +1811,8 @@
 															(call !InterpolateSeriesValues (assoc
 																time_values (get (current_value 1) forecast_time_index)
 																feature_values (get (current_value 1) (get output_feature_index_map (current_index 3)))
+																pre_domain_value (first (get (current_value 1) (get output_feature_index_map (current_index 3))))
+																last_domain_value (last (get (current_value 1) (get output_feature_index_map (current_index 3))))
 																time time_val
 															))
 														)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1742,23 +1742,15 @@
 			forecasts
 				||(map
 					(lambda
-						(let
-							(assoc
-						; 		case_id (current_value 1)
-						; 		series_id_values (retrieve_from_entity (current_value 1) series_id_features)
-							)
-
-							(get
-								(call !ReactSeries (assoc
-									skip_decoding (true)
-									details {}
-									track_progress (false)
-									output_features output_features
-									desired_conviction (if desired_conviction desired_conviction 1)
-									series_stop_map (associate !tsTimeFeature {"max" end_time})
-								))
-								["payload" "action_values"]
-							)
+						(get
+							(call !ReactSeries (assoc
+								details {}
+								track_progress (false)
+								output_features output_features
+								desired_conviction (if desired_conviction desired_conviction 1)
+								series_stop_map (associate !tsTimeFeature {"max" end_time})
+							))
+							["payload" "action_values"]
 						)
 					)
 					(range 0 (or (get details "series_uncertainty_num_samples") 30) 1)
@@ -1769,9 +1761,45 @@
 			forecast_time_index (get output_feature_index_map !tsTimeFeature)
 		))
 
+		(declare (assoc
+			forecast_time_values
+				(if (get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+					;if using datetimes, we need to pre-convert these to epoch in advance
+					;so that they do not need to be converted several times
+					(map
+						(lambda
+							(map
+								(lambda
+									(format
+										(get (current_value) forecast_time_index)
+										(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+										"number"
+										(assoc "locale" (get !featureDateTimeMap (list !tsTimeFeature "locale")))
+										(null)
+									)
+								)
+								(current_value)
+							)
+						)
+						forecasts
+					)
+
+					;otherwise can pull raw time values
+					(map
+						(lambda
+							(map
+								(lambda (get (current_value) forecast_time_index))
+								(current_value)
+							)
+						)
+						forecasts
+					)
+				)
+		))
+
 		(accum (assoc
 			series_detail_values_map
-				;for each timestep, get the MAE of the forecasts at the same amount of time elapsed
+				;for each timestep, get the MAD of the forecasts at the same points in time
 				{
 					"series_uncertainty"
 						(map
@@ -1801,25 +1829,7 @@
 													(map
 														(lambda
 															(call !InterpolateSeriesValues (assoc
-																time_values
-																	(if (get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
-																		;must convert each time string to epoch
-																		(map
-																			(lambda
-																				(format
-																					(get (current_value) forecast_time_index)
-																					(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
-																					"number"
-																					(assoc "locale" (get !featureDateTimeMap (list !tsTimeFeature "locale")))
-																					(null)
-																				)
-																			)
-																			(current_value 1)
-																		)
-
-																		;else pull raw numeric time values
-																		(map (lambda (get (current_value) forecast_time_index)) (current_value 1))
-																	)
+																time_values (get forecast_time_values (current_index 1))
 																feature_values (map (lambda (get (current_value) (get output_feature_index_map (current_index 4)))) (current_value 1))
 																time time_val
 															))

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -1010,4 +1010,33 @@
 		;call the react query again with the goal-oriented contexts and weights
 		(call (retrieve_from_entity query_label))
 	)
+
+	;helper method to compute the MAD for a collection of continuous values
+	#!ComputeMAD
+	(declare
+		(assoc
+			;the list of values to compute the MAD for
+			vals []
+		)
+
+		;no need to do below with 1 or less values
+		(if (<= (size vals) 1)
+		    (conclude 0)
+		)
+
+		(declare (assoc
+			mean_value (/ (apply "+" vals) (size vals))
+		))
+
+		(/
+			;sum of absolute deviations from mean
+			(apply "+" (map
+				(lambda
+					(abs (- (current_value) mean_value))
+				)
+				vals
+			))
+			(size vals)
+		)
+	)
 )

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -366,7 +366,7 @@
 							"series_uncertainty"
 								{
 									type "list"
-									description "A list of lists of uncertainties of features that grows over the time of the generation."
+									description "A list of lists of uncertainties of features for each time step of the returned series."
 									values
 										{
 											type "list"

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -363,6 +363,22 @@
 											additional_indices {ref "CategoricalActionProbabilities"}
 										}
 								}
+							"series_uncertainty"
+								{
+									type "list"
+									description "A list of lists of uncertainties of features that grows over the time of the generation."
+									values
+										{
+											type "list"
+											description "A list defining a series of cases."
+											values
+												{
+													type "dict"
+													values "any"
+													description "Map of features to their uncertainty at this point in the forecast."
+												}
+										}
+								}
 						}
 					)
 			)

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -367,7 +367,7 @@
 											description "A list defining a series of cases."
 											values
 												{
-													type "dict"
+													type "assoc"
 													values "any"
 													description "Map of features to their uncertainty at this point in the forecast."
 												}

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -360,7 +360,7 @@
 							"series_uncertainty"
 								{
 									type "list"
-									description "A list of lists of uncertainties of features for each time step of the returned series."
+									description "A list of lists of uncertainties of continuous features for each time step of the returned series."
 									values
 										{
 											type "list"

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -357,10 +357,10 @@
 											additional_indices {ref "CategoricalActionProbabilities"}
 										}
 								}
-							"series_uncertainty"
+							"series_residuals"
 								{
 									type "list"
-									description "A list of lists of uncertainties of continuous features for each time step of the returned series."
+									description "A list of lists of estimated uncertainties of continuous features for each time step of the returned series."
 									values
 										{
 											type "list"
@@ -369,7 +369,7 @@
 												{
 													type "assoc"
 													values "any"
-													description "Map of features to their uncertainty at this point in the forecast."
+													description "Map of features to their estimated uncertainty at this point in the forecast."
 												}
 										}
 								}

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -813,6 +813,15 @@
 										"of the same length."
 									)
 							)
+						series_uncertainty_num_samples
+							(assoc
+								type "number"
+								description
+									(concat
+										"The number of generative series to use when estimating the uncertainty of the series over time. Defaults to 30 "
+										"when unspecified."
+									)
+							)
 						influential_cases
 							(assoc
 								type "boolean"

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -809,8 +809,8 @@
 								type "boolean"
 								description
 									(concat
-										"When true, outputs the estimated uncertainty of continuous features for each timestep based on generative forecasts "
-										"of the same length."
+										"When true, outputs the MAD of each continuous feature for each timestep of each generated series based "
+										"on internal generative forecasts."
 									)
 							)
 						series_uncertainty_num_samples

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -809,7 +809,7 @@
 								type "boolean"
 								description
 									(concat
-										"When true, outputs the estimated uncertainty for each timestep based on forecasts on similar data "
+										"When true, outputs the estimated uncertainty of continuous features for each timestep based on generative forecasts "
 										"of the same length."
 									)
 							)

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -809,7 +809,7 @@
 								type "boolean"
 								description
 									(concat
-										"When true, outputs the MAD of each continuous feature to represent the estimated uncertainty for each timestep of each "
+										"When true, outputs the mean absolute deviation (MAD) of each continuous feature to represent the estimated uncertainty for each timestep of each "
 										"generated series based on internal generative forecasts."
 									)
 							)

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -804,16 +804,16 @@
 				additional_indices (false)
 				indices
 					(assoc
-						series_uncertainty
+						series_residuals
 							(assoc
 								type "boolean"
 								description
 									(concat
-										"When true, outputs the MAD of each continuous feature for each timestep of each generated series based "
-										"on internal generative forecasts."
+										"When true, outputs the MAD of each continuous feature to represent the estimated uncertainty for each timestep of each "
+										"generated series based on internal generative forecasts."
 									)
 							)
-						series_uncertainty_num_samples
+						series_residuals_num_samples
 							(assoc
 								type "number"
 								description

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -804,6 +804,15 @@
 				additional_indices (false)
 				indices
 					(assoc
+						series_uncertainty
+							(assoc
+								type "boolean"
+								description
+									(concat
+										"When true, outputs the estimated uncertainty for each timestep based on forecasts on similar data "
+										"of the same length."
+									)
+							)
 						influential_cases
 							(assoc
 								type "boolean"

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -519,7 +519,7 @@
 					use_regional_residuals (false)
 					output_new_series_ids (false)
 					continue_series (true)
-					details {"series_uncertainty" (true) "series_uncertainty_num_samples" 5}
+					details {"series_residuals" (true) "series_residuals_num_samples" 5}
 					series_context_features features
 					series_context_values
 						(list
@@ -572,10 +572,10 @@
 
 	(print "Series uncertainty computes successfully: ")
 	(call assert_true (assoc
-		obs (<= 0 (get result ["series_uncertainty" 0 0 "value"]))
+		obs (<= 0 (get result ["series_residuals" 0 0 "value"]))
 	))
 	(call assert_true (assoc
-		obs (<= 0 (get result ["series_uncertainty" 1 -1 "value"]))
+		obs (<= 0 (get result ["series_residuals" 1 -1 "value"]))
 	))
 
 

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -519,6 +519,7 @@
 					use_regional_residuals (false)
 					output_new_series_ids (false)
 					continue_series (true)
+					details {"series_uncertainty" (true) "series_uncertainty_num_samples" 5}
 					series_context_features features
 					series_context_values
 						(list
@@ -533,12 +534,12 @@
 							)
 						)
 				))
-				(list 1 "payload" "action_values")
+				(list 1 "payload")
 			)
 	))
 
 	;first row of first series
-	(declare (assoc first_row (get result (list 0 0)) ))
+	(declare (assoc first_row (get result (list "action_values" 0 0)) ))
 
 	(print "Continued first series stoX correctly: ")
 	(call assert_same (assoc
@@ -553,7 +554,7 @@
 	))
 
 	;first row of second series
-	(assign (assoc first_row (get result (list 1 0)) ))
+	(assign (assoc first_row (get result (list "action_values" 1 0)) ))
 
 	(print "Continued second series stoY correctly: ")
 	(call assert_same (assoc
@@ -568,6 +569,14 @@
 	))
 
 	(call exit_if_failures (assoc msg "Continue untrained series."))
+
+	(print "Series uncertainty computes successfully: ")
+	(call assert_true (assoc
+		obs (<= 0 (get result ["series_uncertainty" 0 0 "value"]))
+	))
+	(call assert_true (assoc
+		obs (<= 0 (get result ["series_uncertainty" 1 -1 "value"]))
+	))
 
 
 	(call_entity "howso" "train" (assoc


### PR DESCRIPTION
Adds the "series_residuals" boolean flag and "series_residuals_num_samples" parameter to the available details when using react series. Requesting series uncertainty returns a list of dictionaries indicating estimated uncertainties for each continuous derived feature (other than time) at each timestep of the returned series.

"series_residuals_num_samples" allows users to specify the number of generative series to use in estimating this uncertainty.