### PR TITLE
24057: Updates the math for the "feature_full_residual_convictions_for_case" detail to smooth out extremes

### DIFF
--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -562,19 +562,11 @@
 							(/
 								(call !LK_metric (assoc
 									difference (first (current_value 1))
-									deviation
-										(if (size global_residuals_map)
-											(get global_residuals_map (current_index 1))
-											0
-										)
+									deviation (or (get global_residuals_map (current_index 1)) 0)
 								))
 								(call !LK_metric (assoc
 									difference (get !cachedFeatureMinResidualMap (current_index 1))
-									deviation
-										(if (size global_residuals_map)
-											(get global_residuals_map (current_index 1))
-											0
-										)
+									deviation (or (get global_residuals_map (current_index 1)) 0)
 								))
 							)
 
@@ -585,19 +577,11 @@
 							(/
 								(call !LK_metric (assoc
 									difference (first (current_value 1))
-									deviation
-										(if (size global_residuals_map)
-											(get global_residuals_map (current_index 1))
-											0
-										)
+									deviation (or (get global_residuals_map (current_index 1)) 0)
 								))
 								(call !LK_metric (assoc
 									difference (last (current_value 1))
-									deviation
-										(if (size global_residuals_map)
-											(get global_residuals_map (current_index 1))
-											0
-										)
+									deviation (or (get global_residuals_map (current_index 1)) 0)
 								))
 							)
 						)
@@ -634,32 +618,25 @@
 		))
 	)
 
-	;compute the lk given a distance (d) and a deviation (b)
-	;d should be positive already
+	;compute the lk given a difference and a deviation
+	;difference and deviation should be positive already (this method won't take the absolute value)
 	#!LK_metric
-	(declare
-		(assoc
-			difference (null)
-			deviation (null)
-		)
-
-		(+
-			difference
-			(/
-				(*
-					(exp
-						(/
-							(- difference)
-							deviation
-						)
-					)
-					(+
-						(* 3 deviation)
-						difference
+	(+
+		difference
+		(/
+			(*
+				(exp
+					(/
+						(- difference)
+						deviation
 					)
 				)
-				2
+				(+
+					(* 3 deviation)
+					difference
+				)
 			)
+			2
 		)
 	)
 )

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -477,6 +477,7 @@
 	(declare
 		(assoc
 			action_features_map (keep case_value_map action_features)
+			global_residuals_map (get hyperparam_map "featureResiduals")
 		)
 
 		;compute the local area residuals for each context feature by
@@ -558,13 +559,47 @@
 						; So, E(I) / I = (MR / MR) / (OR / MR) = MR / OR
 						; In this way, we can directly divide the model (global or local) residual by the observed residual to get conviction
 						(if (= 0 (last (current_value)) )
-							(/ (first (current_value)) (get !cachedFeatureMinResidualMap (current_index)))
+							(/
+								(call !LK_metric (assoc
+									d (first (current_value 1))
+									b
+										(if (size global_residuals_map)
+											(get global_residuals_map (current_index 1))
+											0
+										)
+								))
+								(call !LK_metric (assoc
+									d (get !cachedFeatureMinResidualMap (current_index 1))
+									b
+										(if (size global_residuals_map)
+											(get global_residuals_map (current_index 1))
+											0
+										)
+								))
+							)
 
 							;prevent nan from divide by null, output null as-is when nulls are allowed
 							(= (null) (last (current_value)))
 							(null)
 
-							(/ (first (current_value)) (last (current_value)))
+							(/
+								(call !LK_metric (assoc
+									d (first (current_value 1))
+									b
+										(if (size global_residuals_map)
+											(get global_residuals_map (current_index 1))
+											0
+										)
+								))
+								(call !LK_metric (assoc
+									d (last (current_value 1))
+									b
+										(if (size global_residuals_map)
+											(get global_residuals_map (current_index 1))
+											0
+										)
+								))
+							)
 						)
 					)
 					local_residuals_map
@@ -597,5 +632,34 @@
 						(append local_convictions_map inactive_features_zeros_map)
 				)
 		))
+	)
+
+	;compute the lk given a distance (d) and a deviation (b)
+	;d should be positive already
+	#!LK_metric
+	(declare
+		(assoc
+			d (null)
+			b (null)
+		)
+
+		(+
+			d
+			(/
+				(*
+					(exp
+						(/
+							(- d)
+							b
+						)
+					)
+					(+
+						(* 3 b)
+						d
+					)
+				)
+				2
+			)
+		)
 	)
 )

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -561,16 +561,16 @@
 						(if (= 0 (last (current_value)) )
 							(/
 								(call !LK_metric (assoc
-									d (first (current_value 1))
-									b
+									difference (first (current_value 1))
+									deviation
 										(if (size global_residuals_map)
 											(get global_residuals_map (current_index 1))
 											0
 										)
 								))
 								(call !LK_metric (assoc
-									d (get !cachedFeatureMinResidualMap (current_index 1))
-									b
+									difference (get !cachedFeatureMinResidualMap (current_index 1))
+									deviation
 										(if (size global_residuals_map)
 											(get global_residuals_map (current_index 1))
 											0
@@ -584,16 +584,16 @@
 
 							(/
 								(call !LK_metric (assoc
-									d (first (current_value 1))
-									b
+									difference (first (current_value 1))
+									deviation
 										(if (size global_residuals_map)
 											(get global_residuals_map (current_index 1))
 											0
 										)
 								))
 								(call !LK_metric (assoc
-									d (last (current_value 1))
-									b
+									difference (last (current_value 1))
+									deviation
 										(if (size global_residuals_map)
 											(get global_residuals_map (current_index 1))
 											0
@@ -639,23 +639,23 @@
 	#!LK_metric
 	(declare
 		(assoc
-			d (null)
-			b (null)
+			difference (null)
+			deviation (null)
 		)
 
 		(+
-			d
+			difference
 			(/
 				(*
 					(exp
 						(/
-							(- d)
-							b
+							(- difference)
+							deviation
 						)
 					)
 					(+
-						(* 3 b)
-						d
+						(* 3 deviation)
+						difference
 					)
 				)
 				2


### PR DESCRIPTION
Rather than divide the regional residual by the case residual directly. We now apply the LK metric to both residuals first, then divide. This makes the extreme conviction values returned when either residual is zero (or lesser than the deviation) much more reasonable to the user and prevents random extremes that result when dealing with very predictable regions of the data.