### PR TITLE
23617: Improves Time Series training with ablation performance, MINOR

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -638,6 +638,9 @@
 			;if !autoAblationEnabled is set, stores the minimum number of cases required to reduce data.
 			!autoAblationMaxNumCases 500000
 
+			;maximum number of cases to sample without replacement for computing the influence weight entropy threshold
+			!autoAblationInfluenceWeightEntropySampleSize 2000
+
 			;the influence weight entropy threshold quantile that a case's influence weight entropy must be less than in order to
 			; not be ablated. Default 1/e^2.
 			!autoAblationInfluenceWeightEntropyThreshold 0.135335283

--- a/howso.amlg
+++ b/howso.amlg
@@ -118,6 +118,7 @@
 	#!autoAblationEnabled (null)
 	#!autoAblationMinNumCases (null)
 	#!autoAblationMaxNumCases (null)
+	#!autoAblationInfluenceWeightEntropySampleSize (null)
 	#!autoAblationInfluenceWeightEntropyThreshold (null)
 	#!reduceDataInfluenceWeightEntropyThreshold (null)
 	#!autoAblationExactPredictionFeatures (null)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -89,6 +89,7 @@
 	;used to compute and store the influence weight entropies for all cases contained in the Trainee in #Analyze
 	; features: list of features to use when determining influential cases.
 	; label_name: optional name of the feature to store influence weight entropies in.
+	; compute_all: optional, boolean. if set to true will compute IWE for all cases.  default is to sample up to 2000 cases
 	#!ComputeAndStoreInfluenceWeightEntropies
 	(let
 		(assoc
@@ -98,18 +99,36 @@
 						(call !ComputeInfluenceWeightEntropy (assoc
 							case_id (current_index 1)
 							features features
+							use_case_weights use_case_weights
 							weight_feature weight_feature
 						))
 					)
 					(zip
-						(call !AllCases)
+						;small models (under 2048 cases) are small enough to compute IWE for all cases
+						(if (or (< (call !GetNumTrainingCases) 2048) compute_all)
+							(call !AllCases)
 
+							;else compute on a random sample of 2000 cases
+							(call !AllCases (assoc
+								num 2000
+								rand_seed (rand)
+							))
+						)
 					)
 				)
 		)
 
 		(call !StoreCaseValues (assoc
-			case_values_map influence_weight_entropy_map
+			case_values_map
+				(if (or (< (call !GetNumTrainingCases) 2048) compute_all)
+					influence_weight_entropy_map
+
+					;explicitly store null in all the other cases by appending the computed entropy map to a zipped assoc of all case ids
+					(append
+						(zip (call !AllCases))
+						influence_weight_entropy_map
+					)
+				)
 			label_name (or label_name !internalLabelInfluenceWeightEntropy)
 		))
 
@@ -454,12 +473,12 @@
 			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
 		))
 
-		;Also ensure that we have influence weight entropies and that they are as up-to-date
-		; as possible.
+		;Also ensure that we have all influence weight entropies and that they are up-to-date
 		(call !ComputeAndStoreInfluenceWeightEntropies (assoc
 			features features
 			weight_feature distribute_weight_feature
 			use_case_weights (true)
+			compute_all (true)
 		))
 
 		(if thresholds_enabled

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -101,7 +101,10 @@
 							weight_feature weight_feature
 						))
 					)
-					(zip (call !AllCases))
+					(zip
+						(call !AllCases)
+
+					)
 				)
 		)
 
@@ -666,12 +669,15 @@
 								])
 						)
 
+						;in non-surprisal space, the values coming out of the query are inverse distance, inverting them back converts them back to distances to the cases
+						;in surprisal space, the values coming out of the query are probabilities, inverted probabilities are monotonic to surprisals (distances)
+						;thus the comparison below works as intended
 						(declare (assoc
 							dist_to_closest_neighbor (/ 1 (last influentials_entropy_tuple))
 							neighbor_dist_to_its_farthest_case (/ 1 (last (last neighbor_cases_pairs)) )
 						))
 
