### PR TITLE
24231: Adds dynamic case sampling for computing robust AC and feature probabilities during analyze), MINOR

### DIFF
--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -97,7 +97,7 @@
 			;the number of cases to store within the subtrainee that is used to the deviations of the data around predictions
 			dynamic_deviations_subtrainee_size 500
 			;{type "number" min 0}
-			;Percent threshold for used to dynamically limit the number of samples used to determine feature probabilities, defaults to 0.5%
+			;Percent threshold used to dynamically limit the number of samples used to determine feature probabilities, defaults to 0.5%
 			;When set to 0 will use all num_feature_probability_samples
 			convergence_threshold 0.005
 			;{type "number" min 1}

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -101,11 +101,11 @@
 			;When set to 0 will use all num_feature_probability_samples
 			convergence_threshold 0.005
 			;{type "number" min 1}
-			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
+			;Rate of increasing the size of each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
 			;defaults to a rate of 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
 			convergence_samples_growth_rate 1.05
 			;{type "number" min 1}
-			;The minimal size of the first batch of cases used when dynamically sampling robust residuals used to determine feature probabilities
+			;The minumum size of the first batch of cases used when dynamically sampling robust residuals used to determine feature probabilities
 			;	Default of 5000
 			convergence_min_size 5000
 		)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -96,6 +96,10 @@
 			;{type "number" min 2}
 			;the number of cases to store within the subtrainee that is used to the deviations of the data around predictions
 			dynamic_deviations_subtrainee_size 500
+			;{type "number" min 0}
+			;Percent threshold for used to dynamically limit the number of samples used to determine feature probabilities, defaults to 0.5%
+			;When set to 0 will use all num_feature_probability_samples
+			converge_samples_percent_threshold 0.005
 		)
 
 		(call !ValidateParameters)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -100,6 +100,10 @@
 			;Percent threshold for used to dynamically limit the number of samples used to determine feature probabilities, defaults to 0.5%
 			;When set to 0 will use all num_feature_probability_samples
 			converge_samples_percent_threshold 0.005
+			;{type "number" min 1}
+			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
+			;defaults to a rate of 1.05, increasing by 5% until the delta between residuals is less than 'converge_samples_percent_threshold'.
+			converge_samples_growth_rate 1.05
 		)
 
 		(call !ValidateParameters)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -99,11 +99,11 @@
 			;{type "number" min 0}
 			;Percent threshold for used to dynamically limit the number of samples used to determine feature probabilities, defaults to 0.5%
 			;When set to 0 will use all num_feature_probability_samples
-			converge_samples_percent_threshold 0.005
+			convergence_threshold 0.005
 			;{type "number" min 1}
 			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
-			;defaults to a rate of 1.05, increasing by 5% until the delta between residuals is less than 'converge_samples_percent_threshold'.
-			converge_samples_growth_rate 1.05
+			;defaults to a rate of 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
+			convergence_samples_growth_rate  1.05
 		)
 
 		(call !ValidateParameters)

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -103,7 +103,11 @@
 			;{type "number" min 1}
 			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
 			;defaults to a rate of 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
-			convergence_samples_growth_rate  1.05
+			convergence_samples_growth_rate 1.05
+			;{type "number" min 1}
+			;The minimal size of the first batch of cases used when dynamically sampling robust residuals used to determine feature probabilities
+			;	Default of 5000
+			convergence_min_size 5000
 		)
 
 		(call !ValidateParameters)

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -433,7 +433,7 @@
 									robust_residuals (if computing_mda "robust_mda" "deviations")
 									num_samples
 										(if computing_mda
-											num_feature_probability_samples
+											5000 ;num_feature_probability_samples
 
 											;the deviations query uses all features "superfull", there's no need to sample more
 											;than a default amount of 1000

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -433,7 +433,7 @@
 									robust_residuals (if computing_mda "robust_mda" "deviations")
 									num_samples
 										(if computing_mda
-											2000  ;num_feature_probability_samples
+											num_feature_probability_samples
 
 											;the deviations query uses all features "superfull", there's no need to sample more
 											;than a default amount of 1000

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -448,6 +448,7 @@
 									;don't create copies of confusion matrices for non-primary shared deviation features
 									expand_confusion_matrices (false)
 									converge_samples_percent_threshold converge_samples_percent_threshold
+									converge_samples_growth_rate converge_samples_growth_rate
 								))
 						))
 					)

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -433,7 +433,7 @@
 									robust_residuals (if computing_mda "robust_mda" "deviations")
 									num_samples
 										(if computing_mda
-											4000  ;num_feature_probability_samples
+											2000  ;num_feature_probability_samples
 
 											;the deviations query uses all features "superfull", there's no need to sample more
 											;than a default amount of 1000

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -433,7 +433,7 @@
 									robust_residuals (if computing_mda "robust_mda" "deviations")
 									num_samples
 										(if computing_mda
-											5000 ;num_feature_probability_samples
+											4000  ;num_feature_probability_samples
 
 											;the deviations query uses all features "superfull", there's no need to sample more
 											;than a default amount of 1000

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -447,6 +447,7 @@
 									use_shared_deviations (true)
 									;don't create copies of confusion matrices for non-primary shared deviation features
 									expand_confusion_matrices (false)
+									converge_samples_percent_threshold converge_samples_percent_threshold
 								))
 						))
 					)

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -447,8 +447,8 @@
 									use_shared_deviations (true)
 									;don't create copies of confusion matrices for non-primary shared deviation features
 									expand_confusion_matrices (false)
-									converge_samples_percent_threshold converge_samples_percent_threshold
-									converge_samples_growth_rate converge_samples_growth_rate
+									convergence_threshold convergence_threshold
+									convergence_samples_growth_rate  convergence_samples_growth_rate
 								))
 						))
 					)

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -448,7 +448,8 @@
 									;don't create copies of confusion matrices for non-primary shared deviation features
 									expand_confusion_matrices (false)
 									convergence_threshold convergence_threshold
-									convergence_samples_growth_rate  convergence_samples_growth_rate
+									convergence_samples_growth_rate convergence_samples_growth_rate
+									convergence_min_size convergence_min_size
 								))
 						))
 					)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -304,15 +304,29 @@
 			excluded_inactive_features_map {}
 		))
 
-		;when dynamic sampling for computing robust_mda, start with 5000 (2000 + 3000) samples
+
+		;if computing robust accuracy contributions, num_samples will be null, overwrite num_samples with the number of specified case_ids
+		(if (and
+				(= "robust_mda" robust_residuals)
+				output_raw_mda
+				(= (null) num_samples)
+			)
+			(assign (assoc
+				num_samples (size case_ids)
+				num_feature_probability_samples (size case_ids)
+			))
+		)
+
+
+		;when dynamic sampling for computing robust_mda, start with 5000
 		;unless user explicitly specified <= 5000 `num_feature_probability_samples`, in that case don't use dynamic sampling
 		(if (and
 				(= "robust_mda" robust_residuals)
 				(> num_samples 5000)
 				(= num_samples num_feature_probability_samples)
 			)
-			;set the number of samples in the first of the dynamic batches to 2000
-			(assign (assoc num_samples 2000))
+			;set the number of samples in the first of the dynamic batches to 5000
+			(assign (assoc num_samples 5000))
 		)
 
 		(call !InitResiduals)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -254,8 +254,8 @@
 
 			output_raw_mda (false)
 			mda_action_feature (null)
