### PR TITLE
23985: Removes outdated warnings when using targetless hyperparameters in #react_aggregate

### DIFF
--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -984,22 +984,28 @@
 		(assign (assoc param_path (get expected_hp_map "paramPath") ))
 
 		;if pulled hyperparameters don't match requested, display warning
-		(if (or
-				(!= weight_feature (last param_path))
-				(and
-					(= "targeted" (first param_path))
-					(!= action_feature (get param_path 1))
-				)
-			)
+		(if (!= weight_feature (last param_path))
 			(accum (assoc
 				warnings
 					(associate (concat
-						"Results may be inaccurate because trainee has not been analyzed for these parameters.\n"
+						"Results may be inaccurate because the trainee has not been analyzed for this weight feature.\n"
 						"Run 'analyze()' with "
 						(if (= ".none" weight_feature)
 							"with use_case_weights=False."
 							(concat "with use_case_weights=true, weight_feature='" weight_feature "'.")
 						)
+					))
+			))
+
+			(and
+				(= "targeted" (first param_path))
+				(!= action_feature (get param_path 1))
+			)
+			(accum (assoc
+				warnings
+					(associate (concat
+						"Results may be inaccurate because the trainee has been analyzed for a different action feature.\n"
+						"Run 'analyze()' with '" action_feature "' as action_features, or with no action features specified."
 					))
 			))
 		)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -987,10 +987,6 @@
 		(if (or
 				(!= weight_feature (last param_path))
 				(and
-					(= "targetless" (first param_path))
-					(!= (null) action_feature)
-				)
-				(and
 					(= "targeted" (first param_path))
 					(!= action_feature (get param_path 1))
 				)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -995,7 +995,7 @@
 				warnings
 					(associate (concat
 						"Results may be inaccurate because trainee has not been analyzed for these parameters.\n"
-						"Run 'analyze()' with '" action_feature "' as action_features, "
+						"Run 'analyze()' with "
 						(if (= ".none" weight_feature)
 							"with use_case_weights=False."
 							(concat "with use_case_weights=true, weight_feature='" weight_feature "'.")

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -111,20 +111,6 @@
 
 	(call exit_if_failures (assoc msg "Warnings for react()"))
 
-	(assign (assoc
-		result
-			(call_entity "howso" "react_aggregate" (assoc
-				details (assoc feature_full_accuracy_contributions (true))
-				action_feature "target"
-			))
-	))
-	(call keep_result_warnings)
-
-	(print "Warning about calling react_aggregate() with 'target' as action features:")
-	(call assert_true (assoc
-		obs (= 1 (size result))
-	))
-
 
 	(call_entity "howso" "analyze" (assoc
 		action_features (list (last features))


### PR DESCRIPTION
Updates the warnings logic in react aggregate to no longer warn when targetless params are used for targeted operations.

Additionally, split up the warnings to be slightly different based on if it is the weight feature that is incorrect or if using targeted params on the not-targeted action feature.