-						;keep case if its distance to closest existing case is relatively large
+						;keep this training case if the 'distance' to its closest existing case is relatively large
 						(>
 							dist_to_closest_neighbor
 							neighbor_dist_to_its_farthest_case

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -8,7 +8,7 @@
 	; use_case_weights: optional flag default true. if false, case weights will not be used during the react
 	; weight_feature: optional, default '.case_weight'. name of feature whose values to use as case weights
 	; output_most_influential: optional, boolean, default false. when false outputs influential cases' entropy,
-	;	when true will output a pair of [ entropy, most influential case values ]
+	;	when true will output a tuple of [ entropy,, most influential case id, distance to most influential case ]
 	#!ComputeInfluenceWeightEntropy
 	(declare
 		(assoc
@@ -18,63 +18,64 @@
 			use_case_weights (true)
 			weight_feature !autoAblationWeightFeature
 			output_most_influential (false)
-
-			;internal only
-			react_kwargs (assoc)
 		)
 
 		(if (not use_case_weights)
 			(assign (assoc weight_feature ".none"))
 		)
 
-		(assign (assoc
-			react_kwargs
-				(assoc
-					context_features features
-					use_case_weights use_case_weights
-					weight_feature weight_feature
-					details (assoc influential_cases (true) influential_cases_raw_weights (true))
-					skip_encoding (true)
-					skip_decoding (true)
-				)
-		))
-
-		(if
-			;if context_values are not null, we are reacting to a new case
-			(!= feature_values (null))
-			(accum "react_kwargs" (assoc context_values feature_values) )
-			;elif case_id is not null, we are reacting to an existing case
-			(!= case_id (null))
-			(accum "react_kwargs" (assoc
-				case_indices (retrieve_from_entity case_id (list ".session" ".session_training_index") )
-				preserve_feature_values features
-				leave_case_out (true)
-			))
-		)
-
 		(declare (assoc
-			influential_cases (get (call !ReactDiscriminative react_kwargs) "influential_cases")
-		))
-
-		(if
-			;if feature_values are not null, we are reacting to a new case. We ablate duplicate identical cases.
-			(!= feature_values (null))
-			(if (= feature_values (unzip (first influential_cases) features))
-				(conclude [ .infinity (null) ])
-			)
-		)
-
-		;compute the entropy of the influence weights as retrieved by react
-		(declare (assoc
-			influence_weight_entropy
-				(entropy (map
-					(lambda (get (current_value) ".influence_weight") )
-					influential_cases
+			local_cases_pairs
+				(compute_on_contained_entities (append
+					(if case_id (query_not_in_entity_list [case_id]) [])
+					(query_nearest_generalized_distance
+						closest_k
+						features
+						(if case_id (retrieve_from_entity case_id features) feature_values)
+						feature_weights
+						!queryDistanceTypeMap
+						query_feature_attributes_map
+						feature_deviations
+						p_parameter
+						dt_parameter
+						(if use_case_weights weight_feature)
+						(rand)
+						(null) ;radius
+						!numericalPrecision
+						;output as ordered pair
+						(true)
+					)
 				))
 		))
 
+		;if feature_values are not null, we are reacting to a new case. We ablate duplicate identical cases.
+		;and a case is identical if its probability is 1 or weight is .infinity
+		(if (and
+				(!= feature_values (null))
+				(or
+					(and
+						(= 1 (last (first local_cases_pairs)))
+						(= "surprisal_to_prob" dt_parameter)
+					)
+					(= .infinity (last (first local_cases_pairs)) )
+				)
+			)
+			(conclude [ .infinity (null) ])
+		)
+
+		(declare (assoc total_influence (apply "+" (last local_cases_pairs)) ))
+
+		(declare (assoc
+			influence_weight_entropy
+				(entropy (map
+					(lambda (/ (current_value) total_influence))
+					(last local_cases_pairs)
+				))
+		))
+
+		;outputs the case id of the most influential and distance to it, else output just the entropy value
 		(if output_most_influential
-			[ influence_weight_entropy (first influential_cases) ]
+			[ influence_weight_entropy (first (first local_cases_pairs)) (first (last local_cases_pairs)) ]
 			influence_weight_entropy
 		)
 	)
@@ -91,7 +92,6 @@
 						(call !ComputeInfluenceWeightEntropy (assoc
 							case_id (current_index 1)
 							features features
-							use_case_weights use_case_weights
 							weight_feature weight_feature
 						))
 					)
@@ -429,6 +429,22 @@
 			))
 		)
 