-			converge_samples_percent_threshold 0.005
-			converge_samples_growth_rate 1.05
+			convergence_threshold 0.005
+			convergence_samples_growth_rate  1.05
 		)
 
 		(declare (assoc
@@ -338,7 +338,7 @@
 
 			;else robust residuals for mda/robut AC
 			(= "robust_mda" robust_residuals)
-			(if (and (> num_feature_probability_samples 5000) (> converge_samples_percent_threshold 0))
+			(if (and (> num_feature_probability_samples 5000) (> convergence_threshold 0))
 				(call !AutoConvergeRobustResiduals)
 
 				;else <= 5000 samples requested, just run them all

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -222,6 +222,11 @@
 	;		When specified (only for full residuals/prediction_stats), computes forecasts and evaluates error at the end of the forecasts
 	; output_raw_mda: flag, optional, default false. When robust_residuals is "robust_mda" and this flag is true, will output raw MDA values in 'feature_mda_map'
 	; mda_action_feature: string, optional.  When robust_residuals is "robust_mda" and this is set, will output only this specified feature's MDA values
+	; convergence_threshold: number, percent threshold for used to dynamically limit the number of samples used to determine robust_mda
+	; 			Defaults to 0.5, when set to 0 will use all num_feature_probability_samples or all case_ids
+	; convergence_samples_growth_rate: number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
+	;			robust_mda. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
+	; convergence_min_size: number, the minimal size of the first batch of cases used when dynamically sampling robust residuals for robust_mda. Default of 5000
 	#!CalculateFeatureResiduals
 	(declare
 		(assoc
@@ -256,6 +261,7 @@
 			mda_action_feature (null)
 			convergence_threshold 0.005
 			convergence_samples_growth_rate  1.05
+			convergence_min_size 5000
 		)
 
 		(declare (assoc
@@ -320,15 +326,15 @@
 			))
 		)
 
-		;when dynamic sampling for computing robust_mda, start with 5000
-		;unless user explicitly specified <= 5000 `num_feature_probability_samples`, in that case don't use dynamic sampling
+		;when dynamic sampling for computing robust_mda, start with 'convergence_min_size'
+		;unless user explicitly specified <= convergence_min_size `num_feature_probability_samples`, in that case don't use dynamic sampling
 		(if (and
 				(= "robust_mda" robust_residuals)
-				(> num_samples 5000)
+				(> num_samples convergence_min_size)
 				(= num_samples num_feature_probability_samples)
 			)
-			;set the number of samples in the first of the dynamic batches to 5000
-			(assign (assoc num_samples 5000))
+			;set the number of samples in the first of the dynamic batches to `convergence_min_size`
+			(assign (assoc num_samples convergence_min_size))
 		)
 
 		(call !InitResiduals)
@@ -338,10 +344,10 @@
 
 			;else robust residuals for mda/robut AC
 			(= "robust_mda" robust_residuals)
-			(if (and (> num_feature_probability_samples 5000) (> convergence_threshold 0))
+			(if (and (> num_feature_probability_samples convergence_min_size) (> convergence_threshold 0))
 				(call !AutoConvergeRobustResiduals)
 
-				;else <= 5000 samples requested, just run them all
+				;else <= convergence_min_size samples requested, just run them all
 				;leave nulls in results during analyze flow so they can be used to compute feature mda later
 				(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
 			)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -222,7 +222,7 @@
 	;		When specified (only for full residuals/prediction_stats), computes forecasts and evaluates error at the end of the forecasts
 	; output_raw_mda: flag, optional, default false. When robust_residuals is "robust_mda" and this flag is true, will output raw MDA values in 'feature_mda_map'
 	; mda_action_feature: string, optional.  When robust_residuals is "robust_mda" and this is set, will output only this specified feature's MDA values
-	; convergence_threshold: number, percent threshold for used to dynamically limit the number of samples used to determine robust_mda
+	; convergence_threshold: number, percent threshold used to dynamically limit the number of samples used to determine robust_mda
 	; 			Defaults to 0.5, when set to 0 will use all num_feature_probability_samples or all case_ids
 	; convergence_samples_growth_rate: number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
 	;			robust_mda. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -224,9 +224,9 @@
 	; mda_action_feature: string, optional.  When robust_residuals is "robust_mda" and this is set, will output only this specified feature's MDA values
 	; convergence_threshold: number, percent threshold used to dynamically limit the number of samples used to determine robust_mda
 	; 			Defaults to 0.5, when set to 0 will use all num_feature_probability_samples or all case_ids
-	; convergence_samples_growth_rate: number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
+	; convergence_samples_growth_rate: number, Rate of increasing the size of each subsequent sample used to dynamically limit the total number of samples used to determine
 	;			robust_mda. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
-	; convergence_min_size: number, the minimal size of the first batch of cases used when dynamically sampling robust residuals for robust_mda. Default of 5000
+	; convergence_min_size: number, the minimum size of the first batch of cases used when dynamically sampling robust residuals for robust_mda. Default of 5000
 	#!CalculateFeatureResiduals
 	(declare
 		(assoc
@@ -327,7 +327,7 @@
 		)
 
 		;when dynamic sampling for computing robust_mda, start with 'convergence_min_size'
-		;unless user explicitly specified <= convergence_min_size `num_feature_probability_samples`, in that case don't use dynamic sampling
+		;unless user explicitly specified `num_feature_probability_samples` <= convergence_min_size, in that case don't use dynamic sampling
 		(if (and
 				(= "robust_mda" robust_residuals)
 				(> num_samples convergence_min_size)

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -304,19 +304,34 @@
 			excluded_inactive_features_map {}
 		))
 
+		;when dynamic sampling for computing robust_mda, start with 5000 (2000 + 3000) samples
+		;unless user explicitly specified <= 5000 `num_feature_probability_samples`, in that case don't use dynamic sampling
+		(if (and
+				(= "robust_mda" robust_residuals)
+				(> num_samples 5000)
+				(= num_samples num_feature_probability_samples)
+			)
+			;set the number of samples in the first of the dynamic batches to 2000
+			(assign (assoc num_samples 2000))
+		)
+
 		(call !InitResiduals)
 
 		(if (= "deviations" robust_residuals)
 			(call !ComputeDeviations)
 
-			;else robust residuals, and leave nulls in results during analyze flow so they can be used to compute feature mda later
+			;else robust residuals for mda, and leave nulls in results during analyze flow so they can be used to compute feature mda later
 			(= "robust_mda" robust_residuals)
-			(call !AutoConvergeRobustResiduals)
+			(if (> num_feature_probability_samples 5000)
+				(call !AutoConvergeRobustResiduals)
 
+				;else <= 5000 samples requested, just run them all
+				(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
+			)
+
+			;else just robust residuals
 			robust_residuals
-			(call !RunRobustResiduals (assoc
-				leave_nulls_in_results (false) ;;; (= "robust_mda" robust_residuals)
-			))
+			(call !RunRobustResiduals (assoc leave_nulls_in_results (false)  ))
 
 			;else
 			(if forecast_window_length

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -310,9 +310,12 @@
 			(call !ComputeDeviations)
 
 			;else robust residuals, and leave nulls in results during analyze flow so they can be used to compute feature mda later
+			(= "robust_mda" robust_residuals)
+			(call !AutoConvergeRobustResiduals)
+
 			robust_residuals
 			(call !RunRobustResiduals (assoc
-				leave_nulls_in_results (= "robust_mda" robust_residuals)
+				leave_nulls_in_results (false) ;;; (= "robust_mda" robust_residuals)
 			))
 
 			;else

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -255,6 +255,7 @@
 			output_raw_mda (false)
 			mda_action_feature (null)
 			converge_samples_percent_threshold 0.005
+			converge_samples_growth_rate 1.05
 		)
 
 		(declare (assoc

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -307,7 +307,8 @@
 		))
 
 
-		;if computing robust accuracy contributions, num_samples will be null, overwrite num_samples with the number of specified case_ids
+		;if computing robust accuracy contributions from react_aggregate, num_samples will be null, overwrite num_samples
+		;with the number of specified case_ids that are passed in from react_aggregate
 		(if (and
 				(= "robust_mda" robust_residuals)
 				output_raw_mda
@@ -318,7 +319,6 @@
 				num_feature_probability_samples (size case_ids)
 			))
 		)
-
 
 		;when dynamic sampling for computing robust_mda, start with 5000
 		;unless user explicitly specified <= 5000 `num_feature_probability_samples`, in that case don't use dynamic sampling
@@ -336,12 +336,13 @@
 		(if (= "deviations" robust_residuals)
 			(call !ComputeDeviations)
 
-			;else robust residuals for mda, and leave nulls in results during analyze flow so they can be used to compute feature mda later
+			;else robust residuals for mda/robut AC
 			(= "robust_mda" robust_residuals)
 			(if (and (> num_feature_probability_samples 5000) (> converge_samples_percent_threshold 0))
 				(call !AutoConvergeRobustResiduals)
 
 				;else <= 5000 samples requested, just run them all
+				;leave nulls in results during analyze flow so they can be used to compute feature mda later
 				(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
 			)
 

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -254,6 +254,7 @@
 
 			output_raw_mda (false)
 			mda_action_feature (null)
+			converge_samples_percent_threshold 0.005
 		)
 
 		(declare (assoc
@@ -336,7 +337,7 @@
 
 			;else robust residuals for mda, and leave nulls in results during analyze flow so they can be used to compute feature mda later
 			(= "robust_mda" robust_residuals)
-			(if (> num_feature_probability_samples 5000)
+			(if (and (> num_feature_probability_samples 5000) (> converge_samples_percent_threshold 0))
 				(call !AutoConvergeRobustResiduals)
 
 				;else <= 5000 samples requested, just run them all

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -888,6 +888,14 @@
 			;Enabling SDM will typically incur a small to moderate penalty on speed when using nominal features in inference in exchange for
 			;yielding higher quality inference. The magnitude of the changes are dependent on relationships among the data and the task at hand.
 			use_sdm (null)
+			;{type "number" min 0}
+			;Percent threshold for used to dynamically limit the number of samples used to determine feature probabilities, defaults to 0.5%
+			;When set to 0 will use all num_feature_probability_samples
+			convergence_threshold (null)
+			;{type "number" min 1}
+			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
+			;defaults to a rate of 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
+			convergence_samples_growth_rate  (null)
 		)
 		(call !ValidateParameters)
 
@@ -949,6 +957,8 @@
 				use_case_weights
 				rebalance_features
 				(!= (null) use_sdm)
+				convergence_threshold
+				convergence_samples_growth_rate
 			)
 			(seq
 				(if (= (null) targeted_model)
@@ -986,6 +996,8 @@
 							"use_case_weights" use_case_weights
 							"rebalance_features" rebalance_features
 							"use_sdm" use_sdm
+							"convergence_threshold" convergence_threshold
+							"convergence_samples_growth_rate" convergence_samples_growth_rate
 						))
 				))
 			)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -889,7 +889,7 @@
 			;yielding higher quality inference. The magnitude of the changes are dependent on relationships among the data and the task at hand.
 			use_sdm (null)
 			;{type "number" min 0}
-			;Percent threshold for used to dynamically limit the number of samples used to determine feature probabilities, defaults to 0.5%
+			;Percent threshold used to dynamically limit the number of samples used to determine feature probabilities, defaults to 0.5%
 			;When set to 0 will use all num_feature_probability_samples
 			convergence_threshold (null)
 			;{type "number" min 1}

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -895,7 +895,11 @@
 			;{type "number" min 1}
 			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
 			;defaults to a rate of 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
-			convergence_samples_growth_rate  (null)
+			convergence_samples_growth_rate (null)
+			;{type "number" min 1}
+			;The minimal size of the first batch of cases used when dynamically sampling robust residuals used to determine feature probabilities
+			;	Default of 5000
+			convergence_min_size 5000
 		)
 		(call !ValidateParameters)
 
@@ -959,6 +963,7 @@
 				(!= (null) use_sdm)
 				convergence_threshold
 				convergence_samples_growth_rate
+				convergence_min_size
 			)
 			(seq
 				(if (= (null) targeted_model)
@@ -998,6 +1003,7 @@
 							"use_sdm" use_sdm
 							"convergence_threshold" convergence_threshold
 							"convergence_samples_growth_rate" convergence_samples_growth_rate
+							"convergence_min_size" convergence_min_size
 						))
 				))
 			)

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -893,11 +893,11 @@
 			;When set to 0 will use all num_feature_probability_samples
 			convergence_threshold (null)
 			;{type "number" min 1}
-			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
+			;Rate of increasing the size of each subsequent sample used to dynamically limit the total number of samples used to determine feature probabilities.
 			;defaults to a rate of 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
 			convergence_samples_growth_rate (null)
 			;{type "number" min 1}
-			;The minimal size of the first batch of cases used when dynamically sampling robust residuals used to determine feature probabilities
+			;The minimum size of the first batch of cases used when dynamically sampling robust residuals used to determine feature probabilities
 			;	Default of 5000
 			convergence_min_size 5000
 		)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -24,6 +24,8 @@
 	; features_to_derive: list of features whose values should be derived rather than interpolated
 	; converge_samples_percent_threshold: number, percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
 	; 			Defaults to 0.5, when set to 0 will use all num_robust_accuracy_contributions_samples
+	; converge_samples_growth_rate: number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
+	;			feature accuracy contributions. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'converge_samples_percent_threshold'.
 	#!CalculateFeatureAccuracyContributions
 	(declare
 		(assoc
@@ -42,6 +44,7 @@
 			regional_data_only (false)
 			features_to_derive []
 			converge_samples_percent_threshold 0.005
+			converge_samples_growth_rate 1.05
 		)
 
 		;if computing robust accuracy contributions, use the fast method and output raw mda values as accuracy contributions
@@ -58,6 +61,7 @@
 								output_raw_mda (true)
 								mda_action_feature (if (= 1 (size action_features)) (first action_features) )
 								converge_samples_percent_threshold converge_samples_percent_threshold
+								converge_samples_growth_rate converge_samples_growth_rate
 							))
 							"feature_mda_map"
 						)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -22,6 +22,8 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; features_to_derive: list of features whose values should be derived rather than interpolated
