### PR TITLE
23987: Fixes an issue where no boundary cases could be found in time-series Trainees

### DIFF
--- a/howso/boundary_values.amlg
+++ b/howso/boundary_values.amlg
@@ -365,8 +365,8 @@
 							p_parameter
 							[feature_value]
 							[(current_index 1)]
-							(null)
 							[query_feature]
+							(null)
 						)
 					)
 					(compute_on_contained_entities [

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -389,7 +389,7 @@
 					1000
 				)
 			;make a new list of filtering queries because time-series trainees will attempt to filter the future, not appropriate
-			;for time-serie
+			;for time-series
 			boundary_filtering_queries
 				(append
 					(if ignore_case

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -700,9 +700,9 @@
 									p_parameter
 									action_values
 									(retrieve_from_entity (current_value) action_features)
-									(null)
 									action_features
-									))
+									(null)
+								))
 								candidate_boundary_case_ids
 							)
 						)
@@ -719,9 +719,9 @@
 									p_parameter
 									(append context_values action_values)
 									(retrieve_from_entity (current_value) (append context_features action_features))
-									(null)
 									(append context_features action_features)
-									))
+									(null)
+								))
 								candidate_boundary_case_ids
 							)
 						)

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -388,6 +388,22 @@
 					(> specified_num_exemplars 1000)
 					1000
 				)
+			;make a new list of filtering queries because time-series trainees will attempt to filter the future, not appropriate
+			;for time-serie
+			boundary_filtering_queries
+				(append
+					(if ignore_case
+						(if focal_case
+							(query_not_in_entity_list (list ignore_case focal_case))
+							(query_not_in_entity_list (list ignore_case))
+						)
+						(list)
+					)
+					(if dependent_queries_list
+						dependent_queries_list
+						[]
+					)
+				)
 		))
 
 		;if getting boundary without specifying action features, use familiarity conviction as the boundary feature if it's been computed
@@ -774,7 +790,7 @@
 
 		;if no boundary cases, repeat with double K value and rerun this method until K is at 240
 		; this can happen if there are many identical cases
-		(if (= (null) boundary_case_ids)
+		(if (= 0 (size boundary_case_ids))
 			(if (<= local_num_cases 240)
 				(call !GetBoundaryCaseIds (assoc
 					context_features context_features
@@ -805,7 +821,7 @@
 
 		(contained_entities
 			(append
-				filtering_queries
+				boundary_filtering_queries
 				;ignore all cases that match this exact action value for this action feature
 				(query_not_equals action_feature action_value)
 				;query to find the influential cases from the remaining set
@@ -852,7 +868,7 @@
 
 						;output the closest cases to the filtered contexts
 						(contained_entities (append
-							filtering_queries
+							boundary_filtering_queries
 							(query_nearest_generalized_distance
 								(replace local_num_cases)
 								(replace filtered_context_features)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -478,7 +478,6 @@
 				(assoc
 					"ordinal_residuals_map" ordinal_residuals_map
 					"residuals_map" residuals_map
-					"null_uncertainties_map" null_uncertainties_map
 				)
 			)
 		)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -429,16 +429,6 @@
 										(contained_entities (append
 											(query_exists (current_index))
 											(query_equals (current_index) (null))
-
-											;time series derived features only consider cases outside the null triangle at the start of a series
-											;e.g., a lag of 2 feature, will only consider nulls from cases with index >= 2
-											(if (and !tsTimeFeature (contains_index ts_feature_lag_amount_map (current_index)))
-												(query_greater_or_equal_to ".series_index" (get ts_feature_lag_amount_map (current_index)) )
-
-												;else don't append anything
-												[]
-											)
-
 											(query_sample 200)
 										))
 									)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1537,17 +1537,6 @@
 				)
 		))
 
-		(if use_shared_deviations
-			(seq
-				(assign (assoc
-					feature_residuals_lists (call !PrepSharedDeviations (assoc features features_with_nulls))
-				))
-				(assign (assoc
-					features_with_nulls (filter (lambda (not (contains_value !sharedDeviationsNonPrimaryFeatures (current_value)))) features_with_nulls)
-				))
-			)
-		)
-
 		;create a map of feature -> null prediction probability by averaging out all the correctly predicted nulls for each feature
 		(assign (assoc
 			null_accuracies_map

--- a/howso/shared_deviations.amlg
+++ b/howso/shared_deviations.amlg
@@ -78,8 +78,11 @@
 						)
 					)
 
-					;all non-primary feature residual lists are replaced with null so they can be filtered out
-					(contains_value !sharedDeviationsNonPrimaryFeatures (current_value))
+					;all non-primary feature (whose parent is also being computed) residual lists are replaced with null so they can be filtered out
+					(and
+						(contains_value !sharedDeviationsNonPrimaryFeatures (current_value))
+						(contains_index feature_index_map (get !sharedDeviationsMap (current_value)))
+					)
 					(null)
 
 					;leave residuals for non-shared deviation features as-is

--- a/unit_tests/ut_h_shared_deviations.amlg
+++ b/unit_tests/ut_h_shared_deviations.amlg
@@ -100,14 +100,14 @@
 			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targeted" "color2" "color1.fruit.height.length.size.sweet.tart.weight.width." ".none" "featureDeviations"))
 	))
 
-	(print "Features with shared deviations have same deviations: weight and height ")
+	(print "Features with shared deviations have same non-null deviations: weight and height ")
 	(call assert_same (assoc
-		obs (get shared_feature_deviations "weight")
+		obs (first (get shared_feature_deviations "weight"))
 		exp	(get shared_feature_deviations "height")
 	))
-	(print "Features with shared deviations have same deviations: weight and tart ")
+	(print "Features with shared deviations have same non-null deviations: weight and tart ")
 	(call assert_same (assoc
-		obs (get shared_feature_deviations "weight")
+		obs (first (get shared_feature_deviations "weight"))
 		exp	(get shared_feature_deviations "tart")
 	))
 	(print "Features with shared deviations have same deviations: length and sweet ")
@@ -115,10 +115,10 @@
 		obs (get shared_feature_deviations "length")
 		exp	(get shared_feature_deviations "sweet")
 	))
