### PR TITLE
24100: Adds `predicted_values_for_case` as a return detail when computed, MINOR

### DIFF
--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -197,7 +197,21 @@
 				(get details "feature_full_residual_convictions_for_case")
 			)
 			(seq
+				(declare (assoc predicted_case_values_map (assoc) ))
 				(call !CalculateCaseResiduals (assoc robust_residuals (false)))
+				(accum (assoc
+					output
+						(assoc
+							"predicted_case_values"
+								(zip
+									(indices predicted_case_values_map)
+									(call !ConvertToOutput (assoc
+										features (indices predicted_case_values_map)
+										feature_values (values predicted_case_values_map)
+									))
+								)
+						)
+				))
 				(if (get details "feature_full_residual_convictions_for_case")
 					(call !CalculateLocalCaseFeatureResidualConvictions)
 				)
@@ -313,6 +327,17 @@
 												details (if action_is_nominal (assoc "categorical_action_probabilities" (true)))
 											))
 									)
+
+									(accum (assoc
+										predicted_case_values_map
+											(associate
+												action_feature
+												(if action_is_nominal
+													(get reaction ["action_values" 0])
+													(get reaction 0)
+												)
+											)
+									))
 
 									;if feature is nominal get the categorical action probability for expected value, if it's null then set it to 0
 									;else it's: 1 - probability

--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -202,7 +202,7 @@
 				(accum (assoc
 					output
 						(assoc
-							"predicted_case_values"
+							"predicted_values_for_case"
 								(zip
 									(indices predicted_case_values_map)
 									(call !ConvertToOutput (assoc

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -251,10 +251,10 @@
 								description "A list of maps from feature name to feature full residual conviction for each given case."
 								values {ref "FeatureMetricIndex"}
 							}
-						"predicted_case_values"
+						"predicted_values_for_case"
 							{
 								type "list"
-								description "A list of maps from feature name to feature full residual conviction for each given case."
+								description "A list of maps from feature name to predicted value for each given case."
 								values {type "assoc" values "any"}
 							}
 						"generate_attempts"

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -251,6 +251,12 @@
 								description "A list of maps from feature name to feature full residual conviction for each given case."
 								values {ref "FeatureMetricIndex"}
 							}
+						"predicted_case_values"
+							{
+								type "list"
+								description "A list of maps from feature name to feature full residual conviction for each given case."
+								values {type "assoc" values "any"}
+							}
 						"generate_attempts"
 							{
 								type "list"

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -722,6 +722,20 @@
 		percent 0.1
 	))
 
+	(print "predicted context values are returned and line up with the case residuals: ")
+	(call assert_approximate (assoc
+		exp (keep (get result (list 1 "payload" "feature_full_residuals_for_case")) (trunc iris_features))
+		obs
+			(map
+				(lambda
+					(abs (- (first (current_value)) (last (current_value))))
+				)
+				(keep (get result (list 1 "payload" "predicted_case_values")) (trunc iris_features))
+				(zip (trunc iris_features) (list 6.9 7 7 6))
+			)
+		percent 0.01
+	))
+
 	(assign (assoc
 		result
 			(call_entity "howso" "single_react" (assoc

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -730,7 +730,7 @@
 				(lambda
 					(abs (- (first (current_value)) (last (current_value))))
 				)
-				(keep (get result (list 1 "payload" "predicted_case_values")) (trunc iris_features))
+				(keep (get result (list 1 "payload" "predicted_values_for_case")) (trunc iris_features))
 				(zip (trunc iris_features) (list 6.9 7 7 6))
 			)
 		percent 0.01


### PR DESCRIPTION
Adds a new returned detail, `predicted_values_for_case` that is returned any time the user requests the "feature_full_residuals_for_case" or "feature_full_residual_convictions_for_case" details. These values have always been computed in the process of computing the forementioned details. This change now adds these predicted feature values (for both action and context features) to the returned payload of the reaction.