### PR TITLE
23819: Fixes a warning that can be emitted in forecasting regarding no trained series

### DIFF
--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1281,10 +1281,23 @@
 				(if (= (size existing_series_cases) 0)
 					(accum (assoc
 						warnings
-							(associate (concat
-								"There is no series trained with the set of IDs:\n"
-								(apply "concat" (values (map (lambda (concat (current_index) ": " (current_value) "\n")) id_values_map)))
-							))
+							(if (not (size
+									(contained_entities (map
+										(lambda (query_equals (current_value) (get id_values_map (current_value))))
+										(indices id_values_map)
+									))
+								))
+								;There are no cases from this series in the model
+								(associate (concat
+									"There is no series trained with the set of IDs:\n"
+									(apply "concat" (values (map (lambda (concat (current_index) ": " (current_value) "\n")) id_values_map)))
+								))
+
+								(associate (concat
+									"There are no trained timesteps before the given initial time value with the set of IDs:\n"
+									(apply "concat" (values (map (lambda (concat (current_index) ": " (current_value) "\n")) id_values_map)))
+								))
+							)
 					))
 				)
 


### PR DESCRIPTION
A warning was written a bit incorrectly regarding what message was meant to be sent to the user. Updated it to have one of two possible messages depending on if there are truly no cases with the given series IDs or if there are just no cases that have those IDs that are also before the given starting time for the forecast.