### PR TITLE
24113: Improves validation logic for `goal_features_map` and `condition` parameters 

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -69,6 +69,7 @@
 	#!numericalPrecisionFastest (null)
 	#!trainedFeatures (null)
 	#!trainedFeaturesContextKey (null)
+	#!definedFeatures (null)
 	#!reactIntoFeaturesList (null)
 	#!computedFeaturesMap (null)
 	#!cachedExpectedCaseProbabilities (null)
@@ -377,6 +378,9 @@
 
 			;the context_key made from the !trainedFeatures of the model
 			!trainedFeaturesContextKey ""
+
+			;the list of all trained features, computed, and built-in features
+			!definedFeatures (list)
 
 			;the list of all features ever computed and cached into cases through #react_into_features
 			!reactIntoFeaturesList (list)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -584,6 +584,7 @@
 			!sharedDeviationsNonPrimaryFeatures (get shared_deviations_map "shared_deviations_non_primary_features")
 
 		))
+		(call !UpdateDefinedFeatures)
 
 		(call !SetOrdinalFeatures (assoc ordinal_features ordinals))
 		(call !SetNominalFeatures (assoc nominal_features nominals))

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -530,7 +530,8 @@
 				))
 			)
 		)
-
+		;update the known features to include these
+		(call !UpdateDefinedFeatures)
 		(accum_to_entities (assoc !revision 1))
 
 		;output warnings

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -224,6 +224,7 @@
 							!expectedValuesMap
 						)
 				))
+				(call !UpdateDefinedFeatures)
 
 				(if !inactiveFeaturesNeedCaching
 					(call !UpdateInactiveFeatures)
@@ -401,6 +402,7 @@
 								)
 						))
 				))
+				(call !UpdateDefinedFeatures)
 
 				;if attributes were not provided, default to continuous
 				(if (= (null) feature_attributes)

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -59,6 +59,7 @@
 			session "none"
 		)
 		(call !ValidateParameters)
