### PR TITLE
23995: Fixes an issue in time-series forecasting with uniqueness checks

### DIFF
--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1773,7 +1773,7 @@
 													(assign (assoc
 														total_progress initial_existing_progress
 														series_data (tail existing_series_data largest_max_row_lag)
-														last_series_index -1
+														last_series_index (- num_existing_series_rows 1)
 														num_generated_rows num_existing_series_rows
 														first_generated_row (true)
 														current_case_map (assoc)


### PR DESCRIPTION
When entire series is regenerated for uniqueness, the reset logic had a slight bug that could lead to some timesteps being malformed.