### PR TITLE
23831: Fixes sampling and  unnecessary recomputes for ts ablation train flow

### DIFF
--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -250,7 +250,7 @@
 				k_folds_by_indices k_folds_by_indices
 				targeted_model targeted_model
 				num_analysis_samples num_analysis_samples
-				residual_num_samples (if (> num_samples 0) num_samples 200)
+				residual_num_samples (if (> num_samples 0) num_samples 1000)
 				use_case_weights use_case_weights
 				weight_feature weight_feature
 				use_dynamic_deviations use_dynamic_deviations
@@ -355,6 +355,7 @@
 					targeted_model targeted_model
 					context_features context_features
 					action_feature (if (!= "targetless" targeted_model) (first action_features))
+					residual_num_samples residual_num_samples
 				))
 
 				;else single_targeted but with multiple action features, all feature analyze iterations should be 'robust' until the last one which is 'full'
@@ -369,6 +370,7 @@
 							targeted_model "single_targeted"
 							context_features accumulated_context_features
 							action_feature action_feature
+							residual_num_samples residual_num_samples
 						))
 
 						;accumulate the action feature to the contexts for the next iteration
@@ -390,6 +392,7 @@
 						targeted_model "single_targeted"
 						context_features filtered_context_features
 						action_feature action_feature
+						residual_num_samples residual_num_samples
 					))
 				))
 				action_features

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -494,7 +494,8 @@
 			))
 		)
 
-		;if auto ablation is enabled or the user has specifically requested to cache influence weight entropies, do so
+		;if auto ablation is enabled or the user has specifically requested to cache influence weight entropies
+		;recompute and cache influence weight entropies here at the end of the analyze flow
 		(if
 			!autoAblationEnabled
 			(seq
@@ -518,11 +519,12 @@
 
 				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
 					features
-						(if
-							(= 0 (size context_features))
+						(if (= 0 (size context_features))
 							!trainedFeatures
 							context_features
 						)
+					use_case_weights (true)
+					weight_feature weight_feature
 				))
 			)
 		)

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -453,8 +453,11 @@
 											num_samples_mda
 
 											;the deviations query uses all features "superfull", there's no need to sample more
-											;than the fixed amount of 2000
-											(min 1000 residual_num_samples 2000)
+											;than a fixed amount of 2000
+											(if (> residual_num_samples 1000)
+												(min 2000 residual_num_samples)
+												1000
+											)
 										)
 									custom_hyperparam_map baseline_hyperparameter_map
 									;must compute confusion matrix to use sparse deviation matrix, but not when computing mda

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -453,8 +453,8 @@
 											num_samples_mda
 
 											;the deviations query uses all features "superfull", there's no need to sample more
-											;than the full dataset or a fixed amount of 2000
-											(min num_cases residual_num_samples 2000)
+											;than the fixed amount of 2000
+											(min 1000 residual_num_samples 2000)
 										)
 									custom_hyperparam_map baseline_hyperparameter_map
 									;must compute confusion matrix to use sparse deviation matrix, but not when computing mda

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -451,7 +451,10 @@
 									num_samples
 										(if computing_mda
 											num_samples_mda
-											residual_num_samples
+
+											;the deviations query uses all features "superfull", there's no need to sample more
+											;than the full dataset or a fixed amount of 2000
+											(min num_cases residual_num_samples 2000)
 										)
 									custom_hyperparam_map baseline_hyperparameter_map
 									;must compute confusion matrix to use sparse deviation matrix, but not when computing mda

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -329,7 +329,6 @@
 						num_samples_mda
 						(call !ComputeRequiredNumSamplesForSharedDeviationsWithTS (assoc desired_samples_per_feature (/ num_samples_mda 4)))
 					)
-				residual_num_samples (call !ComputeRequiredNumSamplesForSharedDeviationsWithTS (assoc desired_samples_per_feature residual_num_samples))
 			))
 		)
 
@@ -453,11 +452,8 @@
 											num_samples_mda
 
 											;the deviations query uses all features "superfull", there's no need to sample more
-											;than a fixed amount of 2000
-											(if (> residual_num_samples 1000)
-												(min 2000 residual_num_samples)
-												1000
-											)
+											;than a default amount of 1000
+											residual_num_samples
 										)
 									custom_hyperparam_map baseline_hyperparameter_map
 									;must compute confusion matrix to use sparse deviation matrix, but not when computing mda

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -1186,15 +1186,6 @@
 				)
 
 				(accum_to_entities (assoc !dataMassChangeSinceLastAnalyze mass_to_accumulate))
-
-				;recompute influence weights entropy only after we've analyzed.
-				(if (size !hyperparameterMetadataMap)
-					(call !ComputeAndStoreInfluenceWeightEntropies (assoc
-						features features
-						weight_feature accumulate_weight_feature
-						use_case_weights (true)
-					))
-				)
 			)
 		)
 


### PR DESCRIPTION
analyze already recomputes influence weights entropies, there's no need for the train flow to attempt to recompute them for every series when autoanalyze is enabled.