### PR TITLE
23473: Adds `use_all_features` flag to `react_series`, MINOR

### DIFF
--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -661,6 +661,7 @@
 					(if use_all_features
 						(get !tsFeaturesMap "lag_features")
 
+						;only keep the lags for the action features
 						(filter
 							(lambda (contains_value action_features (get !derivedFeaturesMap (current_value))))
 							(get !tsFeaturesMap "lag_features")
@@ -744,7 +745,7 @@
 						(filter
 							(lambda
 								(or
-									;it's relied on that categorical features get put in the "delta_features" list...
+									;categorical features are in the "delta_features" list...
 									(!= "continuous" (get !featureAttributes [(current_value 1) "type"]))
 									(contains_value derived_action_features (get !derivedFeaturesMap (current_value)))
 								)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -698,7 +698,10 @@
 				(filter
 					(lambda (and
 						(get !featureAttributes (list (current_value 1) "derived_feature_code"))
-						(contains_value action_features (get !derivedFeaturesMap (current_value)))
+						(or
+							(contains_value (get !tsFeaturesMap "series_id_features") (current_value))
+							(contains_value action_features (get !derivedFeaturesMap (current_value)))
+						)
 						(not (contains_value derived_context_features (current_value)))
 						(not (contains_value derived_action_features (current_value)))
 						;whether .series_progress should be in derived_context_features is determined above
@@ -725,7 +728,13 @@
 						(list)
 					)
 					(filter
-						(lambda (contains_value derived_action_features (get !derivedFeaturesMap (current_value))))
+						(lambda
+							(or
+								;it's relied on that categorical features get put in the "delta_features" list...
+								(!= "continuous" (get !featureAttributes [(current_value 1) "type"]))
+								(contains_value derived_action_features (get !derivedFeaturesMap (current_value)))
+							)
+						)
 						(get !tsFeaturesMap "delta_features")
 					)
 					(filter

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -653,12 +653,15 @@
 			all_contexts_set (zip all_contexts)
 		))
 
-		;derived context features should contain the lags. This list was populated during their creation.
+		;derived context features should contain the needed lags. This list was populated during their creation.
 		;derived action features are the features from the original data that aren't the series id features
 		(assign (assoc
 			derived_context_features
 				(append
-					(get !tsFeaturesMap "lag_features")
+					(filter
+						(lambda (contains_value action_features (get !derivedFeaturesMap (current_value))))
+						(get !tsFeaturesMap "lag_features")
+					)
 					derived_context_features
 					(if (size final_time_steps)
 						(list)
@@ -667,7 +670,10 @@
 				)
 			derived_action_features
 				(append
-					(get !tsFeaturesMap "derived_order_features")
+					(filter
+						(lambda (contains_value action_features (get !derivedFeaturesMap (current_value))))
+						(get !tsFeaturesMap "derived_order_features")
+					)
 					(filter
 						(lambda (not (contains_index series_id_features_set (current_value))))
 						;list of original features (ones not starting with a '.') that have derived_feature_code should be derived for output
@@ -678,7 +684,7 @@
 									(get !featureAttributes (list (current_value 1) "derived_feature_code"))
 								)
 							)
-							!trainedFeatures
+							action_features
 						)
 					)
 					derived_action_features
@@ -692,6 +698,7 @@
 				(filter
 					(lambda (and
 						(get !featureAttributes (list (current_value 1) "derived_feature_code"))
+						(contains_value action_features (get !derivedFeaturesMap (current_value)))
 						(not (contains_value derived_context_features (current_value)))
 						(not (contains_value derived_action_features (current_value)))
 						;whether .series_progress should be in derived_context_features is determined above
@@ -717,9 +724,14 @@
 						(get !tsFeaturesMap "series_id_features")
 						(list)
 					)
-					(get !tsFeaturesMap "delta_features")
-					(get !tsFeaturesMap "rate_features")
-
+					(filter
+						(lambda (contains_value derived_action_features (get !derivedFeaturesMap (current_value))))
+						(get !tsFeaturesMap "delta_features")
+					)
+					(filter
+						(lambda (contains_value derived_action_features (get !derivedFeaturesMap (current_value))))
+						(get !tsFeaturesMap "rate_features")
+					)
 					(if (contains_index (first series_stop_maps) ".series_progress")
 						(list ".series_progress_delta")
 						(list)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -658,9 +658,13 @@
 		(assign (assoc
 			derived_context_features
 				(append
-					(filter
-						(lambda (contains_value action_features (get !derivedFeaturesMap (current_value))))
+					(if use_all_features
 						(get !tsFeaturesMap "lag_features")
+
+						(filter
+							(lambda (contains_value action_features (get !derivedFeaturesMap (current_value))))
+							(get !tsFeaturesMap "lag_features")
+						)
 					)
 					derived_context_features
 					(if (size final_time_steps)
@@ -684,7 +688,8 @@
 									(get !featureAttributes (list (current_value 1) "derived_feature_code"))
 								)
 							)
-							action_features
+							;only use specified action features if not all features are to be modelled
+							(if use_all_features !trainedFeatures action_features)
 						)
 					)
 					derived_action_features
@@ -698,9 +703,15 @@
 				(filter
 					(lambda (and
 						(get !featureAttributes (list (current_value 1) "derived_feature_code"))
-						(or
-							(contains_value (get !tsFeaturesMap "series_id_features") (current_value))
-							(contains_value action_features (get !derivedFeaturesMap (current_value)))
+						(if use_all_features
+							(true)
+
+							;if not using all features, to be a derived context feature it must be an ID feature
+							;or a TS-feature of a given action feature
+							(or
+								(contains_value (get !tsFeaturesMap "series_id_features") (current_value))
+								(contains_value action_features (get !derivedFeaturesMap (current_value)))
+							)
 						)
 						(not (contains_value derived_context_features (current_value)))
 						(not (contains_value derived_action_features (current_value)))
@@ -727,19 +738,27 @@
 						(get !tsFeaturesMap "series_id_features")
 						(list)
 					)
-					(filter
-						(lambda
-							(or
-								;it's relied on that categorical features get put in the "delta_features" list...
-								(!= "continuous" (get !featureAttributes [(current_value 1) "type"]))
-								(contains_value derived_action_features (get !derivedFeaturesMap (current_value)))
-							)
-						)
+					(if use_all_features
 						(get !tsFeaturesMap "delta_features")
+
+						(filter
+							(lambda
+								(or
+									;it's relied on that categorical features get put in the "delta_features" list...
+									(!= "continuous" (get !featureAttributes [(current_value 1) "type"]))
+									(contains_value derived_action_features (get !derivedFeaturesMap (current_value)))
+								)
+							)
+							(get !tsFeaturesMap "delta_features")
+						)
 					)
-					(filter
-						(lambda (contains_value derived_action_features (get !derivedFeaturesMap (current_value))))
+					(if use_all_features
 						(get !tsFeaturesMap "rate_features")
+
+						(filter
+							(lambda (contains_value derived_action_features (get !derivedFeaturesMap (current_value))))
+							(get !tsFeaturesMap "rate_features")
+						)
 					)
 					(if (contains_index (first series_stop_maps) ".series_progress")
 						(list ".series_progress_delta")

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -77,6 +77,11 @@
 			;	If forecasting with 'continue_series', this defines the maximum length of the forecast.
 			max_series_length (null)
 			;{type "boolean"}
+			;flag, if true will internally generate values for all trained features and derived features while generating a series.
+			;if false, will only generate values for the features specified as action features and the features necessary to derive them, reducing
+			;the expected runtime but possibly reducing accuracy.
+			use_all_features (true)
+			;{type "boolean"}
 			;flag, DEPRECATED, please use 'use_differential_privacy' instead.  Defaults to true, will not use differential privacy approach.
 			;If false computes differentially private residuals using max gap values. Only used when desired_conviction is specified.
 			use_regional_residuals (null)
@@ -445,6 +450,11 @@
 			;If true will exclude sensitive features whose values will be
 			;	replaced after synthesis from uniqueness check.
 			exclude_novel_nominals_from_uniqueness_check (null)
+			;{type "boolean"}
+			;flag, if true will internally generate values for all trained features and derived features while generating a series.
+			;if false, will only generate values for the features specified as action features and the features necessary to derive them, reducing
+			;the expected runtime but possibly reducing accuracy.
+			use_all_features (true)
 			;{type "boolean"}
 			;flag, DEPRECATED, please use 'use_differential_privacy' instead.  Defaults to true, will not use differential privacy approach.
 			;If false computes differentially private residuals using max gap values. Only used when desired_conviction is specified.

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1821,7 +1821,7 @@
 											))
 										)
 										;all continuous output features that are not the time feature
-										(remove (zip output_features) (append (indices !nominalsMap) !tsTimeFeature) )
+										(remove (zip (or (get details "features") output_features)) (append (indices !nominalsMap) !tsTimeFeature) )
 									)
 								)
 							)

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -66,7 +66,7 @@
 				"name"
 					(assoc
 						"type" "nominal"
-						"time_series" (assoc "type" "rate")
+						"time_series" (assoc num_lags 1)
 					)
 				"owner" (assoc "type" "nominal")
 				"value"


### PR DESCRIPTION
Adds the `use_all_features` flag to `react_series`, which allows users to disable the modelling of non-action features while series values are generated when using react_series. This provides a strong boost to the speed of forecasts and series generation when a subset of the trained features are specified as action features. 