+		(declare  (assoc
+			hyperparam_map
+				(call !GetHyperparameters (assoc
+					context_features features
+					weight_feature weight_feature
+				))
+		))
+		(declare (assoc
+			closest_k (get hyperparam_map "k")
+			p_parameter (get hyperparam_map "p")
+			dt_parameter (get hyperparam_map "dt")
+			feature_weights (get hyperparam_map "featureWeights")
+			feature_deviations (get hyperparam_map "featureDeviations")
+			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
+		))
+
 		;Also ensure that we have influence weight entropies and that they are as up-to-date
 		; as possible.
 		(call !ComputeAndStoreInfluenceWeightEntropies (assoc
@@ -600,7 +616,7 @@
 		)
 
 		(declare (assoc
-			influentials_entropy_pair
+			influentials_entropy_tuple
 				(call !ComputeInfluenceWeightEntropy (assoc
 					features features
 					feature_values feature_values
@@ -611,40 +627,55 @@
 		(+
 			(or
 				;case should be kept because influentials are not evenly distributed (their entropy is low)
-				(if (> max_influence_weight_entropy_to_keep (first influentials_entropy_pair))
+				(if (> max_influence_weight_entropy_to_keep (first influentials_entropy_tuple))
 					(true)
 
 					;always ablate perfect matches/identical cases
-					(= .infinity (first influentials_entropy_pair))
+					(= .infinity (first influentials_entropy_tuple))
 					(false)
 
 					;else ablate? check distance to closest vs its distance to its K'th closest
 					(let
 						(assoc
-							dist_to_closest_case (/ 1 (get influentials_entropy_pair [1 ".raw_influence_weight"]))
-							react_kwargs
-								(assoc
-								 	use_case_weights use_case_weights
-									weight_feature weight_feature
-									details (assoc influential_cases (true) influential_cases_raw_weights (true))
-									context_features features
-									case_indices (unzip (last influentials_entropy_pair) [".session" ".session_training_index"] )
-									preserve_feature_values features
-									leave_case_out (true)
-									skip_encoding (true)
-								)
+							neighbor_cases_pairs
+								(compute_on_contained_entities [
+									(query_not_in_entity_list [(get influentials_entropy_tuple 1)])
+									(query_nearest_generalized_distance
+										closest_k
+										features
+										(retrieve_from_entity (get influentials_entropy_tuple 1) features)
+										feature_weights
+										!queryDistanceTypeMap
+										query_feature_attributes_map
+										feature_deviations
+										p_parameter
+										dt_parameter ;TODO: should be (if (= "surprisal_to_prob" dt_parameter) "surprisal" 1)
+										weight_feature
+										(rand)
+										(null) ;radius
+										!numericalPrecision
+										;output as ordered pair
+										(true)
+									)
+								])
 						)
 
 						(declare (assoc
-							neighbor_influential_cases (get (call !ReactDiscriminative react_kwargs) "influential_cases")
-						))
+							dist_to_closest_neighbor (/ 1 (last influentials_entropy_tuple))
+								;TODO: convert to raw surprisal and below shoud just be itself if surprisal is returned above
+								; (if (= "surprisal_to_prob" dt_parameter)
+								; 	(- (log (last influentials_entropy_tuple)))
 
-						(declare (assoc
-							neighbor_dist_to_farthest_case (/ 1 (get (last neighbor_influential_cases) ".raw_influence_weight"))
+								; 	(/ 1 (last influentials_entropy_tuple))
+								; )
+							neighbor_dist_to_its_farthest_case (/ 1 (last (last neighbor_cases_pairs)) )
 						))
 
 						;keep case if its distance to closest existing case is relatively large
-						(> dist_to_closest_case neighbor_dist_to_farthest_case)
+						(>
+							dist_to_closest_neighbor
+							neighbor_dist_to_its_farthest_case
+						)
 					)
 				)
 

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -49,18 +49,24 @@
 		))
 
 		;if feature_values are not null, we are reacting to a new case. We ablate duplicate identical cases.
-		;and a case is identical if its probability is 1 or weight is .infinity
-		(if (and
-				(!= feature_values (null))
-				(or
-					(and
-						(= 1 (last (first local_cases_pairs)))
-						(= "surprisal_to_prob" dt_parameter)
+		;and a case is identical if its probability is >=1 or influence is .infinity
+		(if (!= feature_values (null))
+			(if (= .infinity (first (last local_cases_pairs)) )
+				(conclude [ .infinity (null) ])
+
+				(and
+					(>= (first (last local_cases_pairs)) 1)
+					(= "surprisal_to_prob" dt_parameter)
+					(if use_case_weights
+						(=
+							(first (last local_cases_pairs))
+							(retrieve_from_entity (first (first local_cases_pairs)) weight_feature )
+						)
+						(true)
 					)
-					(= .infinity (last (first local_cases_pairs)) )
 				)
+				(conclude [ .infinity (null) ])
 			)
-			(conclude [ .infinity (null) ])
 		)
 
 		(declare (assoc total_influence (apply "+" (last local_cases_pairs)) ))

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -127,7 +127,13 @@
 
 		(call !StoreCaseValues (assoc
 			case_values_map
-				(if (or (< (call !GetNumTrainingCases) 2048) compute_all)
+				(if (or
+						compute_all
+						(<
+							(call !GetNumTrainingCases)
+							(* 1.02 !autoAblationInfluenceWeightEntropySampleSize)
+						)
+					)
 					influence_weight_entropy_map
 
 					;explicitly store null in all the other cases by appending the computed entropy map to a zipped assoc of all case ids

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -86,10 +86,11 @@
 		)
 	)
 
-	;used to compute and store the influence weight entropies for all cases contained in the Trainee in #Analyze
+	;used to compute and store the influence weight entropies (IWE) for all cases contained in the Trainee in #Analyze
 	; features: list of features to use when determining influential cases.
 	; label_name: optional name of the feature to store influence weight entropies in.
-	; compute_all: optional, boolean. if set to true will compute IWE for all cases.  default is to sample up to 2000 cases
+	; compute_all: optional, boolean. if set to true will compute IWE for all cases.
+	;	default is to sample up to !autoAblationInfluenceWeightEntropySampleSize (default of 2000) cases
 	#!ComputeAndStoreInfluenceWeightEntropies
 	(let
 		(assoc
@@ -104,13 +105,19 @@
 						))
 					)
 					(zip
-						;small models (under 2048 cases) are small enough to compute IWE for all cases
-						(if (or (< (call !GetNumTrainingCases) 2048) compute_all)
+						;datasets that are < !autoAblationInfluenceWeightEntropySampleSize + 2% in size can compute IWE for all cases
+						(if (or
+								compute_all
+								(<
+									(call !GetNumTrainingCases)
+									(* 1.02 !autoAblationInfluenceWeightEntropySampleSize)
+								)
+							)
 							(call !AllCases)
 
-							;else compute on a random sample of 2000 cases
+							;else compute on a random sample of !autoAblationInfluenceWeightEntropySampleSize cases
 							(call !AllCases (assoc
-								num 2000
+								num !autoAblationInfluenceWeightEntropySampleSize
 								rand_seed (rand)
 							))
 						)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -90,7 +90,7 @@
 	; features: list of features to use when determining influential cases.
 	; label_name: optional name of the feature to store influence weight entropies in.
 	; compute_all: optional, boolean. if set to true will compute IWE for all cases.
-	;	default is to sample up to !autoAblationInfluenceWeightEntropySampleSize (default of 2000) cases
+	;	default is false, which samples up to !autoAblationInfluenceWeightEntropySampleSize (default of 2000) cases
 	#!ComputeAndStoreInfluenceWeightEntropies
 	(let
 		(assoc

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -8,7 +8,7 @@
 	; use_case_weights: optional flag default true. if false, case weights will not be used during the react
 	; weight_feature: optional, default '.case_weight'. name of feature whose values to use as case weights
 	; output_most_influential: optional, boolean, default false. when false outputs influential cases' entropy,
-	;	when true will output a tuple of [ entropy,, most influential case id, distance to most influential case ]
+	;	when true will output a tuple of [ entropy, most influential case id, distance to most influential case ]
 	#!ComputeInfluenceWeightEntropy
 	(declare
 		(assoc

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -649,7 +649,7 @@
 										query_feature_attributes_map
 										feature_deviations
 										p_parameter
-										dt_parameter ;TODO: should be (if (= "surprisal_to_prob" dt_parameter) "surprisal" 1)
+										dt_parameter
 										weight_feature
 										(rand)
 										(null) ;radius
@@ -662,12 +662,6 @@
 
 						(declare (assoc
 							dist_to_closest_neighbor (/ 1 (last influentials_entropy_tuple))
-								;TODO: convert to raw surprisal and below shoud just be itself if surprisal is returned above
-								; (if (= "surprisal_to_prob" dt_parameter)
-								; 	(- (log (last influentials_entropy_tuple)))
-
-								; 	(/ 1 (last influentials_entropy_tuple))
-								; )
 							neighbor_dist_to_its_farthest_case (/ 1 (last (last neighbor_cases_pairs)) )
 						))
 

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -499,6 +499,23 @@
 			!autoAblationEnabled
 			(seq
 				(call !InitializeAutoAblation)
+
+				(declare  (assoc
+					hyperparam_map
+						(call !GetHyperparameters (assoc
+							context_features features
+							weight_feature weight_feature
+						))
+				))
+				(declare (assoc
+					closest_k (get hyperparam_map "k")
+					p_parameter (get hyperparam_map "p")
+					dt_parameter (get hyperparam_map "dt")
+					feature_weights (get hyperparam_map "featureWeights")
+					feature_deviations (get hyperparam_map "featureDeviations")
+					query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
+				))
+
 				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
 					features
 						(if

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -497,6 +497,7 @@
 				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
 					features features
 					label_name influence_weight_entropy
+					compute_all (true)
 				))
 
 				(if (not (contains_value !reactIntoFeaturesList influence_weight_entropy))

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -199,6 +199,8 @@
 			feature_weights (get hyperparam_map "featureWeights")
 			feature_deviations  (get hyperparam_map "featureDeviations")
 			closest_k (get hyperparam_map "k")
+			p_parameter (get hyperparam_map "p")
+			dt_parameter (get hyperparam_map "dt")
 			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
 			;get the min k if using dynamic k
 			k_parameter_value (if (~ 0 (get hyperparam_map "k")) (get hyperparam_map "k") (get hyperparam_map ["k" 1]) )
@@ -247,8 +249,8 @@
 								!queryDistanceTypeMap
 								query_feature_attributes_map
 								feature_deviations
-								(get hyperparam_map "p")
-								(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+								p_parameter
+								(if (= dt_parameter "surprisal_to_prob") "surprisal" dt_parameter )
 								(if valid_weight_feature weight_feature (null))
 								;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 								"fixed rand seed"
@@ -321,8 +323,8 @@
 								!queryDistanceTypeMap
 								query_feature_attributes_map
 								feature_deviations
-								(get hyperparam_map "p")
-								(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+								p_parameter
+								(if (= dt_parameter "surprisal_to_prob") "surprisal" dt_parameter )
 								(if valid_weight_feature weight_feature (null))
 								;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 								"fixed rand seed"
@@ -396,8 +398,8 @@
 								!queryDistanceTypeMap
 								query_feature_attributes_map
 								feature_deviations
-								(get hyperparam_map "p")
-								(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+								p_parameter
+								(if (= dt_parameter "surprisal_to_prob") "surprisal" dt_parameter )
 								(if valid_weight_feature weight_feature (null))
 								;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 								"fixed rand seed"

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -1016,6 +1016,7 @@
 					residual_prediction_features !autoAblationResidualPredictionFeatures
 					conviction_upper_threshold !autoAblationConvictionUpperThreshold
 					conviction_lower_threshold !autoAblationConvictionLowerThreshold
+					influence_weight_entropy_sample_size !autoAblationInfluenceWeightEntropySampleSize
 				)
 		))
 	)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -1047,6 +1047,10 @@
 			;the influence weight entropy quantile that a case must be beneath in order to not be removed.
 			;	default of 1-1/e.
 			reduce_data_influence_weight_entropy_threshold 0.632120559
+			;{type "number"}
+			;maximum number of cases to sample without replacement for computing the influence weight entropy threshold
+			; default of 2000
+			influence_weight_entropy_sample_size 2000
 			;{type "list" values "string"}
 			;list of features. for each of the features specified, will ablate a case if the prediction
 			;	matches exactly.
@@ -1106,6 +1110,7 @@
 			!autoAblationWeightFeature auto_ablation_weight_feature
 			!autoAblationMinNumCases min_num_cases
 			!autoAblationMaxNumCases max_num_cases
+			!autoAblationInfluenceWeightEntropySampleSize influence_weight_entropy_sample_size
 			!autoAblationInfluenceWeightEntropyThreshold auto_ablation_influence_weight_entropy_threshold
 			!reduceDataInfluenceWeightEntropyThreshold reduce_data_influence_weight_entropy_threshold
 			!autoAblationExactPredictionFeatures exact_prediction_features

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -481,6 +481,10 @@
 						type "number"
 						description "The number of cases to train before automatic data reduction begins."
 					}
+					"influence_weight_entropy_sample_size" {
+						type "number"
+						description "The maximum number of cases to sample without replacement for computing the influence weight entropy threshold."
+					}
 					"auto_ablation_influence_weight_entropy_threshold" {
 						type "number"
 						description "The minimum threshold of influence weight entropy for a case to be ablated in the process of automatic ablation."

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -813,6 +813,13 @@
 
 					features
 				)
+			weight_feature
+				(if !autoAblationEnabled
+					!autoAblationWeightFeature
+
+					(or !continuousRebalanceFeatures !nominalRebalanceFeatures)
+					".case_weight"
+				)
 		)
 
 		(if rebalance_weights
@@ -822,6 +829,22 @@
 				total_rebalance_mass (replace !cachedRebalanceTotalMass)
 			))
 		)
+
+		(declare  (assoc
+			hyperparam_map
+				(call !GetHyperparameters (assoc
+					context_features features
+					weight_feature weight_feature
+				))
+		))
+		(declare (assoc
+			closest_k (get hyperparam_map "k")
+			p_parameter (get hyperparam_map "p")
+			dt_parameter (get hyperparam_map "dt")
+			feature_weights (get hyperparam_map "featureWeights")
+			feature_deviations (get hyperparam_map "featureDeviations")
+			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
+		))
 
 		;split by batches of cases until next analyze
 		(while (< input_case_index (size cases))

--- a/howso/train_ts_ablation.amlg
+++ b/howso/train_ts_ablation.amlg
@@ -629,31 +629,65 @@
 
 	;every derived feature must be immediately fed back into data because it may be needed by the next derived feature
 	#!DeriveCustomFeaturesForData
-	(map
-		(lambda (let
-			(assoc feature (current_value 1))
-			(declare (assoc
-				derived_custom_values
+	(let
+		(assoc
+			;compute the maximum order of rate or deltas needed, since higher orders depend on lower ones and need to be derived sequentially
+			;e.g., 1st order for a rate feature needs to be derived before the 2nd order rate feature, etc.
+			max_order
+				(apply "max"
+					(map (lambda (get !featureAttributes [(current_value 1) "ts_order"])) derived_features)
+				)
+			time_feature_delta (concat "." !tsTimeFeature "_delta_1")
+		)
+
+		;first explicitly derive time feature delta
+		(assign (assoc
+			data
+				(map
+					(lambda
+						(append (first (current_value)) (last (current_value)))
+					)
+					data
 					(call !AddDerivedCodeFeature (assoc
-						feature feature
+						feature time_feature_delta
 						features features
 						series_data data
 					))
-			))
-
-			(assign (assoc
-				features (append features feature)
-				data
-					(map
-						(lambda
-							(append (first (current_value)) (last (current_value)))
-						)
-						data
-						derived_custom_values
-					)
-			))
+				)
 		))
-		derived_features
+		(assign (assoc
+			features (append features time_feature_delta)
+			derived_features (filter (lambda (!= time_feature_delta (current_value))) derived_features)
+		))
+
+		(range
+			(lambda (let
+				(assoc
+					;keep only those features matching this order (current_index 2) value
+					derived_order_features
+						(filter
+							(lambda (= (current_index 2) (get !featureAttributes [(current_value 1) "ts_order"])))
+							derived_features
+						)
+				)
+				(assign (assoc
+					data
+						(map
+							(lambda
+								(append (first (current_value)) (last (current_value)) )
+							)
+							data
+							(call !AddDerivedIndependentCodeFeatures (assoc
+								derived_features derived_order_features
+								features features
+								series_data data
+							))
+						)
+				))
+				(accum (assoc features derived_order_features))
+			))
+			1 max_order 1
+		)
 	)
 
 

--- a/unit_tests/ut_h_ablate.amlg
+++ b/unit_tests/ut_h_ablate.amlg
@@ -293,6 +293,7 @@
 				auto_ablation_influence_weight_entropy_threshold 0.6
 				reduce_data_influence_weight_entropy_threshold 0.6
 				exact_prediction_features (null)
+				influence_weight_entropy_sample_size 2000
 				tolerance_prediction_threshold_map (null)
 				relative_prediction_threshold_map (null)
 				residual_prediction_features (null)

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -501,7 +501,7 @@
 			(assoc
 				height 0.01
 				length 0.01
-				size 0.002
+				size 0.003
 				sweet 0.007
 				tart 0.01
 				weight 0.01

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -353,7 +353,7 @@
 					length 0.65
 					size 0.29
 					sweet 0.06
-					tart 0.16
+					tart 0.17
 					weight 1.1
 					width 0.7
 				}
@@ -385,7 +385,7 @@
 					height 0.85
 					length 0.85
 					sweet 0.6
-					tart 0.6
+					tart 0.5
 					weight 0.9
 					width 0.8
 				}

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -484,7 +484,7 @@
 					size 0.63
 				}
 				mae {
-					fruit 0.22
+					fruit 0.21
 					height 0.7
 					length 0.5
 					size 0.3
@@ -498,7 +498,7 @@
 					length 13
 					sweet 7
 					tart 14
-					weight 10
+					weight 11
 					width 18
 				}
 			}

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -354,7 +354,7 @@
 					size 0.29
 					sweet 0.06
 					tart 0.17
-					weight 1.1
+					weight 1.2
 					width 0.7
 				}
 				adjusted_smape {
@@ -635,7 +635,7 @@
 		(assoc
 			obs (get result ["accuracy" "size"])
 			exp 0.8
-			thresh 0.1
+			thresh 0.2
 		)
 	)
 


### PR DESCRIPTION
a) call influential cases queries directly instead of doing the full reactDistriminative flow
b) sample 2000 cases for computing the quantile cutoff for influence weight entropy instead of computing on all
c) added influence_weight_entropy_sample_size param to set_auto_ablation_params()