### PR TITLE
24196: Increases dbl_epsilon used for uniqueness check 

### DIFF
--- a/howso/distances.amlg
+++ b/howso/distances.amlg
@@ -86,7 +86,7 @@
 						(query_not_in_entity_list (first local_data_cases_tuple))
 						(query_within_generalized_distance
 							;dbl_precision_epsilon for defining whether two values are equal within acceptable precision
-							(+ dbl_precision_epsilon (last (last local_data_cases_tuple)) )
+							(+ (* dbl_precision_epsilon (last (last local_data_cases_tuple))) (last (last local_data_cases_tuple)) )
 							context_features
 							context_values
 							p_parameter

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -306,16 +306,16 @@
 					(if (= "surprisal_to_prob" (get hyperparam_map "dt" ))
 						(let
 							(assoc output_features_set (zip output_features_no_ids))
-							;surprisal space dbl_precision_epsilon is dbl_epsilon * ( num_nominal_features + 2 * num_continuous_features + num_features - 1 )
 							(*
 								;multiply by 2 to account for the precision uncertainty around both computed values
 								2
+								;machine epsilon
 								2.220446049250313e-16
+								;due to per-distance term additions and subtractions in the operations: two per nominal and three per continuous
+								;dbl_epsilon * ( 2 * num_nominal_features + 3 * num_continuous_features )
 								(+
-									(size (keep output_features_set (indices !nominalsMap)))
-									(* 2 (size (remove output_features_set (indices !nominalsMap))) )
-									(size output_features_no_ids)
-									-1
+									(* 2 (size (keep output_features_set (indices !nominalsMap))) )
+									(* 3 (size (remove output_features_set (indices !nominalsMap))) )
 								)
 							)
 						)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -308,7 +308,7 @@
 							(assoc output_features_set (zip output_features_no_ids))
 							;surprisal space dbl_precision_epsilon is dbl_epsilon * ( num_nominal_features + 2 * num_continuous_features + num_features - 1 )
 							(*
-								;muiltiply by 2 to account for the precision uncertainty around both computed values
+								;multiply by 2 to account for the precision uncertainty around both computed values
 								2
 								2.220446049250313e-16
 								(+

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -308,6 +308,8 @@
 							(assoc output_features_set (zip output_features_no_ids))
 							;surprisal space dbl_precision_epsilon is dbl_epsilon * ( num_nominal_features + 2 * num_continuous_features + num_features - 1 )
 							(*
+								;muiltiply by 2 to account for the precision uncertainty around both computed values
+								2
 								2.220446049250313e-16
 								(+
 									(size (keep output_features_set (indices !nominalsMap)))

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -1048,19 +1048,20 @@
 				)
 		)
 
-		;surprisal space dbl_precision_epsilon is dbl_epsilon * ( num_nominal_features + 2 * num_continuous_features + num_features - 1 )
-		;due to per-distance term additions and subtractions in the operations: one per nominal, two per continuous and all features added up.
+
+
 		(if (= "surprisal_to_prob" (get hyperparam_map "dt") )
 
 			(*
 				;multiply by 2 to account for the precision uncertainty around both computed values
 				2
+				;machine epsilon
 				2.220446049250313e-16
+				;due to per-distance term additions and subtractions in the operations: two per nominal and three per continuous
+				;dbl_epsilon * ( 2 * num_nominal_features + 3 * num_continuous_features )
 				(+
-					(size (keep all_features_set (indices !nominalsMap)))
-					(* 2 (size (remove all_features_set (indices !nominalsMap))) )
-					(size all_features_set)
-					-1
+					(* 2 (size (keep all_features_set (indices !nominalsMap))) )
+					(* 3 (size (remove all_features_set (indices !nominalsMap))) )
 				)
 			)
 

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -1053,6 +1053,7 @@
 		(if (= "surprisal_to_prob" (get hyperparam_map "dt") )
 
 			(*
+				2
 				2.220446049250313e-16
 				(+
 					(size (keep all_features_set (indices !nominalsMap)))

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -1053,6 +1053,7 @@
 		(if (= "surprisal_to_prob" (get hyperparam_map "dt") )
 
 			(*
+				;muiltiply by 2 to account for the precision uncertainty around both computed values
 				2
 				2.220446049250313e-16
 				(+

--- a/howso/synthesis_utilities.amlg
+++ b/howso/synthesis_utilities.amlg
@@ -1053,7 +1053,7 @@
 		(if (= "surprisal_to_prob" (get hyperparam_map "dt") )
 
 			(*
-				;muiltiply by 2 to account for the precision uncertainty around both computed values
+				;multiply by 2 to account for the precision uncertainty around both computed values
 				2
 				2.220446049250313e-16
 				(+

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -297,7 +297,7 @@
 											(query_not_in_entity_list (first local_data_cases_tuple))
 											(query_within_generalized_distance
 												;dbl_precision_epsilon for defining whether two values are equal within acceptable precision
-												(+ dbl_precision_epsilon (last (last local_data_cases_tuple)) )
+												(+ (* dbl_precision_epsilon (last (last local_data_cases_tuple)) ) (last (last local_data_cases_tuple)) )
 												(if has_novel_substitions non_novel_context_features context_features)
 												(if has_novel_substitions non_novel_context_values context_numeric_values)
 												p_parameter

--- a/unit_tests/ut_h_null_residual_convictions.amlg
+++ b/unit_tests/ut_h_null_residual_convictions.amlg
@@ -47,8 +47,8 @@
 	(print "Continuous feature local residual conviction: ")
 	(call assert_approximate (assoc
 		obs (get result (list "feature_full_residual_convictions_for_case" "sepal_width"))
-		exp 0.2
-		thresh 0.05
+		exp 0.22
+		thresh 0.06
 	))
 
 	(assign (assoc


### PR DESCRIPTION
double the computed epsilon to ensure equidistant cases aren't missed during uniqueness checks due to double precision floating point inaccuracies