### PR TITLE
23971: Checks that referenced entities exist in `#process_train_payload`

### DIFF
--- a/howso/scale.amlg
+++ b/howso/scale.amlg
@@ -332,16 +332,23 @@
 		)
 
 		;check that all of the referenced child entities still exist, and weren't deleted by another caller in between compute_train_payload and now
-		(declare (assoc referenced_entities (assoc)))
-		(if (size weight_accumulation_maps)
-			(assign (assoc referenced_entities (append referenced_entities (reduce (lambda (append (previous_result) (current_value))) weight_accumulation_maps))))
-		)
-		(if case_edit_map
-			(assign (assoc referenced_entities (append referenced_entities case_edit_map)))
-		)
-		(declare (assoc referenced_entity_names (sort (indices referenced_entities))))
-		(declare (assoc child_entity_names (sort (contained_entities (list (query_in_entity_list referenced_entity_names))))))
-		(if (!= referenced_entity_names child_entity_names)
+		(declare (assoc
+			referenced_entities (append
+				(if (size weight_accumulation_maps)
+					(reduce (lambda (append (previous_result) (current_value))) weight_accumulation_maps)
+					(assoc)
+				)
+				(if (size case_edit_map)
+					case_edit_map
+					(assoc)
+				)
+			)
+		))
+		(if
+			(<
+				(size (contained_entities (list (query_in_entity_list (indices referenced_entities)))))
+				(size referenced_entities)
+			)
 			(conclude (call !Return (assoc
 				errors ["Missing related training case"]
 				error_code "conflict"

--- a/howso/scale.amlg
+++ b/howso/scale.amlg
@@ -326,9 +326,26 @@
 		(call !ValidateParameters)
 
 		(if (not !autoAblationEnabled)
-			(call !Return (assoc
+			(conclude (call !Return (assoc
 				errors ["`process_train_payload` should only be used on a Trainee that has auto-ablation enabled."]
-			))
+			)))
+		)
+
+		;check that all of the referenced child entities still exist, and weren't deleted by another caller in between compute_train_payload and now
+		(declare (assoc referenced_entities (assoc)))
+		(if (size weight_accumulation_maps)
+			(assign (assoc referenced_entities (append referenced_entities (reduce (lambda (append (previous_result) (current_value))) weight_accumulation_maps))))
+		)
+		(if case_edit_map
+			(assign (assoc referenced_entities (append referenced_entities case_edit_map)))
+		)
+		(declare (assoc referenced_entity_names (sort (indices referenced_entities))))
+		(declare (assoc child_entity_names (sort (contained_entities (list (query_in_entity_list referenced_entity_names))))))
+		(if (!= referenced_entity_names child_entity_names)
+			(conclude (call !Return (assoc
+				errors ["Missing related training case"]
+				error_code "conflict"
+			)))
 		)
 
 		(if (= (null) weight_feature)

--- a/unit_tests/ut_h_scale.amlg
+++ b/unit_tests/ut_h_scale.amlg
@@ -1,0 +1,89 @@
+;basic tests of scale.amlg / compute_train_payload / process_train_payload
+(seq
+	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_scale.amlg"))
+
+    (call_entity "howso" "set_feature_attributes" (assoc
+        feature_attributes (assoc
+            "x" (assoc "type" "continuous")
+            "y" (assoc "type" "continuous")
+        )
+    ))
+
+    (print "process_train_payload requires auto-ablation to be on: ")
+    (call assert_same (assoc
+        obs (call_entity "howso" "process_train_payload" (assoc))
+        exp (list 0 (assoc
+            detail "`process_train_payload` should only be used on a Trainee that has auto-ablation enabled."
+        ))
+    ))
+    (call exit_if_failures (assoc msg "Precondition checking."))
+
+    (call_entity "howso" "set_auto_ablation_params" (assoc
+        auto_ablation_enabled (true)
+    ))
+
+    (print "compute_train_payload: ")
+    (declare (assoc
+        train_payload (call_entity "howso" "compute_train_payload" (assoc
+            cases (list (list 1 1) (list 2 4))
+            features (list "x" "y")
+            session "unit_test"
+        ))
+    ))
+    (call assert_same (assoc obs (first train_payload) exp 1))
+
+    (print "process_train_payload: ")
+    (call assert_same (assoc
+        obs (call_entity "howso" "process_train_payload" (get train_payload (list 1 "payload")))
+        exp (list 1 (assoc
+            payload (assoc
+                num_trained 2
+                status (null)
+            )
+        ))
+    ))
+
+    (print "get_cases to verify: ")
+    (call assert_same (assoc
+        obs (call_entity "howso" "get_cases" (assoc features (list "x" "y" ".case_weight")))
+        exp (list 1 (assoc
+                payload (assoc
+                    features (list "x" "y" ".case_weight")
+                    cases (list (list 1 1 1) (list 2 4 1))
+                )
+            ))
+    ))
+    (call exit_if_failures (assoc msg "Split training path."))
+
+    (print "process_train_payload with nonexistent weight entity: ")
+    (call assert_same (assoc
+        obs (call_entity "howso" "process_train_payload" (assoc
+            weight_accumulation_maps (list
+                (assoc "_invalid_entity_id_" 1)
+            )
+            session "unit_test"
+        ))
+        exp (list 0 (assoc
+            "detail" "Missing related training case"
+            "code" "conflict"
+        ))
+    ))
+
+    (print "process_train_payload with nonexistent edit case entity: ")
+    (call assert_same (assoc
+        obs (call_entity "howso" "process_train_payload" (assoc
+            case_edit_map (assoc
+                "_invalid_entity_id_" (assoc x 3 y 9)
+            )
+            session "unit_test"
+        ))
+        exp (list 0 (assoc
+            "detail" "Missing related training case"
+            "code" "conflict"
+        ))
+    ))
+    (call exit_if_failures (assoc msg "Nonexistent entities in train payload."))
+
+    (call exit_if_failures (assoc msg unit_test_name))
+)

--- a/unit_tests/ut_h_scale_ablation.amlg
+++ b/unit_tests/ut_h_scale_ablation.amlg
@@ -1,0 +1,119 @@
+;real-data concurrency tests for scale.amlg
+(seq
+	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_scale_ablation.amlg"))
+
+    ; The thing this is trying to simulate is, in Platform, concurrent calls to split training with auto-ablation on.
+    ; In this sequence it's possible for one replica to call compute_train_payload while the primary replica is
+    ; (maybe automatically) doing reduce_data, and so some of the referenced cases won't exist.
+    ;
+    ; This does depend on some specific behavior of ablation which will be called out.
+    ;
+    ; The data set is y=x^2.
+
+    (null
+        #!CreateSquareCases
+        (map
+            (lambda
+                (list
+                    (current_value 1)
+                    (* (current_value 1) (current_value 1))
+                )
+            )
+            xs
+        )
+    )
+
+    (print "set_feature_attributes\n")
+    (call_entity "howso" "set_feature_attributes" (assoc
+        feature_attributes (assoc
+            "x" (assoc "type" "continuous")
+            "y" (assoc "type" "continuous")
+        )
+    ))
+
+    (print "set_auto_ablation_params\n")
+    (call_entity "howso" "set_auto_ablation_params" (assoc
+        auto_ablation_enabled (true)
+        min_num_cases 100
+        max_num_cases 200
+    ))
+
+    (print "train\n")
+    (call_entity "howso" "train" (assoc
+        cases (call !CreateSquareCases (assoc xs (range 0 999)))
+        features (list "x" "y")
+        session "unit_test"
+    ))
+
+    (print "analyze\n")
+    (call_entity "howso" "analyze" (assoc))
+
+    (print "reduce_data\n")
+    (call_entity "howso" "reduce_data" (assoc))
+
+    ; At this point, ablation has gotten rid of all of the cases between x=0 and x=300!
+    ; (There's no specific requirement that ablation does so, but it matters for this test.)
+
+    (declare (assoc
+        first_pass_cases (call_entity "howso" "get_cases" (assoc features (list "x")))
+    ))
+    (print "get_cases succeeded: ")
+    (call assert_same (assoc
+        obs (first first_pass_cases)
+        exp 1
+    ))
+    (print "no cases between x=0 and x=300: ")
+    (call assert_true (assoc
+        obs (apply "and"
+                (map
+                    (lambda (or (= (first (current_value)) 0) (> (first (current_value)) 300)))
+                    (get first_pass_cases (list 1 "payload" "cases"))
+                )
+        )
+    ))
+
+    ; Let's train some more cases with small numbers.
+
+    (print "train\n")
+    (call_entity "howso" "train" (assoc
+        cases (call !CreateSquareCases (assoc xs (range 0 99)))
+        features (list "x" "y")
+        session "unit_test"
+    ))
+
+    ; Now let's set up training a specific number of small-valued cases.
+    ; Remember that anything near here was dropped in the first reduce_data call, but we've loaded in some
+    ; duplicate cases.
+
+    (declare (assoc
+        train_payload (call_entity "howso" "compute_train_payload" (assoc
+            cases (call !CreateSquareCases (assoc xs (range 45 55)))
+            features (list "x" "y")
+            session "unit_test"
+        ))
+    ))
+    (print "compute_train_payload succeeded: ")
+    (call assert_same (assoc
+        obs (first train_payload)
+        exp 1
+    ))
+
+    ; With that payload in hand, let's reduce_data again.
+
+    (print "reduce_data\n")
+    (call_entity "howso" "reduce_data" (assoc))
+
+    ; This will again drop a lot of the small-valued cases, so we're going to fail committing the payload.
+
+    (print "process_train_payload failed: ")
+    (call assert_same (assoc
+        obs (call_entity "howso" "process_train_payload" (get train_payload (list 1 "payload")))
+        exp (list 0 (assoc
+            "detail" "Missing related training case"
+            "code" "conflict"
+        ))
+    ))
+
+    (call exit_if_failures (assoc msg unit_test_name))
+)

--- a/unit_tests/ut_howso.amlg
+++ b/unit_tests/ut_howso.amlg
@@ -79,6 +79,8 @@
 				"ut_h_goal_features.amlg"
 				"ut_h_goal_features_agg.amlg"
 				"ut_h_inactive.amlg"
+				"ut_h_scale.amlg"
+				"ut_h_scale_ablation.amlg"
 
 				;should always be last
 				"ut_h_migration.amlg"


### PR DESCRIPTION
This is used when auto-ablation is on.  It's possible for one actor
to call compute_train_payload while another is executing a train-type
operation concurrently, which triggers automatic data reduction, which
causes child entities to be deleted.  When we do get to the "process"
step, double-check that all of the child entities we'd like to add
weights to are still there.