### PR TITLE
23543: Fixes bad hyperparameters from analyze from react_into_features

### DIFF
--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -128,7 +128,6 @@
 
 		;when storing values for entire dataset, update feature attributes with the feature so it's known that the feature has been cached
 		(if (= (null) case_ids)
-
 			(assign_to_entities (assoc
 				!featureAttributes
 					(append

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -84,13 +84,19 @@
 			(assign (assoc influence_weight_entropy "influence_weight_entropy"))
 		)
 
+		;flag set to true if similarity_conviction was requested without distance_contribution
+		(declare (assoc only_similiarity_conviction (false) ))
+
 		(if (and
 				(!= (null) similarity_conviction)
 				(or (= (null) distance_contribution) (= (false) distance_contribution))
 				(= (null) case_ids)
 			)
 			;if computing similarity_conviction for all cases, distance_contribution is needed for all cases
-			(assign (assoc distance_contribution "distance_contribution"))
+			(assign (assoc
+				distance_contribution "distance_contribution"
+				only_similiarity_conviction (true)
+			))
 		)
 
 		(if (= (null) features)
@@ -106,19 +112,23 @@
 			cache_values (false)
 			;create assoc of type of computation -> stored feature name
 			computed_map
-				(filter (assoc
-					"familiarity_conviction_addition" familiarity_conviction_addition
-					"familiarity_conviction_removal" familiarity_conviction_removal
-					"p_value_of_addition" p_value_of_addition
-					"p_value_of_removal" p_value_of_removal
-					"distance_contribution" distance_contribution
-					"similarity_conviction" similarity_conviction
-					"influence_weight_entropy" influence_weight_entropy
-				))
+				(filter
+					(lambda (current_value))
+					(assoc
+						"familiarity_conviction_addition" familiarity_conviction_addition
+						"familiarity_conviction_removal" familiarity_conviction_removal
+						"p_value_of_addition" p_value_of_addition
+						"p_value_of_removal" p_value_of_removal
+						"distance_contribution" distance_contribution
+						"similarity_conviction" similarity_conviction
+						"influence_weight_entropy" influence_weight_entropy
+					)
+				)
 		))
 
 		;when storing values for entire dataset, update feature attributes with the feature so it's known that the feature has been cached
 		(if (= (null) case_ids)
+
 			(assign_to_entities (assoc
 				!featureAttributes
 					(append
@@ -146,8 +156,19 @@
 				(assign_to_entities (assoc
 					!computedFeaturesMap
 						(assoc
-							"computed_features" (values computed_map)
-							"computed_map" computed_map
+							"computed_features"
+								(values
+									;don't use distance_contribution as a feature for analysis if only similarity_conviction was explicitly specified
+									(if only_similiarity_conviction
+										(remove computed_map "distance_contribution")
+										computed_map
+									)
+								)
+							"computed_map"
+								(if only_similiarity_conviction
+									(set computed_map "distance_contribution" (false))
+									computed_map
+								)
 							"context_features" features
 							"weight_feature" (if use_case_weights weight_feature)
 						)


### PR DESCRIPTION
Note: if user only requested similarity_conviction and did not request distance_contribution while using analyze=true when calling react_into_features(), this also ensures that distance_contribution is not added to the list of features that will be analyzed.