### PR TITLE
23653: Implements ignoring inactive features in all flows

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -496,7 +496,7 @@
 			;assoc of feature -> observational_error value as specified by the user
 			!userSpecifiedFeatureErrorsMap (assoc)
 
-			;map of inactive feature (i.e., feature that has only null values) -> feature weight, set to null when empty
+			;map of inactive feature (i.e., feature that has only one value, like all null values) -> feature weight, set to null when empty
 			!inactiveFeaturesMap (null)
 
 			;flag set to true if there are inactive features but they need to be rechecked if they are still inactive and recached

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -337,6 +337,7 @@
 		(if (= (null) initial_residual_values_map)
 			(assign (assoc
 				initial_residual_values_map
+					#!ComputeInitialResiduals
 					(map
 						(lambda
 							;for nominals, random chance of getting a prediction wrong is: 1 - 1/num_classes

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -115,7 +115,7 @@
 					excluded_inactive_features_map (keep !inactiveFeaturesMap context_features)
 				))
 				(assign (assoc
-					context_features (filter (lambda (not (contains_index !inactiveFeaturesMap (current_value)))) context_features)
+					context_features (filter (lambda (not (contains_index excluded_inactive_features_map (current_value)))) context_features)
 				))
 			)
 		)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -108,6 +108,7 @@
 			)
 		)
 
+		;don't use inactive features for computing prediction contributions
 		(if (size !inactiveFeaturesMap)
 			(seq
 				(assign (assoc
@@ -216,6 +217,7 @@
 			(call !RunFullContributions)
 		)
 
+		;put the inactive features back into output with 0s
 		(if (size excluded_inactive_features_map)
 			(accum (assoc feature_contributions_map excluded_inactive_features_map))
 		)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -62,6 +62,7 @@
 			;store an assoc of lag/rate/delta feature -> lag/order amount for time series flows
 			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
 			max_lag_index_value (null)
+			excluded_inactive_features_map {}
 		))
 		(if ts_feature_lag_amount_map
 			(assign (assoc max_lag_index_value (apply "max" (values ts_feature_lag_amount_map)) ))
@@ -104,6 +105,17 @@
 						))
 					)
 				)
+			)
+		)
+
+		(if (size !inactiveFeaturesMap)
+			(seq
+				(assign (assoc
+					excluded_inactive_features_map (keep !inactiveFeaturesMap context_features)
+				))
+				(assign (assoc
+					context_features (filter (lambda (not (contains_index !inactiveFeaturesMap (current_value)))) context_features)
+				))
 			)
 		)
 
@@ -202,6 +214,10 @@
 			(call !RunRobustContributions)
 
 			(call !RunFullContributions)
+		)
+
+		(if (size excluded_inactive_features_map)
+			(accum (assoc feature_contributions_map excluded_inactive_features_map))
 		)
 
 		(declare (assoc directional_contributions_map (map (lambda (last (current_value))) feature_contributions_map) ))

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -195,7 +195,7 @@
 					))
 				)
 
