### PR TITLE
24256: Adds `get_value_masses` endpoint to the Trainee API, MINOR

### DIFF
--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -954,6 +954,8 @@
 
 
 	;outputs all unique values and the count of each value given the trained data and possible conditions
+	;if a weight feature is specified or auto-ablation is enabled, then the probability masses are returned rather
+	;than frequency of values.
 	#get_value_counts
 	(declare
 		; returns {
@@ -989,7 +991,8 @@
 			;specified minimum count have their frequencies added together and returned under the "remaining" key for the feature.
 			minimum_count_threshold 0
 			;{type "string"}
-			;name of case weight feature
+			;name of case weight feature. When specified, the returned values represent the sum of the weights of all the cases that have
+			;each feature value, rather than the number of cases.
 			weight_feature (null)
 		)
 		(call !ValidateParameters)

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -951,4 +951,134 @@
 				stats
 			)
 		)
+
+
+	;outputs all unique values and the count of each value given the trained data and possible conditions
+	#get_value_counts
+	(declare
+		; returns {
+		; 	type "assoc"
+		; 	description "Object containing the response of get_value_counts"
+		; 	indices {
+		; 		"counts" {
+		; 			type "assoc"
+		; 			additional_indices {
+		; 				type "assoc"
+		; 				indices {
+		; 					"values" {type "list" values "list"}
+		; 					"remaining" {type "number"}
+		; 				}
+		; 			}
+		; 		}
+		; 	}
+		; }
+		(assoc
+			;{type "list" values "string" required (true) min_size 1}
+			;The features to compute and return value counts for.
+			features (null)
+			;{ref "Condition"}
+			;A map of conditions for each feature that is used to select cases for which the value counts
+			;will be computed and output.
+			condition (null)
+			;{ref "Precision"}
+			;default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
+			precision "exact"
+			;{type "number" min 0}
+			;The minimum number of cases must hold a value for that value to be returned.
+			minimum_count 0
+			;{type "string"}
+			;name of case weight feature
+			weight_feature (null)
+		)
+		(call !ValidateParameters)
+
+		(if (= (null) weight_feature)
+			(assign (assoc
+				weight_feature
+					(if !autoAblationEnabled
+						!autoAblationWeightFeature
+						".none"
+					)
+			))
+		)
+
+		(declare (assoc
+			condition_query_list
+				(if (size condition)
+					(call !GetQueryByCondition (assoc
+						condition condition
+						precision precision
+					))
+				)
+		))
+
+		(declare (assoc
+			output_map
+				(map
+					(lambda
+						(let
+							(assoc
+								feature (current_index 1)
+							)
+
+							(declare (assoc
+								value_counts_map
+									(compute_on_contained_entities
+										(query_exists !internalLabelSession)
+										condition_query_list
+										(query_value_masses feature weight_feature)
+									)
+							))
+
+							(if minimum_count
+								(seq
+									;if minimum defined, filter down the insignificant feature values to sum together and remove
+									;those values from the map of value counts to be returned
+									(declare (assoc
+										insignificant_value_counts_map
+											(filter
+												(lambda
+													(< (current_value) minimum_count)
+												)
+												value_counts_map
+											)
+									))
+									(assign (assoc
+										value_counts_map (remove value_counts_map (indices insignificant_value_counts_map))
+									))
+								)
+							)
+
+
+							(append
+								(assoc
+									"values"
+										(values (map
+											(lambda
+												[(current_index 1) (current_value 1)]
+											)
+											value_counts_map
+										))
+								)
+								(if minimum_count
+									(assoc
+										"remaining"
+											(if (size insignificant_value_counts_map)
+												(apply "+" (values insignificant_value_counts_map))
+												0
+											)
+									)
+									(assoc)
+								)
+							)
+						)
+					)
+					(zip features)
+				)
+		))
+
+		(call !Return (assoc
+			payload (assoc "counts" output_map)
+		))
+	)
 )

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -962,11 +962,12 @@
 		; 	indices {
 		; 		"counts" {
 		; 			type "assoc"
+		;			description "A mapping of feature name to map defining the computed value counts."
 		; 			additional_indices {
 		; 				type "assoc"
 		; 				indices {
-		; 					"values" {type "list" values "list"}
-		; 					"remaining" {type "number"}
+		; 					"values" {type "list" values "list" description "A list of tuples of feature value and its frequency."}
+		; 					"remaining" {type "number" description "The sum of counts of values with frequencies below the minumum count threshold."}
 		; 				}
 		; 			}
 		; 		}

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -966,7 +966,7 @@
 		; 			additional_indices {
 		; 				type "assoc"
 		; 				indices {
-		; 					"values" {type "list" values "list" description "A list of tuples of feature value and its frequency."}
+		; 					"values" {type "list" values "list" description "A list of tuples containing a feature value and its frequency."}
 		; 					"remaining" {type "number" description "The sum of counts of values with frequencies below the minumum count threshold."}
 		; 				}
 		; 			}
@@ -1055,6 +1055,10 @@
 							(append
 								(assoc
 									"values"
+										;The value and their counts are returned as 2-item lists
+										;of [feature_value, count] rather than an assoc of value->count
+										;because using an assoc would convert the feature values to strings
+										;when converted to JSON
 										(values (map
 											(lambda
 												[(current_index 1) (current_value 1)]

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -984,8 +984,9 @@
 			;default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
 			precision "exact"
 			;{type "number" min 0}
-			;The minimum number of cases must hold a value for that value to be returned.
-			minimum_count 0
+			;The minimum number of cases must hold a value for that value to be returned. Any values with frequency lesser than the
+			;specified minimum count have their frequencies added together and returned under the "remaining" key for the feature.
+			minimum_count_threshold 0
 			;{type "string"}
 			;name of case weight feature
 			weight_feature (null)
@@ -1030,7 +1031,7 @@
 									)
 							))
 
-							(if minimum_count
+							(if minimum_count_threshold
 								(seq
 									;if minimum defined, filter down the insignificant feature values to sum together and remove
 									;those values from the map of value counts to be returned
@@ -1038,7 +1039,7 @@
 										insignificant_value_counts_map
 											(filter
 												(lambda
-													(< (current_value) minimum_count)
+													(< (current_value) minimum_count_threshold)
 												)
 												value_counts_map
 											)
@@ -1060,7 +1061,7 @@
 											value_counts_map
 										))
 								)
-								(if minimum_count
+								(if minimum_count_threshold
 									(assoc
 										"remaining"
 											(if (size insignificant_value_counts_map)

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -953,23 +953,23 @@
 		)
 
 
-	;outputs all unique values and the count of each value given the trained data and possible conditions
+	;outputs all unique values and the mass of each value given the trained data and possible conditions
 	;if a weight feature is specified or auto-ablation is enabled, then the probability masses are returned rather
-	;than frequency of values.
-	#get_value_counts
+	;than frequency of cases with each value.
+	#get_value_masses
 	(declare
 		; returns {
 		; 	type "assoc"
-		; 	description "Object containing the response of get_value_counts"
+		; 	description "Object containing the response of get_value_masses"
 		; 	indices {
-		; 		"counts" {
+		; 		"masses" {
 		; 			type "assoc"
-		;			description "A mapping of feature name to map defining the computed value counts."
+		;			description "A mapping of feature name to map defining the computed value masses."
 		; 			additional_indices {
 		; 				type "assoc"
 		; 				indices {
-		; 					"values" {type "list" values "list" description "A list of tuples containing a feature value and its frequency."}
-		; 					"remaining" {type "number" description "The sum of counts of values with frequencies below the minumum count threshold."}
+		; 					"values" {type "list" values "list" description "A list of tuples containing a feature value and its mass."}
+		; 					"remaining" {type "number" description "The sum of masses of values with mass below the minumum count threshold."}
 		; 				}
 		; 			}
 		; 		}
@@ -987,9 +987,9 @@
 			;default is 'exact', used only with 'condition' parameter, will find exact matches if 'exact' and similar cases if 'similar'.
 			precision "exact"
 			;{type "number" min 0}
-			;The minimum number of cases must hold a value for that value to be returned. Any values with frequency lesser than the
-			;specified minimum count have their frequencies added together and returned under the "remaining" key for the feature.
-			minimum_count_threshold 0
+			;The minimum mass required for a value to be returned. Any values with mass lesser than the
+			;specified minimum mass have their masses added together and returned under the "remaining" key for the feature.
+			minimum_mass_threshold 0
 			;{type "string"}
 			;name of case weight feature. When specified, the returned values represent the sum of the weights of all the cases that have
 			;each feature value, rather than the number of cases.
@@ -1024,7 +1024,7 @@
 						(assoc feature (current_index 1))
 
 						(declare (assoc
-							value_counts_map
+							value_mass_map
 								(compute_on_contained_entities
 									(query_exists !internalLabelSession)
 									condition_query_list
@@ -1032,19 +1032,19 @@
 								)
 						))
 
-						(if minimum_count_threshold
+						(if minimum_mass_threshold
 							(seq
 								;if minimum defined, filter down the insignificant feature values to sum together and remove
 								;those values from the map of value counts to be returned
 								(declare (assoc
-									insignificant_value_counts_map
+									insignificant_value_mass_map
 										(filter
-											(lambda (< (current_value) minimum_count_threshold))
-											value_counts_map
+											(lambda (< (current_value) minimum_mass_threshold))
+											value_mass_map
 										)
 								))
 								(assign (assoc
-									value_counts_map (remove value_counts_map (indices insignificant_value_counts_map))
+									value_mass_map (remove value_mass_map (indices insignificant_value_mass_map))
 								))
 							)
 						)
@@ -1053,20 +1053,20 @@
 						(append
 							(assoc
 								"values"
-									;The value and their counts are returned as 2-item lists
-									;of [feature_value, count] rather than an assoc of value->count
+									;The value and their masses are returned as 2-item lists
+									;of [feature_value, mass] rather than an assoc of value->mass
 									;because using an assoc would convert the feature values to strings
 									;when converted to JSON
 									(values (map
 										(lambda [(current_index 1) (current_value 1)] )
-										value_counts_map
+										value_mass_map
 									))
 							)
-							(if minimum_count_threshold
+							(if minimum_mass_threshold
 								(assoc
 									"remaining"
-										(if (size insignificant_value_counts_map)
-											(apply "+" (values insignificant_value_counts_map))
+										(if (size insignificant_value_mass_map)
+											(apply "+" (values insignificant_value_mass_map))
 											0
 										)
 								)
@@ -1079,7 +1079,7 @@
 		))
 
 		(call !Return (assoc
-			payload (assoc "counts" output_map)
+			payload (assoc "masses" output_map)
 		))
 	)
 )

--- a/howso/marginal.amlg
+++ b/howso/marginal.amlg
@@ -1017,68 +1017,60 @@
 		(declare (assoc
 			output_map
 				(map
-					(lambda
-						(let
-							(assoc
-								feature (current_index 1)
-							)
+					(lambda (let
+						(assoc feature (current_index 1))
 
-							(declare (assoc
-								value_counts_map
-									(compute_on_contained_entities
-										(query_exists !internalLabelSession)
-										condition_query_list
-										(query_value_masses feature weight_feature)
-									)
-							))
-
-							(if minimum_count_threshold
-								(seq
-									;if minimum defined, filter down the insignificant feature values to sum together and remove
-									;those values from the map of value counts to be returned
-									(declare (assoc
-										insignificant_value_counts_map
-											(filter
-												(lambda
-													(< (current_value) minimum_count_threshold)
-												)
-												value_counts_map
-											)
-									))
-									(assign (assoc
-										value_counts_map (remove value_counts_map (indices insignificant_value_counts_map))
-									))
+						(declare (assoc
+							value_counts_map
+								(compute_on_contained_entities
+									(query_exists !internalLabelSession)
+									condition_query_list
+									(query_value_masses feature weight_feature)
 								)
-							)
+						))
 
-
-							(append
-								(assoc
-									"values"
-										;The value and their counts are returned as 2-item lists
-										;of [feature_value, count] rather than an assoc of value->count
-										;because using an assoc would convert the feature values to strings
-										;when converted to JSON
-										(values (map
-											(lambda
-												[(current_index 1) (current_value 1)]
-											)
+						(if minimum_count_threshold
+							(seq
+								;if minimum defined, filter down the insignificant feature values to sum together and remove
+								;those values from the map of value counts to be returned
+								(declare (assoc
+									insignificant_value_counts_map
+										(filter
+											(lambda (< (current_value) minimum_count_threshold))
 											value_counts_map
-										))
-								)
-								(if minimum_count_threshold
-									(assoc
-										"remaining"
-											(if (size insignificant_value_counts_map)
-												(apply "+" (values insignificant_value_counts_map))
-												0
-											)
-									)
-									(assoc)
-								)
+										)
+								))
+								(assign (assoc
+									value_counts_map (remove value_counts_map (indices insignificant_value_counts_map))
+								))
 							)
 						)
-					)
+
+
+						(append
+							(assoc
+								"values"
+									;The value and their counts are returned as 2-item lists
+									;of [feature_value, count] rather than an assoc of value->count
+									;because using an assoc would convert the feature values to strings
+									;when converted to JSON
+									(values (map
+										(lambda [(current_index 1) (current_value 1)] )
+										value_counts_map
+									))
+							)
+							(if minimum_count_threshold
+								(assoc
+									"remaining"
+										(if (size insignificant_value_counts_map)
+											(apply "+" (values insignificant_value_counts_map))
+											0
+										)
+								)
+								(assoc)
+							)
+						)
+					))
 					(zip features)
 				)
 		))

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -240,12 +240,12 @@
 	))
 
 	(assign (assoc
-		result (call_entity "howso" "get_value_counts" (assoc features ["fruit" "size"]))
+		result (call_entity "howso" "get_value_masses" (assoc features ["fruit" "size"]))
 	))
 	(call keep_result_payload)
 	(print "Correct value counts: ")
 	(call assert_same (assoc
-		obs (zip (get result ["counts" "fruit" "values"]))
+		obs (zip (get result ["masses" "fruit" "values"]))
 		exp (zip [
 				["strawberry" 3]
 				[(null) 1]
@@ -257,7 +257,7 @@
 			])
 	))
 	(call assert_same (assoc
-		obs (zip (get result ["counts" "size" "values"]))
+		obs (zip (get result ["masses" "size" "values"]))
 		exp (zip [
 				["small" 7]
 				["medium" 10]
@@ -267,27 +267,27 @@
 
 	(assign (assoc
 		result
-			(call_entity "howso" "get_value_counts" (assoc
+			(call_entity "howso" "get_value_masses" (assoc
 				features ["fruit" "size"]
 				condition {"height" [3 999]}
-				minimum_count_threshold 2
+				minimum_mass_threshold 2
 			))
 	))
 	(call keep_result_payload)
 	(print "Correct conditioned value counts: ")
 	(call assert_same (assoc
-		obs (zip (get result ["counts" "fruit" "values"]))
+		obs (zip (get result ["masses" "fruit" "values"]))
 		exp (zip [
 				["melon" 3]
 				["pineapple" 4]
 			])
 	))
 	(call assert_same (assoc
-		obs (get result ["counts" "fruit" "remaining"])
+		obs (get result ["masses" "fruit" "remaining"])
 		exp 3
 	))
 	(call assert_same (assoc
-		obs (zip (get result ["counts" "size" "values"]))
+		obs (zip (get result ["masses" "size" "values"]))
 		exp (zip [
 				["medium" 3]
 				["large" 7]

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -270,7 +270,7 @@
 			(call_entity "howso" "get_value_counts" (assoc
 				features ["fruit" "size"]
 				condition {"height" [3 999]}
-				minimum_count 2
+				minimum_count_threshold 2
 			))
 	))
 	(call keep_result_payload)

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -239,6 +239,33 @@
 		exp (list 4 4 17 11 13.75)
 	))
 
+	(assign (assoc
+		result (call_entity "howso" "get_value_counts" (assoc features ["fruit" "size"]))
+	))
+	(call keep_result_payload)
+	(print "Correct value counts: ")
+	(call assert_same (assoc
+		obs (zip (get result ["counts" "fruit" "values"]))
+		exp (zip [
+				["strawberry" 3]
+				[(null) 1]
+				["apple" 4]
+				["banana" 4]
+				["peach" 5]
+				["melon" 3]
+				["pineapple" 4]
+			])
+	))
+	(call assert_same (assoc
+		obs (zip (get result ["counts" "size" "values"]))
+		exp (zip [
+				["small" 7]
+				["medium" 10]
+				["large" 7]
+			])
+	))
+
+
 	(call_entity "howso" "analyze" (assoc
 		context_features context_features
 		action_features (list (last features))

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -265,6 +265,35 @@
 			])
 	))
 
+	(assign (assoc
+		result
+			(call_entity "howso" "get_value_counts" (assoc
+				features ["fruit" "size"]
+				condition {"height" [3 999]}
+				minimum_count 2
+			))
+	))
+	(call keep_result_payload)
+	(print "Correct conditioned value counts: ")
+	(call assert_same (assoc
+		obs (zip (get result ["counts" "fruit" "values"]))
+		exp (zip [
+				["melon" 3]
+				["pineapple" 4]
+			])
+	))
+	(call assert_same (assoc
+		obs (get result ["counts" "fruit" "remaining"])
+		exp 3
+	))
+	(call assert_same (assoc
+		obs (zip (get result ["counts" "size" "values"]))
+		exp (zip [
+				["medium" 3]
+				["large" 7]
+			])
+	))
+
 
 	(call_entity "howso" "analyze" (assoc
 		context_features context_features


### PR DESCRIPTION
Adds a new endpoint: `get_value_masses`. Which is designed to give users a way to get the unique values and their masses for each requested feature.

Example response payload:
```
{
        masses {
                        target {
                                        remaining 19
                                        values [
                                                        [0 29]
                                                        [1 27]
                                                ]
                                }
                }
}
```