### PR TITLE
23987: Fixes issues with the boundary_cases detail when using time-series data

### DIFF
--- a/howso/boundary_values.amlg
+++ b/howso/boundary_values.amlg
@@ -365,8 +365,8 @@
 							p_parameter
 							[feature_value]
 							[(current_index 1)]
-							(null)
 							[query_feature]
+							(null)
 						)
 					)
 					(compute_on_contained_entities [

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -428,7 +428,7 @@
 
 		(if !tsTimeFeature
 			;in time-series flows, derived features pose lots of complex issues with the boundary-case finding logic.
-			;to avoid this, filter the context to remove all of the derived features to avoid these complications.
+			;to avoid this, filter the context to remove all of the derived features
 			(seq
 				(declare (assoc
 					context_map (zip context_features context_values)

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -428,7 +428,7 @@
 
 		(if !tsTimeFeature
 			;in time-series flows, derived features pose lots of complex issues with the boundary-case finding logic.
-			;here we filter the context to remove all of the derived features to avoid these complications.
+			;to avoid this, filter the context to remove all of the derived features to avoid these complications.
 			(seq
 				(declare (assoc
 					context_map (zip context_features context_values)

--- a/howso/details_cases.amlg
+++ b/howso/details_cases.amlg
@@ -388,6 +388,22 @@
 					(> specified_num_exemplars 1000)
 					1000
 				)
+			;make a new list of filtering queries because time-series trainees will attempt to filter the future, not appropriate
+			;for time-series
+			boundary_filtering_queries
+				(append
+					(if ignore_case
+						(if focal_case
+							(query_not_in_entity_list (list ignore_case focal_case))
+							(query_not_in_entity_list (list ignore_case))
+						)
+						(list)
+					)
+					(if dependent_queries_list
+						dependent_queries_list
+						[]
+					)
+				)
 		))
 
 		;if getting boundary without specifying action features, use familiarity conviction as the boundary feature if it's been computed
@@ -408,6 +424,25 @@
 				;ensure that the boundary case familiarity conviction is output along with the boundary cases
 				details (set details "boundary_cases_familiarity_convictions" (true))
 			))
+		)
+
+		(if !tsTimeFeature
+			;in time-series flows, derived features pose lots of complex issues with the boundary-case finding logic.
+			;here we filter the context to remove all of the derived features to avoid these complications.
+			(seq
+				(declare (assoc
+					context_map (zip context_features context_values)
+				))
+
+				(declare (assoc
+					context_features (filter (lambda (not (contains_index !derivedFeaturesMap (current_value)))) context_features)
+				))
+
+				(declare (assoc
+					context_values (unzip context_map context_features)
+				))
+			)
+
 		)
 
 		;get all the boundary case ids
@@ -700,9 +735,9 @@
 									p_parameter
 									action_values
 									(retrieve_from_entity (current_value) action_features)
-									(null)
 									action_features
-									))
+									(null)
+								))
 								candidate_boundary_case_ids
 							)
 						)
@@ -719,9 +754,9 @@
 									p_parameter
 									(append context_values action_values)
 									(retrieve_from_entity (current_value) (append context_features action_features))
-									(null)
 									(append context_features action_features)
-									))
+									(null)
+								))
 								candidate_boundary_case_ids
 							)
 						)
@@ -774,7 +809,7 @@
 
 		;if no boundary cases, repeat with double K value and rerun this method until K is at 240
 		; this can happen if there are many identical cases
-		(if (= (null) boundary_case_ids)
+		(if (= 0 (size boundary_case_ids))
 			(if (<= local_num_cases 240)
 				(call !GetBoundaryCaseIds (assoc
 					context_features context_features
@@ -805,7 +840,7 @@
 
 		(contained_entities
 			(append
-				filtering_queries
+				boundary_filtering_queries
 				;ignore all cases that match this exact action value for this action feature
 				(query_not_equals action_feature action_value)
 				;query to find the influential cases from the remaining set
@@ -852,7 +887,7 @@
 
 						;output the closest cases to the filtered contexts
 						(contained_entities (append
-							filtering_queries
+							boundary_filtering_queries
 							(query_nearest_generalized_distance
 								(replace local_num_cases)
 								(replace filtered_context_features)

--- a/howso/distances.amlg
+++ b/howso/distances.amlg
@@ -401,7 +401,6 @@
 							p_value
 							from_case_values
 							to_case_values
-							(null)
 							features
 							in_surprisal_space
 						)


### PR DESCRIPTION
Fixes issues that prevented boundary cases from being found in time-series Trainees through a few changes
- *Fixes* some usages of the (generalized_distance) opcode
- Filters out TS derived features from the contexts when using a time-series trainee in the boundary_cases logic
- Removes the "no-future" query constraints when searching for boundary cases