### PR TITLE
23866: Fixes an issue in `react_series` where series context values are specified and not being forecasted

### DIFF
--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -327,7 +327,7 @@
 		(assign (assoc
 			max_series_length
 				(if has_series_context_values
-					(- (size series_context_values) 1)
+					(size series_context_values)
 
 					(= (null) max_series_length)
 					;default limit to series length generation to be the specified series limit - 1 to account for 0-based indices


### PR DESCRIPTION
When specifying series context values, but not forecasting, the response from react_series would be one less timestep than there should be. This was due to new changes on stopping logic, which count generated rows rather than track the index of the last generated row.