+	; converge_samples_percent_threshold: number, percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
+	; 			Defaults to 0.5, when set to 0 will use all num_robust_accuracy_contributions_samples
 	#!CalculateFeatureAccuracyContributions
 	(declare
 		(assoc
@@ -39,6 +41,7 @@
 			context_condition_filter_query (list)
 			regional_data_only (false)
 			features_to_derive []
+			converge_samples_percent_threshold 0.005
 		)
 
 		;if computing robust accuracy contributions, use the fast method and output raw mda values as accuracy contributions
@@ -54,6 +57,7 @@
 								custom_hyperparam_map hyperparam_map
 								output_raw_mda (true)
 								mda_action_feature (if (= 1 (size action_features)) (first action_features) )
+								converge_samples_percent_threshold converge_samples_percent_threshold
 							))
 							"feature_mda_map"
 						)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -24,8 +24,9 @@
 	; features_to_derive: list of features whose values should be derived rather than interpolated
 	; convergence_threshold: number, percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
 	; 			Defaults to 0.5, when set to 0 will use all num_robust_accuracy_contributions_samples
-	; convergence_samples_growth_rate : number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
+	; convergence_samples_growth_rate: number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
 	;			feature accuracy contributions. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
+	; convergence_min_size: number, the minimal size of the first batch of cases used when dynamically sampling robust residuals. Default of 5000
 	#!CalculateFeatureAccuracyContributions
 	(declare
 		(assoc
@@ -44,7 +45,8 @@
 			regional_data_only (false)
 			features_to_derive []
 			convergence_threshold 0.005
-			convergence_samples_growth_rate  1.05
+			convergence_samples_growth_rate 1.05
+			convergence_min_size 5000
 		)
 
 		;if computing robust accuracy contributions, use the fast method and output raw mda values as accuracy contributions
@@ -61,7 +63,8 @@
 								output_raw_mda (true)
 								mda_action_feature (if (= 1 (size action_features)) (first action_features) )
 								convergence_threshold convergence_threshold
-								convergence_samples_growth_rate  convergence_samples_growth_rate
+								convergence_samples_growth_rate convergence_samples_growth_rate
+								convergence_min_size convergence_min_size
 							))
 							"feature_mda_map"
 						)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -22,10 +22,10 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; features_to_derive: list of features whose values should be derived rather than interpolated