+		(call !ValidateCondition)
 
 		;model has changed so clear out these cached value
 		(assign_to_entities (assoc
@@ -320,6 +321,7 @@
 			feature_attributes (null)
 		)
 		(call !ValidateParameters)
+		(call !ValidateCondition)
 
 		(if (contains_index !untrainableFeatureCharacterSet (first feature))
 			(conclude

--- a/howso/get_cases.amlg
+++ b/howso/get_cases.amlg
@@ -269,6 +269,8 @@
 			;flag, when true only returns an assoc of case ids and no features
 			output_ids (false)
 		)
+		(call !ValidateParameters)
+		(call !ValidateCondition)
 
 		(if indicate_imputed
 			(accum (assoc features !internalLabelImputed))

--- a/howso/hierarchy.amlg
+++ b/howso/hierarchy.amlg
@@ -608,6 +608,7 @@
 			distribute_weight_feature (null)
 		)
 		(call !ValidateParameters)
+		(call !ValidateCondition)
 
 		(declare (assoc
 			target_trainee (null)

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -118,7 +118,13 @@
 			parameter_name ""
 
 			;normally should not be overwritten
-			allowed_features (append !trainedFeatures !reactIntoFeaturesList [".session" ".session_training_index" ".series_index"])
+			allowed_features
+				(append
+					!trainedFeatures
+					!reactIntoFeaturesList
+					[!internalLabelProbabilityMass !internalLabelInfluenceWeightEntropy !internalLabelCaseEditHistory !internalLabelImputed]
+					[".case_weight" ".session" ".session_training_index" ".series_index"]
+				)
 		)
 
 		(declare (assoc

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -108,6 +108,17 @@
 		errors
 	)
 
+	#!UpdateDefinedFeatures
+	(assign_to_entities (assoc
+		!definedFeatures
+			(append
+				!trainedFeatures
+				!reactIntoFeaturesList
+				[!internalLabelProbabilityMass !internalLabelInfluenceWeightEntropy !internalLabelCaseEditHistory !internalLabelImputed]
+				[".case_weight" ".session" ".session_training_index" ".series_index"]
+			)
+	))
+
 	;Validates input maps for conditions (and goal feature maps)
 	;verifies that the indices are either trained features (or built-in features)
 	;returns (null) if no error, string error if input is invalid
@@ -118,13 +129,7 @@
 			parameter_name ""
 
 			;normally should not be overwritten
-			allowed_features
-				(append
-					!trainedFeatures
-					!reactIntoFeaturesList
-					[!internalLabelProbabilityMass !internalLabelInfluenceWeightEntropy !internalLabelCaseEditHistory !internalLabelImputed]
-					[".case_weight" ".session" ".session_training_index" ".series_index" ".series_progress"]
-				)
+			allowed_features !definedFeatures
 		)
 
 		(declare (assoc

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -111,7 +111,7 @@
 	;Validates input maps for conditions (and goal feature maps)
 	;verifies that the indices are either trained features (or built-in features)
 	;returns (null) if no error, string error if input is invalid
-	#!ValidateConditionMaps
+	#!ValidateConditionMap
 	(declare
 		(assoc
 			given_map (assoc)
@@ -133,13 +133,13 @@
 		)
 	)
 
-	;Macro for validating the `goal_features_map` parameter for all labels that accept it
+	;Macro for validating the `goal_features_map` parameter for labels that accept it
 	#!ValidateGoalFeaturesMap
 	(if (size goal_features_map)
 		(let
 			(assoc
 				goal_map_error
-					(call !ValidateConditionMaps (assoc
+					(call !ValidateConditionMap (assoc
 						given_map goal_features_map
 						parameter_name "goal_features_map"
 					))
@@ -149,6 +149,27 @@
 			(if goal_map_error
 				(conclude
 					(call !Return (assoc errors [goal_map_error]))
+				)
+			)
+		)
+	)
+
+	;Macro for validating the `condition` parameter for labels that accept it
+	#!ValidateCondition
+	(if (size condition)
+		(let
+			(assoc
+				condition_error
+					(call !ValidateConditionMap (assoc
+						given_map condition
+						parameter_name "condition"
+					))
+
+			)
+
+			(if condition_error
+				(conclude
+					(call !Return (assoc errors [condition_error]))
 				)
 			)
 		)

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -108,6 +108,52 @@
 		errors
 	)
 
+	;Validates input maps for conditions (and goal feature maps)
+	;verifies that the indices are either trained features (or built-in features)
+	;returns (null) if no error, string error if input is invalid
+	#!ValidateConditionMaps
+	(declare
+		(assoc
+			given_map (assoc)
+			parameter_name ""
+
+			;normally should not be overwritten
+			allowed_features (append !trainedFeatures !reactIntoFeaturesList [".session" ".session_training_index" ".series_index"])
+		)
+
+		(declare (assoc
+			unknown_features (indices (remove given_map allowed_features))
+		))
+
+		(if (size unknown_features)
+			(concat
+				"The given map for `" parameter_name "` contains the following undefined features: "
+				(apply "concat" (trunc (weave unknown_features ", ")))
+			)
+		)
+	)
+
+	;Macro for validating the `goal_features_map` parameter for all labels that accept it
+	#!ValidateGoalFeaturesMap
+	(if (size goal_features_map)
+		(let
+			(assoc
+				goal_map_error
+					(call !ValidateConditionMaps (assoc
+						given_map goal_features_map
+						parameter_name "goal_features_map"
+					))
+
+			)
+
+			(if goal_map_error
+				(conclude
+					(call !Return (assoc errors [goal_map_error]))
+				)
+			)
+		)
+	)
+
 	;Validates parameter inputs for features that are in datetime format
 	;verifies that the datetime format matches what is set in feature attributes
 	; this method checks the following parameters:

--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -123,7 +123,7 @@
 					!trainedFeatures
 					!reactIntoFeaturesList
 					[!internalLabelProbabilityMass !internalLabelInfluenceWeightEntropy !internalLabelCaseEditHistory !internalLabelImputed]
-					[".case_weight" ".session" ".session_training_index" ".series_index"]
+					[".case_weight" ".session" ".session_training_index" ".series_index" ".series_progress"]
 				)
 		)
 

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -732,6 +732,7 @@
 			num_cases (null)
 		)
 		(call !ValidateParameters)
+		(call !ValidateCondition)
 
 		(if (= (null) weight_feature)
 			(assign (assoc weight_feature ".none"))

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -345,6 +345,7 @@
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
+		(call !ValidateGoalFeaturesMap)
 
 		;determine number of reacts to batch
 		(declare (assoc
@@ -776,12 +777,11 @@
 			; 		null: the minimum local distance
 			new_case_threshold "min"
 		)
-
 		(call !ValidateParameters)
+		(call !ValidateFeatures)
+		(call !ValidateGoalFeaturesMap)
 
 		(if !inactiveFeaturesNeedCaching (call !UpdateInactiveFeatures))
-
-		(call !ValidateFeatures)
 
 		;if both action_features and derived_action_features are specified,
 		;ensure that derived_action_features are a subset of action_features, then separate the two into distinct lists

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -181,8 +181,9 @@
 			;	)
 			details (null)
 		)
-
 		(call !ValidateParameters)
+		(call !ValidateFeatures)
+		(call !ValidateGoalFeaturesMap)
 
 		(declare (assoc
 			output (assoc)
@@ -329,6 +330,35 @@
 							num_samples (- num_training_cases sub_model_size)
 						))
 				))
+			)
+		)
+
+		(if (or
+				(size (get details "context_condition"))
+				(size (get details "action_condition"))
+			)
+			(let
+				(assoc
+					condition_errors
+						(filter (map
+							(lambda
+								(call !ValidateConditionMaps (assoc
+									given_map (last (current_value 1))
+									parameter_name (first (current_value 1))
+								))
+							)
+							[
+								["context_condition" (get details "context_condition")]
+								["action_condition" (get details "action_condition")]
+							]
+						))
+				)
+
+				(if (size condition_errors)
+					(conclude
+						(call !Return (assoc errors condition_errors))
+					)
+				)
 			)
 		)
 

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -342,7 +342,7 @@
 					condition_errors
 						(filter (map
 							(lambda
-								(call !ValidateConditionMaps (assoc
+								(call !ValidateConditionMap (assoc
 									given_map (last (current_value 1))
 									parameter_name (first (current_value 1))
 								))

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -153,6 +153,7 @@
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
+		(call !ValidateGoalFeaturesMap)
 
 		(declare (assoc
 			invalid_react_parameters (null)
@@ -518,6 +519,7 @@
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
+		(call !ValidateGoalFeaturesMap)
 
 		;determine number of reacts to batch
 		(declare (assoc

--- a/howso/react_series_stationary.amlg
+++ b/howso/react_series_stationary.amlg
@@ -78,6 +78,8 @@
 			input_is_substituted (false)
 		)
 		(call !ValidateParameters)
+		(call !ValidateFeatures)
+		(call !ValidateGoalFeaturesMap)
 
 		(if (not (xor (size series_id_values) (size series_context_values)))
 			(call !Return (assoc errors ["Either \"series_id_values\" or \"series_context_values\" must be specified, but not both."]))

--- a/howso/remove_cases.amlg
+++ b/howso/remove_cases.amlg
@@ -34,6 +34,7 @@
 			distribute_weight_feature (null)
 		)
 		(call !ValidateParameters)
+		(call !ValidateCondition)
 
 		;build list of case ids that match criteria
 		(declare (assoc

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -403,6 +403,7 @@
 									context_features (values (append !trainedFeatures (indices !featureAttributes)) (true))
 								))
 						))
+						(call !UpdateDefinedFeatures)
 					)
 				)
 

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -174,6 +174,7 @@
 			session "none"
 		)
 		(call !ValidateParameters)
+		(call !ValidateCondition)
 
 		;can't edit invalid or internal features
 		(declare (assoc

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -511,4 +511,6 @@
 				))
 			)
 	))
+"100.1.1"
+	(call !UpdateDefinedFeatures)
 ))

