### PR TITLE
23723: Fixes issues that arise while using encoded features when computing forecast accuracy

### DIFF
--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -1457,6 +1457,7 @@
 
 		(declare (assoc
 			feature_index_map (zip all_features (indices all_features))
+			;parameters needed within ReactSeries
 			derived_context_features
 				(filter
 					(lambda (contains_value all_features (get !derivedFeaturesMap (current_value))))
@@ -1484,6 +1485,7 @@
 				)
 		))
 
+		;Another param needed in ReactSeries
 		(declare (assoc
 			series_action_features
 				(append
@@ -1508,6 +1510,8 @@
 			case_residuals_lists
 				||(map
 					(lambda
+						;For each case, forecast the til the window-length is elapsed and interpolate both
+						;the forecast and the trained series to get find the error at the end of the window
 						(let
 							(assoc
 								case_id (current_value 1)
@@ -1541,11 +1545,11 @@
 													case_time_value
 													"number"
 													(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
+													(null)
 													{
 														"locale" (get !featureDateTimeMap [ !tsTimeFeature "locale" ] )
 														"time_zone" (get !featureDateTimeMap [ !tsTimeFeature "default_time_zone" ] )
 													}
-													(null)
 												)]
 
 												[case_time_value]
@@ -1564,30 +1568,24 @@
 										))
 									))
 							))
+							;convert the forecast cases back to encoded values to compare to trained cases
+							(declare (assoc
+								forecast_cases
+									(map
+										(lambda
+											(call !ConvertFromInput (assoc
+												features all_features
+												feature_values (current_value 1)
+											))
+										)
+										(get forecast_result ["payload" "action_values"])
+									)
+							))
 							(declare (assoc
 								forecast_time_values
-									(if (contains_index !featureDateTimeMap !tsTimeFeature)
-										(map
-											(lambda
-												(format
-													(get (current_value) (get feature_index_map !tsTimeFeature))
-													(get !featureDateTimeMap (list !tsTimeFeature "date_time_format"))
-													"number"
-													{
-														"locale" (get !featureDateTimeMap [ !tsTimeFeature "locale" ] )
-														"time_zone" (get !featureDateTimeMap [ !tsTimeFeature "default_time_zone" ] )
-													}
-													(null)
-												)
-
-											)
-											(get forecast_result ["payload" "action_values"])
-										)
-
-										(map
-											(lambda (get (current_value) (get feature_index_map !tsTimeFeature)) )
-											(get forecast_result ["payload" "action_values"])
-										)
+									(map
+										(lambda (get (current_value) (get feature_index_map !tsTimeFeature)) )
+										forecast_cases
 									)
 							))
 
@@ -1601,6 +1599,7 @@
 										trained_series_cases
 									)
 							))
+							;Deliberately pull out the time column as it will be needed for each feature
 							(declare (assoc
 								trained_time_values
 									(map
@@ -1611,6 +1610,8 @@
 
 							(map
 								(lambda
+									;for each feature, interpolate both the forecast and trained series at the end time
+									;and compute the tuple needed for downstream calculations
 									(let
 										(assoc
 											feat_to_diff (current_value 1)
@@ -1626,13 +1627,13 @@
 														feature_values
 															(map
 																(lambda (get (current_value) feat_index))
-																(get forecast_result ["payload" "action_values"])
+																forecast_cases
 															)
 														time end_time
 
 														;hopefully don't need these
-														pre_domain_value (get forecast_result ["payload" "action_values" 0 feat_index])
-														post_domain_value (get forecast_result ["payload" "action_values" -1 feat_index])
+														pre_domain_value (get forecast_cases [0 feat_index])
+														post_domain_value (get forecast_cases [-1 feat_index])
 													))
 												case_feature_value
 													;interpolated value for trained data
@@ -1663,13 +1664,13 @@
 														feature_values
 															(map
 																(lambda (get (current_value) feat_index))
-																(get forecast_result ["payload" "action_values"])
+																forecast_cases
 															)
 														time end_time
 
 														;hopefully don't need these
-														pre_domain_value (get forecast_result ["payload" "action_values" 0 feat_index])
-														post_domain_value (get forecast_result ["payload" "action_values" -1 feat_index])
+														pre_domain_value (get forecast_cases [0 feat_index])
+														post_domain_value (get forecast_cases [-1 feat_index])
 													))
 												case_feature_value
 													;interpolated value for trained data


### PR DESCRIPTION
When using encoded features and computing forecast accuracy, the values compared were not comparable leading to misleading or invalid results.

also fixes a datetime conversion bug, and adds some more comments to RunForecastResiduals