### PR TITLE
23913: Updates the default number of samples logic for robust accuracy contributions in `#react_aggregate`

### DIFF
--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -97,7 +97,7 @@
 			num_robust_prediction_contributions_samples_per_case (null)
 			;{type "number" min 0}
 			;Total sample size of model to use (using sampling with replacement) for feature_robust_accuracy_contributions.
-			;	Defaults to the smaller of 10000 or (num cases * 2^number of features)
+			;	Defaults to the smaller of 150000 or (6321 * num_context_features)
 			num_robust_accuracy_contributions_samples (null)
 			;{type "number" min 0}
 			;Total sample size of model to use (using sampling with replacement) for feature_robust_accuracy_contributions_permutation.
@@ -557,8 +557,8 @@
 							(if num_robust_accuracy_contributions_samples
 								num_robust_accuracy_contributions_samples
 
-								;if the model is small, use the smaller of 10k or (num_cases * 2^f) because that's the amount of all possible combinations
-								(min 10000 (* num_training_cases (pow 2 (size context_features))) )
+								;if unspecified, then use 10000 * (1-1/e) * num_context_features samples, cap it at 150k
+								(min (* 6321 (size context_features)) 150000)
 							)
 						case_weight_feature (if valid_weight_feature weight_feature)
 						query_conditions action_condition_filter_query


### PR DESCRIPTION
Following recent change in `#analyze` to increase the number of samples used when computing robust feature accuracy contributions, we have decided to also update the default logic to determine the number of samples to use when computing this same metric using `#react_aggregate`.