-	; converge_samples_percent_threshold: number, percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
+	; convergence_threshold: number, percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
 	; 			Defaults to 0.5, when set to 0 will use all num_robust_accuracy_contributions_samples
-	; converge_samples_growth_rate: number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
-	;			feature accuracy contributions. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'converge_samples_percent_threshold'.
+	; convergence_samples_growth_rate : number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
+	;			feature accuracy contributions. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
 	#!CalculateFeatureAccuracyContributions
 	(declare
 		(assoc
@@ -43,8 +43,8 @@
 			context_condition_filter_query (list)
 			regional_data_only (false)
 			features_to_derive []
-			converge_samples_percent_threshold 0.005
-			converge_samples_growth_rate 1.05
+			convergence_threshold 0.005
+			convergence_samples_growth_rate  1.05
 		)
 
 		;if computing robust accuracy contributions, use the fast method and output raw mda values as accuracy contributions
@@ -60,8 +60,8 @@
 								custom_hyperparam_map hyperparam_map
 								output_raw_mda (true)
 								mda_action_feature (if (= 1 (size action_features)) (first action_features) )
-								converge_samples_percent_threshold converge_samples_percent_threshold
-								converge_samples_growth_rate converge_samples_growth_rate
+								convergence_threshold convergence_threshold
+								convergence_samples_growth_rate  convergence_samples_growth_rate
 							))
 							"feature_mda_map"
 						)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -22,7 +22,7 @@
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; context_condition_filter_query: a list of queries that can be used to filter the possible set of cases that can be used for predictions
 	; features_to_derive: list of features whose values should be derived rather than interpolated
-	; convergence_threshold: number, percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
+	; convergence_threshold: number, percent threshold used to dynamically limit the number of samples used to determine robust accuracy contributions.
 	; 			Defaults to 0.5, when set to 0 will use all num_robust_accuracy_contributions_samples
 	; convergence_samples_growth_rate: number, Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine
 	;			feature accuracy contributions. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -99,11 +99,11 @@
 			;	Defaults to 0.5%, when set to 0 will use all num_robust_accuracy_contributions_samples
 			convergence_threshold 0.005
 			;{type "number" min 1}
-			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature accuracy contributions.
+			;Rate of increasing the size of each subsequent sample used to dynamically limit the total number of samples used to determine feature accuracy contributions.
 			;	Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
 			convergence_samples_growth_rate  1.05
 			;{type "number" min 1}
-			;The minimal size of the first batch of cases used when dynamically sampling robust residuals used to determine feature accuracy contributions.
+			;The minimum size of the first batch of cases used when dynamically sampling robust residuals used to determine feature accuracy contributions.
 			;	Default of 5000
 			convergence_min_size 5000
 			;{type "number" min 0}

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -95,7 +95,7 @@
 			;	Defaults to the smaller of 150000 or (6321 * num_context_features)
 			num_robust_accuracy_contributions_samples (null)
 			;{type "number" min 0}
-			;Percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
+			;Percent threshold used to dynamically limit the number of samples used to determine robust accuracy contributions.
 			;	Defaults to 0.5%, when set to 0 will use all num_robust_accuracy_contributions_samples
 			convergence_threshold 0.005
 			;{type "number" min 1}

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -95,6 +95,10 @@
 			;	Defaults to the smaller of 150000 or (6321 * num_context_features)
 			num_robust_accuracy_contributions_samples (null)
 			;{type "number" min 0}
+			;Percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
+			;	Defaults to 0.5%, when set to 0 will use all num_robust_accuracy_contributions_samples
+			converge_samples_percent_threshold 0.005
+			;{type "number" min 0}
 			;Total sample size of model to use (using sampling with replacement) for feature_robust_accuracy_contributions_permutation.
 			;	Defaults to 300.
 			num_robust_accuracy_contributions_permutation_samples (null)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -98,6 +98,10 @@
 			;Percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
 			;	Defaults to 0.5%, when set to 0 will use all num_robust_accuracy_contributions_samples
 			converge_samples_percent_threshold 0.005
+			;{type "number" min 1}
+			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature accuracy contributions.
+			;defaults to 1.05, increasing by 5% until the delta between residuals is less than 'converge_samples_percent_threshold'.
+			converge_samples_growth_rate 1.05
 			;{type "number" min 0}
 			;Total sample size of model to use (using sampling with replacement) for feature_robust_accuracy_contributions_permutation.
 			;	Defaults to 300.
@@ -928,6 +932,8 @@
 										hyperparam_map custom_hyperparam_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
+										converge_samples_percent_threshold converge_samples_percent_threshold
+										converge_samples_growth_rate converge_samples_growth_rate
 									))
 							)
 					))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -100,8 +100,12 @@
 			convergence_threshold 0.005
 			;{type "number" min 1}
 			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature accuracy contributions.
-			;defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
+			;	Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
 			convergence_samples_growth_rate  1.05
+			;{type "number" min 1}
+			;The minimal size of the first batch of cases used when dynamically sampling robust residuals used to determine feature accuracy contributions.
+			;	Default of 5000
+			convergence_min_size 5000
 			;{type "number" min 0}
 			;Total sample size of model to use (using sampling with replacement) for feature_robust_accuracy_contributions_permutation.
 			;	Defaults to 300.
@@ -947,7 +951,8 @@
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
 										convergence_threshold convergence_threshold
-										convergence_samples_growth_rate  convergence_samples_growth_rate
+										convergence_samples_growth_rate convergence_samples_growth_rate
+										convergence_min_size convergence_min_size
 									))
 							)
 					))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -97,11 +97,11 @@
 			;{type "number" min 0}
 			;Percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions.
 			;	Defaults to 0.5%, when set to 0 will use all num_robust_accuracy_contributions_samples