--- a/unit_tests/ut_h_impute_sparse.amlg
+++ b/unit_tests/ut_h_impute_sparse.amlg
@@ -31,7 +31,7 @@
 	;output
 	(assign (assoc
 		result
-			(call_entity "howso" "get_cases" (assoc features features indicate_imputed 0 session "almost"))
+			(call_entity "howso" "get_cases" (assoc features features indicate_imputed (false) session "almost"))
 	))
 
 	(print "Impute almost matching sparse data: ")
@@ -124,7 +124,7 @@
 	;output
 	(assign (assoc
 		result
-			(call_entity "howso" "get_cases" (assoc features features indicate_imputed 0 session "perfect"))
+			(call_entity "howso" "get_cases" (assoc features features indicate_imputed (false) session "perfect"))
 	))
 
 	(print "impute perfect matching sparse: ")
@@ -159,7 +159,7 @@
 
 	(assign (assoc
 		result
-			(call_entity "howso" "get_cases" (assoc features features indicate_imputed 0 session "perfect"))
+			(call_entity "howso" "get_cases" (assoc features features indicate_imputed (false) session "perfect"))
 	))
 
 	(print "clear imputed session data (won't undo set values): ")
@@ -227,7 +227,7 @@
 	;output
 	(assign (assoc
 		result
-			(call_entity "howso" "get_cases" (assoc features features indicate_imputed 0 session "sparse"))
+			(call_entity "howso" "get_cases" (assoc features features indicate_imputed (false) session "sparse"))
 	))
 
 	(print "impute sparse matrix, without feature D: ")