-				(call !SetFeatureWeightsForFeatures (assoc
+				(call !SetInactiveFeatureWeights (assoc
 					features_weights_map (zip inactive_derived_features 1)
 					overwrite (true)
 				))

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -371,22 +371,17 @@
 		))
 
 		(if add_feature_to_dataset
-			(let
-				(assoc
-					min_deviation_value (/ 1 (call !GetNumTrainingCases))
-					null_feature (= (null) feature_value)
-				)
+			(seq
+				;all features are added as inactive since they start with a single value
+				(if !inactiveFeaturesMap
+					(accum_to_entities (assoc !inactiveFeaturesMap (associate feature 0)))
 
-				(if null_feature
-					(if !inactiveFeaturesMap
-						(accum_to_entities (assoc !inactiveFeaturesMap (associate feature 0)))
-
-						(assign_to_entities (assoc !inactiveFeaturesMap (associate feature 0) ))
-					)
+					(assign_to_entities (assoc !inactiveFeaturesMap (associate feature 0) ))
 				)
 
 				;update hyperparameters and clear the cached residuals flags
 				(assign_to_entities (assoc
+					!inactiveFeaturesNeedCaching (true)
 					!hyperparameterMetadataMap (call !UpdateHyperparametersWithNewFeature (assoc hp_map !hyperparameterMetadataMap))
 					!defaultHyperparameters (call !UpdateHyperparametersWithNewFeature (assoc hp_map !defaultHyperparameters))
 

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -299,6 +299,10 @@
 			feature_mda_map (null)
 			original_features (replace features)
 			features_for_derivation_map (assoc)
+
+			;map of inactive features that were excluded from computations but should be added back in for output
+			;with preset values of 0 or 1 as applicable depending on the metric, eg., residual=0, accuracy=1
+			excluded_inactive_features_map {}
 		))
 
 		(call !InitResiduals)
@@ -328,7 +332,11 @@
 				(assoc
 					"feature_mda_map"
 						(call !ComputeRobustTargetlessMDA (assoc
-							features original_features
+							features
+								(if (size excluded_inactive_features_map)
+									(append features (indices excluded_inactive_features_map))
+									original_features
+								)
 							output_raw_mda output_raw_mda
 							mda_action_feature mda_action_feature
 						))
@@ -455,6 +463,11 @@
 			(assign (assoc
 				residuals_map (map (lambda (/ (current_value) 2)) residuals_map)
 			))
+		)
+
+		;put excluded inactive features back into residuals_map with 0s
+		(if (size excluded_inactive_features_map)
+			(accum (assoc residuals_map excluded_inactive_features_map ))
 		)
 
 		;for shared deviations, only one set of deviations are calculated for each group. At the end of the calculations,
@@ -1219,6 +1232,42 @@
 					recall_map unique_feature_map
 					mcc_map unique_feature_map
 				))
+			)
+		)
+
+		(if (size excluded_inactive_features_map)
+			(seq
+				;put nominal inactive features back in
+				(if (size (keep excluded_inactive_features_map (indices !nominalsMap)))
+					(let
+						(assoc
+							nominal_inactives_map (map 1 (keep excluded_inactive_features_map (indices !nominalsMap)) )
+						)
+						(accum (assoc
+							accuracy_map nominal_inactives_map
+							precision_map nominal_inactives_map
+							recall_map nominal_inactives_map
+							mcc_map nominal_inactives_map
+						))
+					)
+				)
+
+				;put continuous inactive features back in
+				(if (size (remove excluded_inactive_features_map (indices !nominalsMap)))
+					(let
+						(assoc
+							continuous_inactives_1_map (map 1 (remove excluded_inactive_features_map (indices !nominalsMap)) )
+							continuous_inactives_0_map (remove excluded_inactive_features_map (indices !nominalsMap))
+						)
+						(accum (assoc
+							r2_map continuous_inactives_1_map
+							spearman_coeff_map continuous_inactives_1_map
+							rmse_map continuous_inactives_0_map
+							adjusted_smape_map continuous_inactives_0_map
+							smape_map continuous_inactives_0_map
+						))
+					)
+				)
 			)
 		)
 

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -1559,7 +1559,7 @@
 			case_residuals_lists
 				||(map
 					(lambda
-						;For each case, forecast the til the window-length is elapsed and interpolate both
+						;For each case, forecast until the window-length is elapsed and interpolate both
 						;the forecast and the trained series to get find the error at the end of the window
 						(let
 							(assoc

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -438,7 +438,7 @@
 		)
 	)
 
-	;update hyperparameter map for newly added feature
+	;update hyperparameter map for newly added inactive feature
 	; hp_map: the hp map to be updated, should be either !defaultHyperparameters or !hyperparameterMetadataMap
 	#!UpdateHyperparametersWithNewFeature
 	(declare
@@ -454,21 +454,20 @@
 						)
 
 						(if (!= (null) feature_weights_map)
-							(assign (assoc feature_weights_map (append feature_weights_map (associate feature 1)) ))
+							(assign (assoc feature_weights_map (append feature_weights_map (associate feature 0)) ))
 
 							;else no weights, assign all active features weight 1
 							(assign (assoc
 								feature_weights_map
 									(append
-										(zip (append !trainedFeatures feature) 1)
-										;prevent appending null to an assoc
-										(if !inactiveFeaturesMap !inactiveFeaturesMap (assoc))
+										(zip !trainedFeatures 1)
+										!inactiveFeaturesMap
 									)
 							))
 						)
 
-						(if (!= (null) feature_deviations_map)
-							(assign (assoc feature_deviations_map (set feature_deviations_map feature min_deviation_value) ))
+						(if (size feature_deviations_map)
+							(assign (assoc feature_deviations_map (set feature_deviations_map feature 0) ))
 						)
 
 						(append (current_value) (assoc

--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -331,6 +331,8 @@
 								)
 						)
 
+						(if (contains_index excluded_inactive_features_map feature) (conclude (range 0 1 (size features) 1)) )
+
 						(map
 							(lambda (let
 								(assoc
@@ -355,6 +357,8 @@
 								(if (and mda_action_feature (!= mda_feature mda_action_feature))
 									(conclude)
 								)
+
+								(if (contains_index excluded_inactive_features_map mda_feature) (conclude 0) )
 
 								;output delta of the (expectedly) larger residual computed without this feature - residual computed with this feature
 								(if output_raw_mda
@@ -501,14 +505,24 @@
 							(lambda
 								(if (or (> (current_value) 0) (= target_feature (current_index)))
 									(/ (current_value) total_probs)
-									smallest_probability
+									(if (contains_index !inactiveFeaturesMap (current_index))
+										0
+										smallest_probability
+									)
 								)
 							)
 							probabilities_of_contribution_map
 						)
 
-						;else set them all to 1 because this feature had no affect on others
-						(map 1 probabilities_of_contribution_map)
+						;else set them all to 1 because this feature had no affect on others, except inactives should remain 0
+						(if (size !inactiveFeaturesMap)
+							(append
+								(map 1 probabilities_of_contribution_map)
+								(keep !inactiveFeaturesMap features)
+							)
+
+							(map 1 probabilities_of_contribution_map)
+						)
 					)
 				))
 				features

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -567,8 +567,8 @@
 			(seq
 				(assign (assoc excluded_inactive_features_map (keep !inactiveFeaturesMap features) ))
 				(assign (assoc
-					features (filter (lambda (not (contains_index !inactiveFeaturesMap (current_value)))) features)
-					context_features (filter (lambda (not (contains_index !inactiveFeaturesMap (current_value)))) context_features)
+					features (filter (lambda (not (contains_index excluded_inactive_features_map (current_value)))) features)
+					context_features (filter (lambda (not (contains_index excluded_inactive_features_map (current_value)))) context_features)
 				))
 			)
 		)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -186,8 +186,12 @@
 			temp_residual_map
 				(map
 					(lambda
-						;set upper bound to nominals to be max nominal deviation, accounting for imbalanced classes
-						(if (contains_index !nominalsMap (current_index))
+						;inactive features don't expact residuals because they are all 0
+						(if (contains_index !inactiveFeaturesMap (current_index))
+							0
+
+							;set upper bound to nominals to be max nominal deviation, accounting for imbalanced classes
+							(contains_index !nominalsMap (current_index))
 							(let
 								(assoc
 									;map of class -> count
@@ -555,6 +559,17 @@
 					;else reset unique_features_for_populating_output back to null
 					(assign (assoc unique_features_for_populating_output (null) ))
 				)
+			)
+		)
+
+		;don't bother using inactive features in any way for residuals
+		(if (size !inactiveFeaturesMap)
+			(seq
+				(assign (assoc excluded_inactive_features_map (keep !inactiveFeaturesMap features) ))
+				(assign (assoc
+					features (filter (lambda (not (contains_index !inactiveFeaturesMap (current_value)))) features)
+					context_features (filter (lambda (not (contains_index !inactiveFeaturesMap (current_value)))) context_features)
+				))
 			)
 		)
 	)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -186,7 +186,7 @@
 			temp_residual_map
 				(map
 					(lambda
-						;inactive features don't expact residuals because they are all 0
+						;inactive features don't expand residuals because they are all 0
 						(if (contains_index !inactiveFeaturesMap (current_index))
 							0
 
@@ -568,7 +568,7 @@
 				(assign (assoc excluded_inactive_features_map (keep !inactiveFeaturesMap features) ))
 				(assign (assoc
 					features (filter (lambda (not (contains_index excluded_inactive_features_map (current_value)))) features)
-					context_features (filter (lambda (not (contains_index excluded_inactive_features_map (current_value)))) context_features)
+					context_features (filter (lambda (not (contains_index !inactiveFeaturesMap (current_value)))) context_features)
 				))
 			)
 		)

--- a/howso/train_utilities.amlg
+++ b/howso/train_utilities.amlg
@@ -152,11 +152,9 @@
 	#!UpdateInactiveFeatures
 	(seq
 		;prime the caches for the query engine using all the trained features
-		(size
-			(contained_entities (append
-				(map (lambda (query_exists (current_value))) !trainedFeatures)
-			))
-		)
+		(size (contained_entities
+			(map (lambda (query_exists (current_value))) !trainedFeatures)
+		))
 
 		(declare (assoc
 			inactive_features_map
@@ -164,21 +162,31 @@
 					(lambda (let
 						(assoc feature (current_index 1))
 
-						;only keep those features that have no valid values (0 non-nulls)
-						(=
-							(size
-								(contained_entities (list
-									(query_exists !internalLabelSession)
-									(query_exists feature)
-									(query_not_equals feature (null))
+						;only keep those features that only have one value
+						(declare (assoc
+							feature_value
+								(first (first
+									(compute_on_contained_entities [
+										(query_exists !internalLabelSession)
+										(query_select 1 0)
+										(query_exists feature)
+									])
 								))
+						))
+
+						;there are no other cases that have a different value
+						(= 0
+							(size
+								(compute_on_contained_entities [
+									(query_exists !internalLabelSession)
+									(query_not_equals feature feature_value)
+								])
 							)
-							0
 						)
 					))
 					(if !inactiveFeaturesMap
 						!inactiveFeaturesMap
-						(zip !trainedFeatures 0)
+						(zip !trainedFeatures (range 0 1 (size !trainedFeatures) 1))
 					)
 				)
 		))

--- a/howso/train_utilities.amlg
+++ b/howso/train_utilities.amlg
@@ -68,7 +68,7 @@
 											(assign (assoc weights_map (append weights_map features_weights_map) ))
 
 											;if there is a featureMdaMap specified, temporarily set the weight of activated features to be 1/num_features
-											;so that they can be used in queries until the dataset is reanalized
+											;so that they can be used in queries until the dataset is reanalyzed
 											(declare (assoc
 												scaled_features_weights_map
 													(if (size (get (current_value 1) "featureMdaMap"))
@@ -92,7 +92,7 @@
 																(get (current_value 1) "featureMdaMap")
 															)
 														;temporarily set the deviations of activated features to be initial values
-														;so that they can be used in queries until the dataset is reanalized
+														;so that they can be used in queries until the dataset is reanalyzed
 														"featureDeviations"
 															(append
 																(get (current_value 1) "featureDeviations")

--- a/howso/train_utilities.amlg
+++ b/howso/train_utilities.amlg
@@ -212,6 +212,8 @@
 							)
 						)
 					))
+					;once !inactiveFeaturesMap is created, add_feature and remove_feature edit it, so unless
+					;cases are beind edited, only need to check !inactiveFeaturesMap instead of all the trained features
 					(if (and !inactiveFeaturesMap (not editing_existing_cases))
 						!inactiveFeaturesMap
 						(zip !trainedFeatures (range 0 1 (size !trainedFeatures) 1))

--- a/howso/train_utilities.amlg
+++ b/howso/train_utilities.amlg
@@ -36,7 +36,7 @@
 		)
 	)
 
-	;set specified feature weights in all hyperparameter maps (!defaultHyperparameters and !hyperparameterMetadataMap)
+	;set specified feature weights for inactive features in all hyperparameter maps (!defaultHyperparameters and !hyperparameterMetadataMap)
 	;If weights haven't been defined yet, set them to 0 for invacitves and 1 for actives
 	;If already defined, will overwrite the weight of the specified features in feature_weights_map
 	;
@@ -44,7 +44,7 @@
 	; features_weights_map: assoc of feature -> weight to overwrite in all hyperparameter sets
 	; overwrite: flag, if set to true will assume that featureWeights already exist and overwrites them.
 	;			 When false, will create featureWeights in the hyperparameter set
-	#!SetFeatureWeightsForFeatures
+	#!SetInactiveFeatureWeights
 	(declare
 		(assoc
 			features_weights_map (assoc)
@@ -65,22 +65,44 @@
 											;take featureWeights in HP assoc and alter them
 											(assoc weights_map (get (current_value 1) "featureWeights") )
 
-											(map
-												(lambda
-													(assign (assoc
-														weights_map
-															(set
-																weights_map
-																(current_index 1)
-																(current_value 1)
-															)
-													))
-												)
-												features_weights_map
-											)
+											(assign (assoc weights_map (append weights_map features_weights_map) ))
+
+											;if there is a featureMdaMap specified, temporarily set the weight of activated features to be 1/num_features
+											;so that they can be used in queries until the dataset is reanalized
+											(declare (assoc
+												scaled_features_weights_map
+													(if (size (get (current_value 1) "featureMdaMap"))
+														(map
+															(lambda (/ (current_value) (size weights_map)) )
+															features_weights_map
+														)
+													)
+											))
 
 											;append the updated deviations_map to this hp map
-											(append (current_value) (assoc "featureWeights" weights_map) )
+											(append
+												(current_value)
+												(assoc "featureWeights" weights_map)
+
+												(if scaled_features_weights_map
+													(assoc
+														"featureMdaMap"
+															(map
+																(lambda (append (current_value) scaled_features_weights_map))
+																(get (current_value 1) "featureMdaMap")
+															)
+														;temporarily set the deviations of activated features to be initial values
+														;so that they can be used in queries until the dataset is reanalized
+														"featureDeviations"
+															(append
+																(get (current_value 1) "featureDeviations")
+																(call !ComputeInitialResiduals (assoc features (indices scaled_features_weights_map) ))
+															)
+													)
+
+													{}
+												)
+											)
 										)
 
 										(let
@@ -193,7 +215,7 @@
 
 		;if there are now less inactive features than there were, set the no-longer inactive feature weights to 1
 		(if (< (size inactive_features_map) (size !inactiveFeaturesMap))
-			(call !SetFeatureWeightsForFeatures (assoc
+			(call !SetInactiveFeatureWeights (assoc
 				features_weights_map
 					(zip
 						(indices (remove !inactiveFeaturesMap (indices inactive_features_map)) )
@@ -207,7 +229,7 @@
 			(seq
 				;if there are inactive features and they haven't been set yet, set their weight to 0
 				(if (!= !inactiveFeaturesMap inactive_features_map)
-					(call !SetFeatureWeightsForFeatures (assoc
+					(call !SetInactiveFeatureWeights (assoc
 						features_weights_map inactive_features_map
 						overwrite (false)
 					))

--- a/howso/train_utilities.amlg
+++ b/howso/train_utilities.amlg
@@ -213,7 +213,7 @@
 						)
 					))
 					;once !inactiveFeaturesMap is created, add_feature and remove_feature edit it, so unless
-					;cases are beind edited, only need to check !inactiveFeaturesMap instead of all the trained features
+					;cases are being edited, only need to check !inactiveFeaturesMap instead of all the trained features
 					(if (and !inactiveFeaturesMap (not editing_existing_cases))
 						!inactiveFeaturesMap
 						(zip !trainedFeatures (range 0 1 (size !trainedFeatures) 1))

--- a/howso/train_utilities.amlg
+++ b/howso/train_utilities.amlg
@@ -171,8 +171,14 @@
 	)
 
 	;Helper method to prime query caches for all !trainedFeatures and update the !inactiveFeaturesMap
+	;parameters:
+	; editing_existing_cases: boolean, default false. If true this method is being called from cases
+	;		being edited and thus !inactiveFeaturesMap may be being added to or removed from and
+	;		all the features are already defined in hyperparameters.
 	#!UpdateInactiveFeatures
-	(seq
+	(declare
+		(assoc editing_existing_cases (false) )
+
 		;prime the caches for the query engine using all the trained features
 		(size (contained_entities
 			(map (lambda (query_exists (current_value))) !trainedFeatures)
@@ -206,15 +212,17 @@
 							)
 						)
 					))
-					(if !inactiveFeaturesMap
+					(if (and !inactiveFeaturesMap (not editing_existing_cases))
 						!inactiveFeaturesMap
 						(zip !trainedFeatures (range 0 1 (size !trainedFeatures) 1))
 					)
 				)
 		))
 
-		;if there are now less inactive features than there were, set the no-longer inactive feature weights to 1
-		(if (< (size inactive_features_map) (size !inactiveFeaturesMap))
+		;if there are inactive features that are no longer inactive, set their feature weights to 1
+		(if (size
+				(indices (remove !inactiveFeaturesMap (indices inactive_features_map)) )
+			)
 			(call !SetInactiveFeatureWeights (assoc
 				features_weights_map
 					(zip
@@ -231,7 +239,9 @@
 				(if (!= !inactiveFeaturesMap inactive_features_map)
 					(call !SetInactiveFeatureWeights (assoc
 						features_weights_map inactive_features_map
-						overwrite (false)
+						;overwrite only if this flow is working on existing cases and features only
+						;otherwise assume new features are being added
+						overwrite editing_existing_cases
 					))
 				)
 				(assign_to_entities (assoc
@@ -240,7 +250,7 @@
 				))
 			)
 
-			;else all features have some non-null values
+			;else all features have more than one value
 			(assign_to_entities (assoc
 				!inactiveFeaturesMap (null)
 				!inactiveFeaturesNeedCaching (false)

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -333,6 +333,9 @@
 
 		(call !UpdateHasNulls (assoc features features))
 
+		;it's possible that the resulting case values activate or deactivate a feature
+		(call !UpdateInactiveFeatures (assoc editing_existing_cases (true) ))
+
 		(accum_to_entities (assoc !revision 1))
 
 		;return number of case ids edited

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -192,7 +192,7 @@
 		obs
 			(and
 				; TEST is in the weights map
-				(= 1 (get result ["targetless" "fruit.height.length.size.sweet.tart.weight.width." ".none" "featureWeights" "TEST"]) )
+				(= 0 (get result ["targetless" "fruit.height.length.size.sweet.tart.weight.width." ".none" "featureWeights" "TEST"]) )
 			)
 	))
 
@@ -248,13 +248,13 @@
 	(if (contains_index result ["targeted" "width" "fruit.height.length.size.sweet.tart.weight." ".none" "featureDeviations" "TEST"])
 		(call assert_approximate (assoc
 			obs (get result ["targeted" "width" "fruit.height.length.size.sweet.tart.weight." ".none" "featureDeviations" "TEST"])
-			exp 0.0416666
+			exp 0
 		))
 	)
 
 	(call assert_approximate (assoc
 		obs (get result ["targetless" "fruit.height.length.size.sweet.tart.weight.width." ".none" "featureWeights" "TEST"])
-		exp 1
+		exp 0
 	))
 
 

--- a/unit_tests/ut_h_basic_ablation.amlg
+++ b/unit_tests/ut_h_basic_ablation.amlg
@@ -151,7 +151,7 @@
 	;this should  be added to the model
 	(call_entity "howso" "train" (assoc
 		features (list "A" "B" "C" "D" "E")
-		cases (list (list 1 5 2 1 1))
+		cases (list (list 1 5.1 2 1 1))
 		session "my_session"
 	))
 	(print "New model size after absolute threshold filter: ")
@@ -247,7 +247,7 @@
 	(print "Conviction of new case: ")
 	(call assert_approximate (assoc obs (first conv1) exp .89354))
 	(print "Conviction of existing case: ")
-	(call assert_approximate (assoc obs (first conv2) exp .90499))
+	(call assert_approximate (assoc obs (first conv2) exp .8507))
 
 	(call exit_if_failures (assoc msg "Conviction of new case vs knockout"))
 

--- a/unit_tests/ut_h_inactive.amlg
+++ b/unit_tests/ut_h_inactive.amlg
@@ -1,0 +1,176 @@
+(seq
+	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_inactive.amlg"))
+
+	(call_entity "howso" "set_feature_attributes" (assoc
+		feature_attributes (assoc "B" (assoc "type" "nominal") )
+	))
+
+	(declare (assoc
+		data
+			(list
+				(list 10	"A"		(null) 2 ) ;0
+				(list 10	(null)	(null) 2 ) ;1
+				(list 10	"B"		(null) 2 ) ;2
+				(list 20	"C"		(null) 2 ) ;3
+				(list 20	"A"		(null) 2 ) ;4
+				(list 20	"B"		(null) 2 ) ;5
+				(list 30	"D"		(null) 2 ) ;6
+				(list 30	(null)	(null) 2 ) ;7
+				(list 30	"D"		(null) 2 ) ;8
+				(list 40 	"D"		(null) 2 ) ;9
+				(list 50	"E"		(null) 2 ) ;10
+				(list 50	"E"		(null) 2 ) ;11
+				(list 40	(null)	(null) 2 ) ;12
+				(list 50	(null)	(null) 2 ) ;13
+				(list 100	"E"		(null) 2 ) ;14
+
+			)
+		features (list "A" "B" "C" "D")
+		result (null)
+	))
+
+	(call_entity "howso" "train" (assoc
+		features features
+		cases data
+	))
+
+	(call_entity "howso" "analyze")
+
+	(declare (assoc
+		opt_hp_map
+			(get
+				(call_entity "howso" "get_params")
+				(list 1 "payload" "hyperparameter_map" "targetless" "A.B.C.D." ".none")
+			)
+	))
+
+	(print "Inactive features all have 0's for weights: ")
+	(call assert_true (assoc
+		obs
+			(= 0
+				(get opt_hp_map ["featureWeights" "C"])
+				(get opt_hp_map ["featureWeights" "D"])
+				(get opt_hp_map ["featureDeviations" "C"])
+				(get opt_hp_map ["featureDeviations" "D"])
+				(get opt_hp_map ["featureMdaMap" "A" "C"])
+				(get opt_hp_map ["featureMdaMap" "A" "D"])
+				(get opt_hp_map ["featureMdaMap" "B" "C"])
+				(get opt_hp_map ["featureMdaMap" "B" "D"])
+				(get opt_hp_map ["featureMdaMap" "C" "D"])
+				(get opt_hp_map ["featureMdaMap" "D" "C"])
+			)
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "react_aggregate" (assoc
+				action_feature "A"
+				details
+					{
+						"feature_deviations" (true)
+						"feature_full_residuals" (true)
+						"feature_robust_residuals" (true)
+						"prediction_stats" (true)
+						"feature_full_accuracy_contributions" (true)
+						"feature_robust_accuracy_contributions" (true)
+						"feature_full_prediction_contributions" (true)
+						"feature_robust_prediction_contributions" (true)
+					}
+			))
+	))
+	(call keep_result_payload)
+	(print "React aggregate appropriately fixed values for inactives: ")
+	(call assert_true (assoc
+		obs
+			(= 0
+				(get result ["adjusted_smape" "C"])
+				(get result ["adjusted_smape" "D"])
+				(get result ["smape" "C"])
+				(get result ["smape" "D"])
+				(get result ["rmse" "C"])
+				(get result ["rmse" "D"])
+				(get result ["mae" "C"])
+				(get result ["mae" "D"])
+				(get result ["feature_robust_prediction_contributions" "C"])
+				(get result ["feature_robust_prediction_contributions" "D"])
+				(get result ["feature_robust_directional_prediction_contributions" "C"])
+				(get result ["feature_robust_directional_prediction_contributions" "D"])
+				(get result ["feature_robust_accuracy_contributions" "A" "C"])
+				(get result ["feature_robust_accuracy_contributions" "A" "D"])
+				(get result ["feature_full_accuracy_contributions" "C"])
+				(get result ["feature_full_accuracy_contributions" "D"])
+				(get result ["feature_full_directional_prediction_contributions" "C"])
+				(get result ["feature_full_directional_prediction_contributions" "D"])
+				(get result ["feature_full_directional_prediction_contributions" "C"])
+				(get result ["feature_full_directional_prediction_contributions" "D"])
+
+			)
+	))
+	(call assert_true (assoc
+		obs
+			(= 1
+				(get result ["r2" "C"])
+				(get result ["r2" "D"])
+				(get result ["spearman_coeff" "C"])
+				(get result ["spearman_coeff" "D"])
+			)
+	))
+	(call assert_true (assoc
+		obs
+			(= 0.06451612903225806
+				(get result ["feature_deviations" "C"])
+				(get result ["feature_deviations" "D"])
+				(get result ["feature_robust_residuals" "C"])
+				(get result ["feature_robust_residuals" "D"])
+			)
+	))
+
+	(call exit_if_failures (assoc msg "Inactive Features weights and stats." ))
+
+
+	(call_entity "howso" "train" (assoc
+		features features
+		cases
+			[
+				[100 "E" 2000 2]
+				[120 "E" 2100 2]
+			]
+	))
+
+	(call_entity "howso" "analyze")
+
+	(assign (assoc
+		opt_hp_map
+			(get
+				(call_entity "howso" "get_params")
+				(list 1 "payload" "hyperparameter_map" "targetless" "A.B.C.D." ".none")
+			)
+	))
+
+	(print "Feature C has values, feature D is still inactive: ")
+	(call assert_true (assoc
+		obs
+			(= 0
+				(get opt_hp_map ["featureWeights" "D"])
+				(get opt_hp_map ["featureDeviations" "D"])
+				(get opt_hp_map ["featureMdaMap" "A" "D"])
+				(get opt_hp_map ["featureMdaMap" "B" "D"])
+				(get opt_hp_map ["featureMdaMap" "C" "D"])
+			)
+	))
+	(call assert_true (assoc
+		obs
+			(and
+				(!= 0 (get opt_hp_map ["featureWeights" "C"]) )
+				(!= 0 (get opt_hp_map ["featureDeviations" "C"]) )
+				(!= 0 (get opt_hp_map ["featureMdaMap" "A" "C"]) )
+				(!= 0 (get opt_hp_map ["featureMdaMap" "B" "C"]) )
+				(!= 0 (get opt_hp_map ["featureMdaMap" "D" "C"]) )
+			)
+	))
+
+	(call exit_if_failures (assoc msg "Reactivated Features weights and stats." ))
+
+	(call exit_if_failures (assoc msg unit_test_name ))
+)

--- a/unit_tests/ut_howso.amlg
+++ b/unit_tests/ut_howso.amlg
@@ -77,6 +77,7 @@
 				"ut_h_weighted_residuals_nom.amlg"
 				"ut_h_goal_features.amlg"
 				"ut_h_goal_features_agg.amlg"
+				"ut_h_inactive.amlg"
 
 				;should always be last
 				"ut_h_migration.amlg"


### PR DESCRIPTION
This explicitly removes inactive features from the context_features when computing residuals, contributions, deviations, stats, etc, to increase performance, while also ensuring that their weights are zero'd out everywhere feature weights could be used (both featureWeights and featureMdaMap)