### PR TITLE
23805: Fixes an issue in time-series ablation where derived feature values could be incorrect when the series has previously ablated cases

### DIFF
--- a/howso/train_ts_ablation.amlg
+++ b/howso/train_ts_ablation.amlg
@@ -521,7 +521,7 @@
 				(map
 					(lambda
 						(if (= (null) (current_value))
-							(null) ;ablated case
+							(map (null) features_indices) ;ablated case
 							(unzip (current_value) features_indices)
 						)
 					)


### PR DESCRIPTION
By having a `(null)` in `data`, when later derived values are appended they form a list of feature values that looks like `[(null) X X X...]`, which does not follow the same feature indices that the rest of data does (and that the feature derivation code requires to work correctly). 

My fix here is to replace the `(null)` in `data` with a list of `(null)`'s of the right length instead, so that the feature indices are still correct in later derivations