### PR TITLE
23897: Updates num_feature_probability_samples to be dynamically computed if unspecified

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -697,7 +697,7 @@
 			!autoAnalyzeThreshold 100
 
 			;if !autoAnalyzeEnabledis set, the factor by which to increase that threshold every time the model grows to that threshold size
-			!autoAnalyzeGrowthFactorAmount 2.718281828459
+			!autoAnalyzeGrowthFactorAmount 7.3890561
 
 			;map of parameters used when analyze was called on this model
 			!savedAnalyzeParameterMap (null)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -256,7 +256,7 @@
 				k_folds_by_indices k_folds_by_indices
 				targeted_model targeted_model
 				num_analysis_samples num_analysis_samples
-				num_feature_probability_samples (if (> num_feature_probability_samples 0) num_feature_probability_samples 10000)
+				num_feature_probability_samples num_feature_probability_samples
 				num_deviation_samples (if (> num_deviation_samples 0) num_deviation_samples 1000)
 				use_case_weights use_case_weights
 				weight_feature weight_feature
@@ -560,7 +560,7 @@
 			action_feature (null)
 			num_analysis_samples (null)
 			num_deviation_samples 1000
-			num_feature_probability_samples 10000
+			num_feature_probability_samples (null)
 		)
 
 		(declare (assoc
@@ -996,6 +996,13 @@
 		;for k_folds = 1, set the default num_analysis_samples to be 1000 for targeted flows
 		(if (and (= 1 k_folds) (= (null) num_analysis_samples ))
 			(assign (assoc num_analysis_samples 1000 ))
+		)
+
+		;1000 * (1-1/e) * num_features, cap it at 150k
+		(if (= (null) num_feature_probability_samples)
+			(assign (assoc
+				num_feature_probability_samples (min (* 6321 (size context_features)) 150000)
+			))
 		)
 
 		;pre-compute and cache all the expected feature values and nominal probabilities so that they don't have to be

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -49,7 +49,7 @@
 			num_deviation_samples (null)
 			;{type "number" min 2}
 			;number of samples to use to compute feature probabilities, only applies to targetless flow.
-			;defaults to 10000 if unspecified.
+			;If unspecified will be dynamically set based on number features and data characteristics.
 			num_feature_probability_samples (null)
 			;{type "number" min 2}
 			;number of cases to sample used for grid search for the targeted flow. only applies for k_folds = 1. defaults to 1000.

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -774,7 +774,7 @@
 		(assign_to_entities (assoc
 			!autoAnalyzeEnabled (false)
 			!autoAnalyzeThreshold 100
-			!autoAnalyzeGrowthFactorAmount 2.718281828459
+			!autoAnalyzeGrowthFactorAmount 7.3890561
 			!numericalPrecision (null)
 			!numericalPrecisionFastest (false)
 			!defaultNumSamples 100
@@ -806,8 +806,8 @@
 			analyze_threshold 100
 			;{type "number" exclusive_min 1.0}
 			;the factor by which to increase the analyze threshold every time the model grows to the current threshold size
-			;	default of using the universal scaling factor e
-			analyze_growth_factor 2.718281828459
+			;	default of using the universal scaling factor e^2
+			analyze_growth_factor 7.3890561
 			;{type "list" values "string"}
 			;the features to use as contexts in the analysis
 			context_features (null)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -837,7 +837,7 @@
 			num_deviation_samples (null)
 			;{type "number" min 2}
 			;number of samples to use to compute feature probabilities, only applies to targetless flow.
-			;defaults to 10000 if unspecified.
+			;If unspecified will be dynamically set based on number features and data characteristics.
 			num_feature_probability_samples (null)
 			;{type "number" min 2}
 			;number of cases to sample used for grid search for the targeted flow. only applies for k_folds = 1. defaults to 1000.

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -476,10 +476,16 @@
 						)
 
 						(if robust_residuals
-							(call !SampleCases (assoc
-								num num_samples
-								case_weight_feature (if valid_weight_feature weight_feature)
-							))
+							;for deviations, if num_samples is approximately same as number of cases, just use the whole dataset
+							(if (and (= "deviations" robust_residuals) (<= num_training_cases (* 1.05 num_samples)))
+								(call !AllCases)
+
+								(call !SampleCases (assoc
+									num num_samples
+									case_weight_feature (if valid_weight_feature weight_feature)
+								))
+							)
+
 							;else just use all the case ids because the model size is <= num_samples or the model is small
 							(seq
 								(declare (assoc using_all_cases (true) ))

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -476,9 +476,12 @@
 						)
 
 						(if robust_residuals
-							;for deviations, if num_samples is approximately same as number of cases, just use the whole dataset
-							(if (and (= "deviations" robust_residuals) (<= num_training_cases (* 1.05 num_samples)))
-								(call !AllCases)
+							(if (= "deviations" robust_residuals)
+								;for local (superfull) deviations, if the dataset is tiny, use more samples than in dataset to compute SDM values
+								(call !SampleCases (assoc
+									num (min num_samples (* num_training_cases (pow 2 (size features))))
+									case_weight_feature (if valid_weight_feature weight_feature)
+								))
 
 								(call !SampleCases (assoc
 									num num_samples

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -475,11 +475,9 @@
 							(call !AllCases (assoc num num_samples rand_seed (rand)))
 						)
 
-						;else the model is small, use the smaller of num_samples or (num_cases * 2^f) because that's the amount of all possible combinations
-						;for local (superfull) deviations use more samples than in dataset to compute SDM values
 						(if robust_residuals
 							(call !SampleCases (assoc
-								num (min num_samples (* num_training_cases (pow 2 (size features))))
+								num num_samples
 								case_weight_feature (if valid_weight_feature weight_feature)
 							))
 							;else just use all the case ids because the model size is <= num_samples or the model is small

--- a/unit_tests/ut_h_rebalance_features.amlg
+++ b/unit_tests/ut_h_rebalance_features.amlg
@@ -124,12 +124,11 @@
 				[ 3 0.75 	1 ]
 				;class 'M' reciprocal is 1/(4+1)=0.2, new total rebalance weight is 2.5333,
 				;new total mass is 8, thus scalar is 8 / 2.5333 = 3.158,  0.2 * 3.158 = 0.6316
-				;distributing about 0.6316 worth of weight among two cases with a ~ 30/70 split:
-				[ 4 0.93 	1.3 ]
-				[ 5 1.19 	1.7 ]
+				;distributing about 0.6316 worth of weight among two cases with a ~ 25/75 split:
+				[ 4 0.91 	1.25 ]
+				[ 5 1.22 	1.75 ]
 				[ 6 1		1 ]
 			]
-		percent .02
 	))
 
 
@@ -157,14 +156,13 @@
 				[ 1 1.5 	1 ]
 				[ 2 0.75 	1 ]
 				[ 3 0.75 	1 ]
-				[ 4 0.93 	1.3 ]
-				[ 5 1.19 	1.7 ]
+				[ 4 0.91 	1.23 ]
+				[ 5 1.22 	1.75 ]
 				[ 6 1 	 	1 ]
 				;unknown class 'L' value is (0.5+0.25)/2=0.375, new total rebalance weight is 2.908
 				;new total mass is 9, thus scalar is 9 / 2.908 = 3.095, 0.375 * 3.095 = 1.16
 				[ 8 1.16 	1 ]
 			]
-		percent .02
 	))
 
 	(call exit_if_failures (assoc msg "Basic Rebalance features."))
@@ -329,20 +327,20 @@
 				context_values [[ 3.5 "M" "blue"]]
 				use_case_weights (true)
 				weight_feature "custom_weight"
-				details {"distance_contribution" (true)}
+				details
+					{
+						"distance_contribution" (true)
+						"num_most_similar_cases" 2
+						"most_similar_cases" (true)
+					}
 			))
 	))
 	(call keep_result_payload)
 