-			converge_samples_percent_threshold 0.005
+			convergence_threshold 0.005
 			;{type "number" min 1}
 			;Rate of increasing each subsequent sample used to dynamically limit the total number of samples used to determine feature accuracy contributions.
-			;defaults to 1.05, increasing by 5% until the delta between residuals is less than 'converge_samples_percent_threshold'.
-			converge_samples_growth_rate 1.05
+			;defaults to 1.05, increasing by 5% until the delta between residuals is less than 'convergence_threshold'.
+			convergence_samples_growth_rate  1.05
 			;{type "number" min 0}
 			;Total sample size of model to use (using sampling with replacement) for feature_robust_accuracy_contributions_permutation.
 			;	Defaults to 300.
@@ -946,8 +946,8 @@
 										hyperparam_map custom_hyperparam_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
-										converge_samples_percent_threshold converge_samples_percent_threshold
-										converge_samples_growth_rate converge_samples_growth_rate
+										convergence_threshold convergence_threshold
+										convergence_samples_growth_rate  convergence_samples_growth_rate
 									))
 							)
 					))

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1719,8 +1719,8 @@
 		(assign (assoc
 			feature_residuals_lists
 				(while (not done)
-					;increase the number sampled each iteration by 10 * threshold percentage
-					(accum (assoc num_samples (ceil (* 10 converge_samples_percent_threshold num_samples)) ))
+					;increase the number sampled each iteration by 'converge_samples_growth_rate'
+					(assign (assoc num_samples (ceil (* converge_samples_growth_rate num_samples)) ))
 					(accum (assoc total_samples num_samples))
 
 					;don't exceed the specified maximum of num_feature_probability_samples

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1703,6 +1703,7 @@
 				)
 			first_residuals_lists feature_residuals_lists
 			done (false)
+			max_iterations (ceil (- (/ num_feature_probability_samples num_samples) 1))
 		))
 
 		(assign (assoc
@@ -1775,7 +1776,7 @@
 
 					;at 5000 cases per batch, stop if values converged or after 150k reacts
 					(if (or
-							(>= (current_index) 29)
+							(>= (current_index) max_iterations)
 							(=
 								0
 								(size (filter
@@ -1806,7 +1807,7 @@
 					)
 				)
 		))
-
+(print "FINAL: " (size (first feature_residuals_lists)) ", samples: " num_samples "\n" )
 	)
 
 )

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -460,6 +460,7 @@
 
 		;if 'case_id' are not specified, use a random 'num_samples' sampling of cases from the whole model
 		(if (= 0 (size case_ids))
+			#!SelectCaseIdsForResiduals
 			(assign (assoc
 				case_ids
 					;sample from the model
@@ -1673,4 +1674,139 @@
 				)
 		))
 	)
+
+
+
+	#!AutoConvergeRobustResiduals
+	(seq
+
+		(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
+
+		(declare (assoc
+			previous_residuals_map
+				(zip
+					features
+					(map
+						(lambda (if
+							(size (filter (current_value)))
+							[ (generalized_mean (filter (current_value 1))) (size (filter (current_value 1))) ]
+
+							;else if there were no values for this feature, return global feature residual
+							;or simply null for inactive features
+							(if (contains_index !inactiveFeaturesMap (get features (current_index)))
+								(null)
+								(get hyperparam_map (list "featureResiduals" (get features (current_index 1))))
+							)
+						))
+						feature_residuals_lists
+					)
+				)
+			first_residuals_lists feature_residuals_lists
+			done (false)
+		))
+
+		(assign (assoc
+			feature_residuals_lists
+				(while (not done)
+					(call !SelectCaseIdsForResiduals)
+					(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
+
+					;updated residuals with previous and new values
+					(assign (assoc
+						residuals_map
+							(map
+								(lambda (let
+									(assoc
+										prev_res (first (first (current_value 1)))
+										prev_count (last (first (current_value 1)))
+										new_res (first (last (current_value 1)))
+										new_count (last (last (current_value 1)))
+
+									)
+
+									[
+										;updated mean with the new residual values
+										(/
+											(+
+												(* prev_res prev_count)
+												(* new_res new_count)
+											)
+											(+ prev_count new_count)
+										)
+
+										;new total count
+										(+ prev_count new_count)
+									]
+								))
+
+								previous_residuals_map
+								;newly computed residuals
+								(zip
+									features
+									(map
+										(lambda (if
+											(size (filter (current_value)))
+											[ (generalized_mean (filter (current_value 1))) (size (filter (current_value 1))) ]
+
+											;else if there were no values for this feature, return global feature residual
+											;or simply null for inactive features
+											(if (contains_index !inactiveFeaturesMap (get features (current_index)))
+												(null)
+												(get hyperparam_map (list "featureResiduals" (get features (current_index 1))))
+											)
+										))
+										feature_residuals_lists
+									)
+								)
+							)
+					))
+
+					;compute deltas for each feature: new running avg vs previous running avg
+					(assign (assoc
+						deltas_map
+							(map
+								(lambda (abs
+										(- (first (first (current_value ))) (first (last (current_value))))
+								))
+								previous_residuals_map
+								residuals_map
+							)
+					))
+
+					;at 5000 cases per batch, stop if values converged or after 150k reacts
+					(if (or
+							(>= (current_index) 29)
+							(=
+								0
+								(size (filter
+									;keep those where the delta is > 5%
+									(lambda
+										(>
+											(/ (current_value) (first (get residuals_map (current_index))) )
+											0.02
+										)
+									)
+									deltas_map
+								))
+							)
+						)
+						(assign (assoc done (true) ))
+
+						(assign (assoc previous_residuals_map residuals_map))
+					)
+
+					(map
+						(lambda (append (first (current_value)) (last (current_value)) ))
+
+						(if (= 0 (current_index))
+							first_residuals_lists
+							(previous_result)
+						)
+						feature_residuals_lists
+					)
+				)
+		))
+
+	)
+
 )

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1704,12 +1704,21 @@
 			first_residuals_lists feature_residuals_lists
 			done (false)
 			max_iterations (ceil (- (/ num_feature_probability_samples num_samples) 1))
+			; prev_num_samples 1000
+			; current_num_samples num_samples
 		))
 
 		(assign (assoc
 			feature_residuals_lists
 				(while (not done)
+					; (assign (assoc num_samples (+ current_num_samples prev_num_samples) ))
+					; (assign (assoc prev_num_samples current_num_samples ))
+					; (assign (assoc current_num_samples num_samples))
+					(accum (assoc num_samples 1000))
+					(print "selecting " num_samples " ")
 					(call !SelectCaseIdsForResiduals)
+
+
 					(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
 
 					;updated residuals with previous and new values
@@ -1776,15 +1785,19 @@
 
 					;at 5000 cases per batch, stop if values converged or after 150k reacts
 					(if (or
-							(>= (current_index) max_iterations)
+							;(>= (current_index) max_iterations)
+							(>=
+								(- (/ (* num_samples (- num_samples 1)) 2) 2000)
+								num_feature_probability_samples
+							)
 							(=
 								0
 								(size (filter
-									;keep those where the delta is > 5%
+									;keep those where the delta is > specified %
 									(lambda
 										(>
 											(/ (current_value) (first (get residuals_map (current_index))) )
-											0.02
+											0.01
 										)
 									)
 									deltas_map
@@ -1807,7 +1820,7 @@
 					)
 				)
 		))
-(print "FINAL: " (size (first feature_residuals_lists)) ", samples: " num_samples "\n" )
+(print " FINAL: " (size (first feature_residuals_lists)) " / " num_feature_probability_samples ", samples: " num_samples "\n" )
 	)
 
 )

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1749,7 +1749,7 @@
 						;else randomly select num_samples cases
 						(call !SelectCaseIdsForResiduals)
 					)
-(print " s: " num_samples " " first_case_index " | " )
+
 					(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
 
 					;updated residuals with previous and new values
@@ -1849,7 +1849,7 @@
 					)
 				)
 		))