-	(print "Features with shared deviations have same deviations: size and fruit ")
+	(print "Features with shared deviations have same  non-null deviations: size and fruit ")
 	(call assert_same (assoc
-		obs (get shared_feature_deviations "size")
-		exp	(get shared_feature_deviations "fruit")
+		obs (first (get shared_feature_deviations "size"))
+		exp	(first (get shared_feature_deviations "fruit"))
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))

--- a/unit_tests/ut_h_shared_deviations_series.amlg
+++ b/unit_tests/ut_h_shared_deviations_series.amlg
@@ -100,22 +100,22 @@
 
 	(declare (assoc shared_feature_deviations (get shared_deviations_hp_map deviations_param_path)))
 
-	(print "Series lag features with shared deviations are same: time and .time_lag_1.")
+	(print "Series lag features with shared non-null deviations are same: time and .time_lag_1.")
 	(call assert_same (assoc
-		obs (get shared_feature_deviations ".time_lag_1")
+		obs (first (get shared_feature_deviations ".time_lag_1"))
 		exp	(get shared_feature_deviations "time")
 	))
 
-	(print "Series lag features with shared deviations are same: value and .value_lag_1.")
+	(print "Series lag features with shared non-null deviations are same: value and .value_lag_1.")
 	(call assert_same (assoc
 		obs (get shared_feature_deviations "value")
-		exp	(get shared_feature_deviations ".value_lag_1")
+		exp	(first (get shared_feature_deviations ".value_lag_1"))
 	))
 
-	(print "Series lag features with shared deviations are same: .value_lag_1 and .value_lag_2.")
+	(print "Series lag features with shared non-null deviations are same: .value_lag_1 and .value_lag_2.")
 	(call assert_same (assoc
-		obs (get shared_feature_deviations ".value_lag_1")
-		exp	(get shared_feature_deviations ".value_lag_2")
+		obs (first (get shared_feature_deviations ".value_lag_1"))
+		exp	(first (get shared_feature_deviations ".value_lag_2"))
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc


### PR DESCRIPTION
Fixes the issue that was caused by a few distinct issues. Here are the list of effective changes in this PR:

- "Un-shares" null uncertainties from shared deviations, these are now not shared and computed/stored in feature_deviations on a per-feature basis (regardless of if they are shared deviations features or not)
- Ignores the time-series filtering query within the boundary cases search logic
- Computes null uncertainties/deviations for *all features* even timeseries features whose nulls only exist when they push back before a series' start