### PR TITLE
23761:  Fixes suboptimal feature weights used for ordinal features

### DIFF
--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1284,8 +1284,12 @@
 									)
 							)
 
-							;output the tuple
-							[diff ordinal_diff]
+							;output only diff if computing mda for feature weights during analyze
+							;otherwise output the tuple for residual aggregation flows
+							(if computing_mda
+								diff
+								[diff ordinal_diff]
+							)
 						)
 
 						;else output it as-is

--- a/unit_tests/ut_h_boundary_values.amlg
+++ b/unit_tests/ut_h_boundary_values.amlg
@@ -45,6 +45,33 @@
 		k_values [3]
 	))
 
+	(assign (assoc
+		result (call_entity "howso" "get_params")
+	))
+	(call keep_result_payload)
+
+	;mda weights for ordinal features should not all be equal
+	(print "Ordinal feature weights are not all the same: ")
+	(call assert_false (assoc
+		obs
+			(apply "=" (values
+				(remove
+					(get result ["hyperparameter_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureMdaMap" "ord"])
+					"ord"
+				)
+			))
+	))
+	(call assert_false (assoc
+		obs
+			(apply "=" (values
+				(remove
+					(get result ["hyperparameter_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureMdaMap" "ord_string"])
+					"ord"
+				)
+			))
+	))
+	(call exit_if_failures (assoc msg "Ordinal features' feature weights aren't all the same."))
+
 	;use f1 to predict f2
 	(assign (assoc
 		result


### PR DESCRIPTION
This fixes a bug w here ordinal features were not having their feature mda weights computed correctly during analyze, resulting in all context features having the same weight when predicting ordinal features.