-	;surprisal for both should be ~ 1.1984
-	;but because one has a weigth of 2x, influences should be 1/3 and 2/3:
-	;probabilities are: e^-1.1984 = 0.30167 and 2*.30167 = 0.60334
-	;total of probabilities is 0.30167 + 0.60334 = 0.90501,
-	; 1.1984 * .3067 / .90501 + 1.1984 * 0.60334 / 0.90501 = 1.19842
 	(print "distance contribution of weighted neighbors using surprisals: ")
 	(call assert_approximate (assoc
-		obs (get result "distance_contribution")
-		exp [1.19842]
+		obs (get result ["distance_contribution" 0])
+		exp (get result ["most_similar_cases" 0 0 ".distance"])
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))

--- a/unit_tests/ut_h_rebalance_features.amlg
+++ b/unit_tests/ut_h_rebalance_features.amlg
@@ -156,8 +156,8 @@
 				[ 1 1.5 	1 ]
 				[ 2 0.75 	1 ]
 				[ 3 0.75 	1 ]
-				[ 4 0.91 	1.23 ]
-				[ 5 1.22 	1.75 ]
+				[ 4 0.93 	1.3 ]
+				[ 5 1.19 	1.7 ]
 				[ 6 1 	 	1 ]
 				;unknown class 'L' value is (0.5+0.25)/2=0.375, new total rebalance weight is 2.908
 				;new total mass is 9, thus scalar is 9 / 2.908 = 3.095, 0.375 * 3.095 = 1.16

--- a/unit_tests/ut_h_rebalance_features.amlg
+++ b/unit_tests/ut_h_rebalance_features.amlg
@@ -124,9 +124,9 @@
 				[ 3 0.75 	1 ]
 				;class 'M' reciprocal is 1/(4+1)=0.2, new total rebalance weight is 2.5333,
 				;new total mass is 8, thus scalar is 8 / 2.5333 = 3.158,  0.2 * 3.158 = 0.6316
-				;distributing about 0.6316 worth of weight among two cases with a ~ 25/75 split:
-				[ 4 0.91 	1.25 ]
-				[ 5 1.22 	1.75 ]
+				;distributing about 0.6316 worth of weight among two cases with a ~ 30/70 split:
+				[ 4 0.93 	1.3 ]
+				[ 5 1.19 	1.7 ]
 				[ 6 1		1 ]
 			]
 	))

--- a/unit_tests/ut_h_rl.amlg
+++ b/unit_tests/ut_h_rl.amlg
@@ -356,7 +356,7 @@
 	(print "Verify that auto-analyze is enabled with default params: ")
 	(call assert_same (assoc
 		obs result
-		exp (list (true) 100 2.718281828459)
+		exp (list (true) 100 7.3890561)
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))


### PR DESCRIPTION
set to 6321  * num_features with a max cap of 150,000 samples.

1000 * (1 - 1/e) = 6321.

Note: this makes analyze() run approximately an order of magnitude slower than before 