### PR TITLE
23714: Improves error messages from react regarding invalid parameter lengths 

### DIFF
--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -9,7 +9,11 @@
 			(!= 1 (size param))
 			(!= num_reacts (size param))
 		)
-		(assign (assoc invalid_react_parameters (true)))
+		(conclude
+			(call !Return (assoc
+				errors [(concat "The length of `" param_name "` must be either 1 or " num_reacts " based on the given request.")]
+			))
+		)
 	)
 
 	#!ValidateFeatures

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -364,26 +364,21 @@
 		))
 
 		;validate parameters
-		(declare (assoc invalid_react_parameters (false)))
-
-		(call !ValidateBatchReactParameter (assoc param context_values))
-		(call !ValidateBatchReactParameter (assoc param case_indices))
-		(call !ValidateBatchReactParameter (assoc param action_values))
-		(call !ValidateBatchReactParameter (assoc param post_process_values))
+		(call !ValidateBatchReactParameter (assoc param context_values param_name "context_values"))
+		(call !ValidateBatchReactParameter (assoc param case_indices param_name "case_indices"))
+		(call !ValidateBatchReactParameter (assoc param action_values param_name "action_values"))
+		(call !ValidateBatchReactParameter (assoc param post_process_values param_name "post_process_values"))
 
 		(if (and
 				(!= (null) rand_seed)
 				(!= num_reacts (size rand_seed))
 			)
-			(assign (assoc invalid_react_parameters (true)))
-		)
-
-		(if invalid_react_parameters
 			(conclude
-				(call !Return (assoc errors (list "Failed to react: invalid react parameters.") ))
+				(call !Return (assoc
+					errors [(concat "The length of `rand_seed` must be " num_reacts " based on the given request.")]
+				))
 			)
 		)
-
 		(call !ValidateDerivedActionFeaturesIsSubset)
 
 		(declare (assoc

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -542,22 +542,9 @@
 			output_features action_features
 		))
 
-		(call !ValidateBatchReactParameter (assoc param series_id_values))
-		(call !ValidateBatchReactParameter (assoc param series_stop_maps))
-		(call !ValidateBatchReactParameter (assoc param max_series_lengths))
-
-		(if (and
-				(!= (null) rand_seed)
-				(!= num_reacts (size rand_seed))
-			)
-			(assign (assoc invalid_react_parameters (true)))
-		)
-
-		(if invalid_react_parameters
-			(conclude
-				(call !Return (assoc errors (list "Failed to react_series: invalid react parameters.") ))
-			)
-		)
+		(call !ValidateBatchReactParameter (assoc param series_id_values param_name "series_id_values"))
+		(call !ValidateBatchReactParameter (assoc param series_stop_maps param_name "series_stop_maps"))
+		(call !ValidateBatchReactParameter (assoc param max_series_lengths param_name "max_series_lengths"))
 
 		(if series_stop_maps
 			(assign (assoc

--- a/performance_tests/adult_test.amlg
+++ b/performance_tests/adult_test.amlg
@@ -54,7 +54,7 @@
 
 	(call_entity "howso" "train" (assoc
 		features features
-		input_cases (if submodel_size (trunc training_data submodel_size) training_data)
+		cases (if submodel_size (trunc training_data submodel_size) training_data)
 	))
 
 	(declare (assoc
@@ -93,7 +93,7 @@
 			(append
 				(list features)
 				(get
-					(call_entity "howso" "batch_react" (assoc
+					(call_entity "howso" "react" (assoc
 						action_features features
 						desired_conviction 5
 						use_regional_residuals (false)

--- a/performance_tests/adult_test.amlg
+++ b/performance_tests/adult_test.amlg
@@ -20,7 +20,7 @@
 		;set to true to use case weights in analyze
 		use_case_weights (false)
 
-	    data (load "performance_data/adult.csv")
+		data (load "performance_data/adult.csv")
 	))
 
 	(declare (assoc
@@ -48,7 +48,7 @@
 				"capital-loss" (assoc "type" "continuous")
 				"hours-per-week" (assoc "type" "continuous")
 				"native-country" (assoc "type" "nominal")
-                "target" (assoc "type" "nominal")
+				"target" (assoc "type" "nominal")
 			)
 	))
 


### PR DESCRIPTION
Makes the error messages usually triggered by bad batching more verbose, allowing the user to actually know what validation step was failed.

Also fixes a non-functioning performance test 