### PR TITLE
23513: Fixes full residuals output to always return a single value

### DIFF
--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -1328,7 +1328,7 @@
 								;or simply null for inactive features
 								(if (contains_index !inactiveFeaturesMap (get features (current_index)))
 									(null)
-									(get hyperparam_map (list "featureDeviations" (get features (current_index 1))))
+									(get hyperparam_map (list "featureResiduals" (get features (current_index 1))))
 								)
 							))
 							feature_residuals_lists

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -792,12 +792,12 @@
 	(call assert_approximate (assoc
 		obs (get result (list 1 "payload" "feature_robust_residuals_for_case"))
 		exp (assoc
-				"A" .24
+				"A" .27
 				"B" 2.2
 		)
 		thresh
 			(assoc
-				"A" .14
+				"A" .17
 				"B" 1
 			)
 	))


### PR DESCRIPTION
featureDeviations in hyperparameters store tuples of null uncertainties, SDM, etc. 
featureResiduals store just the residual value, so the fix is to simply pull dataset value from that instead.