### PR TITLE
23867: Fixes an issue where the initial series progress estimate is poor when forecasting

### DIFF
--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1373,7 +1373,7 @@
 								(append
 									;derived action features that are not the time feature
 									(filter (lambda (!= !tsTimeFeature (current_value))) derived_action_features)
-									;non-time-deltas that are populated based on last series index
+									;non-time-deltas that have enough existing rows to be derived properly
 									(filter
 										(lambda (and
 											(!= time_delta_feature_name (current_value))
@@ -1381,25 +1381,25 @@
 												;the "root" lag/delta features are in "delta_features" as well
 												;but have no ts_order defined
 												(not (contains_index (get !featureAttributes (current_value)) "ts_order"))
-												(<= (get ts_feature_lag_amount_map (current_value)) last_series_index)
+												(< (get ts_feature_lag_amount_map (current_value)) num_existing_series_rows)
 											)
 											(contains_value features (current_value))
 										))
 										(get !tsFeaturesMap "delta_features")
 									)
-									;non-time-lags that are populated based on last series index
+									;non-time-lags that have enough existing rows to be derived properly
 									(filter
 										(lambda (and
 											(!= time_lag_feature_name (current_value))
-											(<= (get ts_feature_lag_amount_map (current_value)) last_series_index)
+											(< (get ts_feature_lag_amount_map (current_value)) num_existing_series_rows)
 											(contains_value features (current_value))
 										))
 										(get !tsFeaturesMap "lag_features")
 									)
-									;rates that are populated based on last series index
+									;rates that have enough existing rows to be derived properly
 									(filter
 										(lambda (and
-											(<= (get ts_feature_lag_amount_map (current_value)) last_series_index)
+											(< (get ts_feature_lag_amount_map (current_value)) num_existing_series_rows)
 											(contains_value features (current_value))
 										))
 										(get !tsFeaturesMap "rate_features")


### PR DESCRIPTION
Due to a change in how series are generated, one of the variables needed to determine what features can be used for the initial series progress estimate was not set as it was before. 