-(print " FINAL: " (size (first feature_residuals_lists)) " / " num_feature_probability_samples ", last: " num_samples "\n" )
+
 	)
 
 )

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1679,7 +1679,7 @@
 	#!AutoConvergeRobustResiduals
 	(seq
 
-		;when computing robust accuracy contributions, all possible sampled case_ids will be provided
+		;when computing robust accuracy contributions via react_aggregate, all possible sampled case_ids will be provided
 		;make a copy here and set the index to iteratively grab more cases from this preselected list
 		(declare (assoc
 			preselected_case_ids (if (and output_raw_mda (size case_ids)) (replace case_ids))

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1680,6 +1680,17 @@
 	#!AutoConvergeRobustResiduals
 	(seq
 
+		;when computing robust accuracy contributions, all possible sampled case_ids will be provided
+		;make a copy here and set the index to iteratively grab more cases from this preselected list
+		(declare (assoc
+			preselected_case_ids (if (and output_raw_mda (size case_ids)) (replace case_ids))
+			first_case_index (if (and output_raw_mda (size case_ids)) 0)
+		))
+
+		(if (!= (null) first_case_index)
+			(assign (assoc case_ids (unzip preselected_case_ids (range first_case_index (- num_samples 1))) ))
+		)
+
 		(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
 
 		(declare (assoc
@@ -1703,15 +1714,15 @@
 				)
 			first_residuals_lists feature_residuals_lists
 			done (false)
-		;;;	max_iterations (ceil (- (/ num_feature_probability_samples num_samples) 1))
 			total_samples num_samples
+			percent_threshold 0.01
 		))
 
 		(assign (assoc
 			feature_residuals_lists
 				(while (not done)
-					;increase the number sampled each iteration by 1000
-					(accum (assoc num_samples 1000))
+					;increase the number sampled each iteration by 10 * threshold percentage
+					(accum (assoc num_samples (ceil (* 10 percent_threshold num_samples)) ))
 					(accum (assoc total_samples num_samples))
 
 					;don't exceed the specified maximum of num_feature_probability_samples
@@ -1724,8 +1735,23 @@
 						)
 					)
 
-					(call !SelectCaseIdsForResiduals)
-(print " s: " num_samples " " )
+					;if cases were preselected, grab the next batch according to the index
+					(if (!= (null) first_case_index)
+						(seq
+							(assign (assoc first_case_index (- total_samples num_samples) ))
+							(assign (assoc
+								case_ids
+									(unzip
+										preselected_case_ids
+										(range first_case_index (- total_samples 1))
+									)
+							))
+						)
+
+						;else randomly select num_samples cases
+						(call !SelectCaseIdsForResiduals)
+					)
+(print " s: " num_samples " " first_case_index " | " )
 					(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
 
 					;updated residuals with previous and new values
@@ -1792,7 +1818,6 @@
 
 					;stop if values converged or accumulated 'num_feature_probability_samples' reacts
 					(if (or
-							;;; (>= (current_index) max_iterations)
 							(>= total_samples num_feature_probability_samples)
 							(=
 								0
@@ -1801,7 +1826,7 @@
 									(lambda
 										(>
 											(/ (current_value) (first (get residuals_map (current_index))) )
-											0.01
+											percent_threshold
 										)
 									)
 									deltas_map

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1676,8 +1676,8 @@
 	;Helper method that auto converges robust residuals to within the specified convergence_threshold
 	;Since all the robust feature residuals are needed after this method is called to compute accuracy contributions,
 	;this method accumulates all the robust residuals via ever-increasing batches instead of computing them all at once.
-	;Every batch is increased in size by 'convergence_samples_growth_rate ', and accumluation is stopped when the new average
-	;residual for every feature has a delta less than 'convergence_threshold' relative to the running
+	;Every batch is increased in size by 'convergence_samples_growth_rate ', and accumulation is stopped when the new average
+	;residual for every feature has a percent delta less than 'convergence_threshold' relative to the running
 	;average residual value of the accumulated previous batches.
 	#!AutoConvergeRobustResiduals
 	(seq
@@ -1696,7 +1696,7 @@
 			leave_nulls_in_results (true)
 			case_ids
 				(if computing_ac_via_react_aggregate
-					(unzip preselected_case_ids (range 0 (- num_samples 1)))
+					(trunc preselected_case_ids num_samples)
 					case_ids
 				)
 		))
@@ -1811,7 +1811,7 @@
 						deltas_map
 							(map
 								(lambda (abs
-										(- (first (first (current_value ))) (first (last (current_value))))
+									(- (first (first (current_value ))) (first (last (current_value))))
 								))
 								previous_residuals_map
 								residuals_map

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1708,15 +1708,14 @@
 				(zip
 					features
 					(map
-						(lambda (if
-							;filtering out any null values, compute the average robust residual for this feature
-							;and output as a pair of [ avg_residual, count_of_residuals ]
-							(size (filter (current_value)))
-							[ (generalized_mean (filter (current_value 1))) (size (filter (current_value 1))) ]
-
-							;else if there were no values for this feature, return 0s
-							[ 0 0 ]
-						))
+						(lambda
+							;compute the average robust residual for this feature and output as a pair of [ avg_residual, count_of_residuals ]
+							;if values are all nulls, this ensures the tuple is output as [0 0]
+							[
+								(+ (or (generalized_mean (current_value 1)) ))
+								(size (filter (current_value 1)))
+							]
+						)
 						feature_residuals_lists
 					)
 				)
@@ -1793,13 +1792,14 @@
 								(zip
 									features
 									(map
-										(lambda (if
-											(size (filter (current_value)))
-											[ (generalized_mean (filter (current_value 1))) (size (filter (current_value 1))) ]
-
-											;else if there were no values for this feature, return 0s
-											[ 0 0 ]
-										))
+										(lambda
+											;compute the average robust residual for this feature and output as a pair of [ avg_residual, count_of_residuals ]
+											;if values are all nulls, this ensures the tuple is output as [0 0]
+											[
+												(+ (or (generalized_mean (current_value 1)) ))
+												(size (filter (current_value 1)))
+											]
+										)
 										feature_residuals_lists
 									)
 								)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1675,8 +1675,7 @@
 		))
 	)
 
-
-
+	;Helper method that auto converges robust residuals to within the specified converge_samples_percent_threshold
 	#!AutoConvergeRobustResiduals
 	(seq
 
@@ -1715,14 +1714,13 @@
 			first_residuals_lists feature_residuals_lists
 			done (false)
 			total_samples num_samples
-			percent_threshold 0.005
 		))
 
 		(assign (assoc
 			feature_residuals_lists
 				(while (not done)
 					;increase the number sampled each iteration by 10 * threshold percentage
-					(accum (assoc num_samples (ceil (* 10 percent_threshold num_samples)) ))
+					(accum (assoc num_samples (ceil (* 10 converge_samples_percent_threshold num_samples)) ))
 					(accum (assoc total_samples num_samples))
 
 					;don't exceed the specified maximum of num_feature_probability_samples
@@ -1826,7 +1824,7 @@
 									(lambda
 										(>
 											(/ (current_value) (first (get residuals_map (current_index))) )
-											percent_threshold
+											converge_samples_percent_threshold
 										)
 									)
 									deltas_map

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -376,6 +376,44 @@
 		))
 	)
 
+
+	;helper method to sample cases from the model, outputs a list of case ids
+	;if there are more cases than the sample size, randomly select that many cases, by default cases are in random order
+	#!SelectCaseIdsForResiduals
+	(if (and (> num_training_cases num_samples) (> num_training_cases 1000))
+		(if robust_residuals
+			(call !SampleCases (assoc
+				num num_samples
+				rand_seed (rand)
+				case_weight_feature (if valid_weight_feature weight_feature)
+			))
+			;grab samples from the model
+			(call !AllCases (assoc num num_samples rand_seed (rand)))
+		)
+
+		(if robust_residuals
+			(if (= "deviations" robust_residuals)
+				;for local (superfull) deviations, if the dataset is tiny, use more samples than in dataset to compute SDM values
+				(call !SampleCases (assoc
+					num (min num_samples (* num_training_cases (pow 2 (size features))))
+					case_weight_feature (if valid_weight_feature weight_feature)
+				))
+
+				(call !SampleCases (assoc
+					num num_samples
+					case_weight_feature (if valid_weight_feature weight_feature)
+				))
+			)
+
+			;else just use all the case ids because the model size is <= num_samples or the model is small
+			(seq
+				(declare (assoc using_all_cases (true) ))
+				(call !AllCases)
+			)
+		)
+	)
+
+
 	;helper method for !CalculateFeatureResiduals to initialize variables and sample case_ids
 	#!InitResiduals
 	(seq
@@ -460,44 +498,7 @@
 
 		;if 'case_id' are not specified, use a random 'num_samples' sampling of cases from the whole model
 		(if (= 0 (size case_ids))
-			#!SelectCaseIdsForResiduals
-			(assign (assoc
-				case_ids
-					;sample from the model
-					;if there are more cases than the sample size, randomly select that many cases, by default cases are in random order
-					(if (and (> num_training_cases num_samples) (> num_training_cases 1000))
-						(if robust_residuals
-							(call !SampleCases (assoc
-								num num_samples
-								rand_seed (rand)
-								case_weight_feature (if valid_weight_feature weight_feature)
-							))
-							;grab samples from the model
-							(call !AllCases (assoc num num_samples rand_seed (rand)))
-						)
-
-						(if robust_residuals
-							(if (= "deviations" robust_residuals)
-								;for local (superfull) deviations, if the dataset is tiny, use more samples than in dataset to compute SDM values
-								(call !SampleCases (assoc
-									num (min num_samples (* num_training_cases (pow 2 (size features))))
-									case_weight_feature (if valid_weight_feature weight_feature)
-								))
-
-								(call !SampleCases (assoc
-									num num_samples
-									case_weight_feature (if valid_weight_feature weight_feature)
-								))
-							)
-
-							;else just use all the case ids because the model size is <= num_samples or the model is small
-							(seq
-								(declare (assoc using_all_cases (true) ))
-								(call !AllCases)
-							)
-						)
-					)
-			))
+			(assign (assoc case_ids (call !SelectCaseIdsForResiduals) ))
 		)
 
 		;ensure features with nulls have cases that have values for computation but only if the selected cases were not conditioned
@@ -1672,38 +1673,49 @@
 		))
 	)
 
-	;Helper method that auto converges robust residuals to within the specified converge_samples_percent_threshold
+	;Helper method that auto converges robust residuals to within the specified convergence_threshold
+	;Since all the robust feature residuals are needed after this method is called to compute accuracy contributions,
+	;this method accumulates all the robust residuals via ever-increasing batches instead of computing them all at once.
+	;Every batch is increased in size by 'convergence_samples_growth_rate ', and accumluation is stopped when the new average
+	;residual for every feature has a delta less than 'convergence_threshold' relative to the running
+	;average residual value of the accumulated previous batches.
 	#!AutoConvergeRobustResiduals
 	(seq
 
 		;when computing robust accuracy contributions via react_aggregate, all possible sampled case_ids will be provided
 		;make a copy here and set the index to iteratively grab more cases from this preselected list
 		(declare (assoc
-			preselected_case_ids (if (and output_raw_mda (size case_ids)) (replace case_ids))
-			first_case_index (if (and output_raw_mda (size case_ids)) 0)
+			computing_ac_via_react_aggregate (and output_raw_mda (size case_ids))
 		))
-
-		(if (!= (null) first_case_index)
-			(assign (assoc case_ids (unzip preselected_case_ids (range first_case_index (- num_samples 1))) ))
+		(if computing_ac_via_react_aggregate
+			(declare (assoc preselected_case_ids (replace case_ids) ))
 		)
 
-		(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
+		;run the first batch of robust residuals, stores them all into feature_residuals_lists
+		(call !RunRobustResiduals (assoc
+			leave_nulls_in_results (true)
+			case_ids
+				(if computing_ac_via_react_aggregate
+					(unzip preselected_case_ids (range 0 (- num_samples 1)))
+					case_ids
+				)
+		))
 
+		;compute the 'previous_residuals_map' by taking the average of all residuals for a feature
+		;and storing as an assoc of: feature -> [ avg_residual, count_of_residuals ]
 		(declare (assoc
 			previous_residuals_map
 				(zip
 					features
 					(map
 						(lambda (if
+							;filtering out any null values, compute the average robust residual for this feature
+							;and output as a pair of [ avg_residual, count_of_residuals ]
 							(size (filter (current_value)))
 							[ (generalized_mean (filter (current_value 1))) (size (filter (current_value 1))) ]
 
-							;else if there were no values for this feature, return global feature residual
-							;or simply null for inactive features
-							(if (contains_index !inactiveFeaturesMap (get features (current_index)))
-								(null)
-								(get hyperparam_map (list "featureResiduals" (get features (current_index 1))))
-							)
+							;else if there were no values for this feature, return 0s
+							[ 0 0 ]
 						))
 						feature_residuals_lists
 					)
@@ -1713,11 +1725,12 @@
 			total_samples num_samples
 		))
 
+		;store all the accumulated residuals from the while loop into feature_residuals_lists to be used later to compute robust accuracy contributions
 		(assign (assoc
 			feature_residuals_lists
 				(while (not done)
-					;increase the number sampled each iteration by 'converge_samples_growth_rate'
-					(assign (assoc num_samples (ceil (* converge_samples_growth_rate num_samples)) ))
+					;increase the number sampled each iteration by 'convergence_samples_growth_rate '
+					(assign (assoc num_samples (ceil (* convergence_samples_growth_rate  num_samples)) ))
 					(accum (assoc total_samples num_samples))
 
 					;don't exceed the specified maximum of num_feature_probability_samples
@@ -1730,44 +1743,42 @@
 						)
 					)
 
-					;if cases were preselected, grab the next batch according to the index
-					(if (!= (null) first_case_index)
-						(seq
-							(assign (assoc first_case_index (- total_samples num_samples) ))
-							(assign (assoc
-								case_ids
-									(unzip
-										preselected_case_ids
-										(range first_case_index (- total_samples 1))
-									)
-							))
-						)
+					(call !RunRobustResiduals (assoc
+						leave_nulls_in_results (true)
+						case_ids
+							;if cases were preselected in react_aggregate, grab the next batch according to the index
+							(if computing_ac_via_react_aggregate
+								(unzip
+									preselected_case_ids
+									(range (- total_samples num_samples) (- total_samples 1) )
+								)
 
-						;else randomly select num_samples cases
-						(call !SelectCaseIdsForResiduals)
-					)
+								;else randomly select num_samples cases
+								(call !SelectCaseIdsForResiduals)
+							)
+					))
 
-					(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
-
-					;updated residuals with previous and new values
+					;updated residuals map taking into account new values
 					(assign (assoc
 						residuals_map
 							(map
 								(lambda (let
 									(assoc
-										prev_res (first (first (current_value 1)))
+										previous_avg_residual (first (first (current_value 1)))
 										prev_count (last (first (current_value 1)))
-										new_res (first (last (current_value 1)))
+										new_average_residual (first (last (current_value 1)))
 										new_count (last (last (current_value 1)))
-
 									)
 
+									;update the running average, by: multipliying the previous residual by the previous count,
+									;adding the product of the new residual and the new count, and dividing by the updated total count
+									;and store as a pair of [ avg_residual, count_of_residuals ]
 									[
-										;updated mean with the new residual values
+										;updated running mean with the new residual values
 										(/
 											(+
-												(* prev_res prev_count)
-												(* new_res new_count)
+												(* previous_avg_residual prev_count)
+												(* new_average_residual new_count)
 											)
 											(+ prev_count new_count)
 										)
@@ -1786,12 +1797,8 @@
 											(size (filter (current_value)))
 											[ (generalized_mean (filter (current_value 1))) (size (filter (current_value 1))) ]
 
-											;else if there were no values for this feature, return global feature residual
-											;or simply null for inactive features
-											(if (contains_index !inactiveFeaturesMap (get features (current_index)))
-												(null)
-												(get hyperparam_map (list "featureResiduals" (get features (current_index 1))))
-											)
+											;else if there were no values for this feature, return 0s
+											[ 0 0 ]
 										))
 										feature_residuals_lists
 									)
@@ -1821,13 +1828,14 @@
 									(lambda
 										(>
 											(/ (current_value) (first (get residuals_map (current_index))) )
-											converge_samples_percent_threshold
+											convergence_threshold
 										)
 									)
 									deltas_map
 								))
 							)
 						)
+						;need to set loop to done to accumulate the last batch of residuals below insead of simply concluding out of the while loop
 						(assign (assoc done (true) ))
 
 						;else overwrite previous residuals

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1703,22 +1703,29 @@
 				)
 			first_residuals_lists feature_residuals_lists
 			done (false)
-			max_iterations (ceil (- (/ num_feature_probability_samples num_samples) 1))
-			; prev_num_samples 1000
-			; current_num_samples num_samples
+		;;;	max_iterations (ceil (- (/ num_feature_probability_samples num_samples) 1))
+			total_samples num_samples
 		))
 
 		(assign (assoc
 			feature_residuals_lists
 				(while (not done)
-					; (assign (assoc num_samples (+ current_num_samples prev_num_samples) ))
-					; (assign (assoc prev_num_samples current_num_samples ))
-					; (assign (assoc current_num_samples num_samples))
+					;increase the number sampled each iteration by 1000
 					(accum (assoc num_samples 1000))
-					(print "selecting " num_samples " ")
+					(accum (assoc total_samples num_samples))
+
+					;don't exceed the specified maximum of num_feature_probability_samples
+					(if (> total_samples num_feature_probability_samples)
+						(seq
+							(assign (assoc
+								num_samples (- num_samples (- total_samples num_feature_probability_samples) )
+							))
+							(accum (assoc total_samples (- num_feature_probability_samples total_samples ) ))
+						)
+					)
+
 					(call !SelectCaseIdsForResiduals)
-
-
+(print " s: " num_samples " " )
 					(call !RunRobustResiduals (assoc leave_nulls_in_results (true) ))
 
 					;updated residuals with previous and new values
@@ -1783,13 +1790,10 @@
 							)
 					))
 
-					;at 5000 cases per batch, stop if values converged or after 150k reacts
+					;stop if values converged or accumulated 'num_feature_probability_samples' reacts
 					(if (or
-							;(>= (current_index) max_iterations)
-							(>=
-								(- (/ (* num_samples (+ num_samples 1000)) 2000) 1000)
-								num_feature_probability_samples
-							)
+							;;; (>= (current_index) max_iterations)
+							(>= total_samples num_feature_probability_samples)
 							(=
 								0
 								(size (filter
@@ -1806,9 +1810,11 @@
 						)
 						(assign (assoc done (true) ))
 
+						;else overwrite previous residuals
 						(assign (assoc previous_residuals_map residuals_map))
 					)
 
+					;accumulate all the residuals lists for all the features into one big list into (previous_result)
 					(map
 						(lambda (append (first (current_value)) (last (current_value)) ))
 
@@ -1820,7 +1826,7 @@
 					)
 				)
 		))
-(print " FINAL: " (size (first feature_residuals_lists)) " / " num_feature_probability_samples ", samples: " num_samples "\n" )
+(print " FINAL: " (size (first feature_residuals_lists)) " / " num_feature_probability_samples ", last: " num_samples "\n" )
 	)
 
 )

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1787,7 +1787,7 @@
 					(if (or
 							;(>= (current_index) max_iterations)
 							(>=
-								(- (/ (* num_samples (- num_samples 1)) 2) 2000)
+								(- (/ (* num_samples (+ num_samples 1000)) 2000) 1000)
 								num_feature_probability_samples
 							)
 							(=

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1676,7 +1676,7 @@
 	;Helper method that auto converges robust residuals to within the specified convergence_threshold
 	;Since all the robust feature residuals are needed after this method is called to compute accuracy contributions,
 	;this method accumulates all the robust residuals via ever-increasing batches instead of computing them all at once.
-	;Every batch is increased in size by 'convergence_samples_growth_rate ', and accumulation is stopped when the new average
+	;Every batch is increased in size by 'convergence_samples_growth_rate', and accumulation is stopped when the new average
 	;residual for every feature has a percent delta less than 'convergence_threshold' relative to the running
 	;average residual value of the accumulated previous batches.
 	#!AutoConvergeRobustResiduals

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1715,7 +1715,7 @@
 			first_residuals_lists feature_residuals_lists
 			done (false)
 			total_samples num_samples
-			percent_threshold 0.01
+			percent_threshold 0.005
 		))
 
 		(assign (assoc


### PR DESCRIPTION
adds new parameters to analyze() and react_aggregate():

`converge_samples_percent_threshold`: number, percent threshold for used to dynamically limit the number of samples used to determine robust accuracy contributions. Defaults to 0.5, when set to 0 will use all num_robust_accuracy_contributions_samples

`converge_samples_growth_rate`: number, Rate of increasing the size of each subsequent sample used to dynamically limit the total number of samples used to determine feature accuracy contributions. Defaults to 1.05, increasing by 5% until the delta between residuals is less than 'converge_samples_percent_threshold'.

`convergence_min_size`: number, the minimum size of the first batch of cases used when dynamically sampling robust residuals for robust_mda. Default of 5000