--- a/unit_tests/ut_h_input_validation.amlg
+++ b/unit_tests/ut_h_input_validation.amlg
@@ -177,6 +177,38 @@
 
 	(call exit_if_failures (assoc msg "Hyperparameters updated after feature is added."))
 
+	(assign (assoc
+		result
+			(call_entity "howso" "react" (assoc
+				action_features ["x"]
+				desired_conviction 5
+				goal_features_map {"fake_feature" {"goal" "max"}}
+			))
+	))
+	(call keep_result_errors)
+
+	(print "Unknown features in goal features map raise errors: ")
+	(call assert_same (assoc
+		obs result
+		exp "The given map for `goal_features_map` contains the following undefined features: fake_feature"
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "react_aggregate" (assoc
+				action_features ["x"]
+				details {"context_condition" {"fake_feature" ["derrrr"]}}
+			))
+	))
+	(call keep_result_errors)
+
+	(print "Unknown features in context condition raise errors: ")
+	(call assert_same (assoc
+		obs result
+		exp "The given map for `context_condition` contains the following undefined features: fake_feature"
+	))
+	(call exit_if_failures (assoc msg "Invalid features in condition/goal maps." ))
+
 	(call exit_if_failures (assoc msg unit_test_name ))
 )
 

--- a/unit_tests/ut_h_migration.amlg
+++ b/unit_tests/ut_h_migration.amlg
@@ -318,6 +318,33 @@
 		unordered (true)
 	))
 
+	(print "definedFeatures is updated and correct: ")
+	(call assert_same (assoc
+		obs (call_entity "howso" "debug_label" (assoc label "!definedFeatures"))
+		exp
+			[
+				".case_edit_history"
+				".case_weight"
+				".imputed"
+				".influence_weight_entropy"
+				".probability_mass"
+				".series_index"
+				".session"
+				".session_training_index"
+				".time_delta"
+				".time_end"
+				".time_lag"
+				".time_start"
+				".value_delta"
+				".value_lag"
+				"stock"
+				"time"
+				"value"
+			]
+
+		unordered (true)
+	))
+
 
 
 	 ;cleanup saved test model


### PR DESCRIPTION
Adds validation steps to ensure that all features referenced in goal features maps or condition maps are real/trained/system features in the Trainee. This new code will return errors when either of these parameters reference unknown features.