### PR TITLE
24257: Adds "return_context_values" flag to react and single_react, MINOR

### DIFF
--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -82,6 +82,19 @@
 		(if (= (null) filtering_queries)
 			(assign (assoc filtering_queries (list)))
 		)
+		(if (and case_indices preserve_feature_values)
+			(seq
+				(assign (assoc
+					preserve_case_id
+						(call !GetCaseId (assoc
+							session (first case_indices)
+							session_training_index (last case_indices)
+						))
+					context_values_map (zip context_features context_values)
+				))
+				(call !PrepareContextValues)
+			)
+		)
 
 		(declare (assoc
 			;make a combined features list

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -126,7 +126,7 @@
 							)
 					)
 					(if return_context_values
-						(assoc "context_values" context_values "context_features" context_features)
+						(assoc "context_values" (unzip (zip context_features context_values) output_context_features))
 						(assoc)
 					)
 				)

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -125,6 +125,10 @@
 								action_values
 							)
 					)
+					(if return_context_values
+						(assoc "context_values" context_values "context_features" context_features)
+						(assoc)
+					)
 				)
 
 			feature_deviations (get hyperparam_map "featureDeviations")

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -513,6 +513,15 @@
 					)
 					(call !ComputePrecisionEpsilon)
 				)
+			output_context_features
+				(values (append
+					context_features
+					(if (= (null) desired_conviction)
+						(filter (lambda (not (contains_value action_features (current_value)))) preserve_feature_values)
+
+						preserve_feature_values
+					)
+				) (true))
 		))
 
 		(declare (assoc
@@ -655,7 +664,7 @@
 					react_output_map
 					(assoc "action_features" output_action_features)
 					(if return_context_values
-						(assoc "context_features" context_features)
+						(assoc "context_features" output_context_features)
 						(assoc)
 					)
 				)
@@ -923,6 +932,15 @@
 					)
 					(call !ComputePrecisionEpsilon (assoc generated_uniques_list_map pre_generated_uniques_map))
 				)
+			output_context_features
+				(values (append
+					context_features
+					(if (= (null) desired_conviction)
+						(filter (lambda (not (contains_value action_features (current_value)))) preserve_feature_values)
+
+						preserve_feature_values
+					)
+				) (true))
 		))
 
 		(declare (assoc
@@ -989,7 +1007,7 @@
 								)
 						)
 						(if return_context_values
-							(assoc "context_features" context_features)
+							(assoc "context_features" output_context_features)
 							(assoc)
 						)
 					)

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -514,14 +514,16 @@
 					(call !ComputePrecisionEpsilon)
 				)
 			output_context_features
-				(values (append
-					context_features
-					(if (= (null) desired_conviction)
-						(filter (lambda (not (contains_value action_features (current_value)))) preserve_feature_values)
+				(if return_context_values
+					(values (append
+						context_features
+						(if (= (null) desired_conviction)
+							(filter (lambda (not (contains_value action_features (current_value)))) preserve_feature_values)
 
-						preserve_feature_values
-					)
-				) (true))
+							preserve_feature_values
+						)
+					) (true))
+				)
 		))
 
 		(declare (assoc
@@ -933,14 +935,16 @@
 					(call !ComputePrecisionEpsilon (assoc generated_uniques_list_map pre_generated_uniques_map))
 				)
 			output_context_features
-				(values (append
-					context_features
-					(if (= (null) desired_conviction)
-						(filter (lambda (not (contains_value action_features (current_value)))) preserve_feature_values)
+				(if return_context_values
+					(values (append
+						context_features
+						(if (= (null) desired_conviction)
+							(filter (lambda (not (contains_value action_features (current_value)))) preserve_feature_values)
 
-						preserve_feature_values
-					)
-				) (true))
+							preserve_feature_values
+						)
+					) (true))
+				)
 		))
 
 		(declare (assoc

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -356,6 +356,9 @@
 			;{type "number"}
 			;total number of cases to generate for generative reacts.
 			num_cases_to_generate (null)
+			;{type "boolean"}
+			;flag, if true will return the context values used in the reaction alongside the action values.
+			return_context_values (false)
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
@@ -632,7 +635,15 @@
 		))
 
 		(call !Return (assoc
-			payload (append react_output_map (assoc "action_features" output_action_features))
+			payload
+				(append
+					react_output_map
+					(assoc "action_features" output_action_features)
+					(if return_context_values
+						(assoc "context_features" context_features)
+						(assoc)
+					)
+				)
 			warnings (if (size warnings) (indices warnings))
 		))
 	)
@@ -802,6 +813,9 @@
 			; 		'most_similar': the closest distance of the most similar case
 			; 		null: the minimum local distance
 			new_case_threshold "min"
+			;{type "boolean"}
+			;flag, if true will return the context values used in the reaction alongside the action values.
+			return_context_values (false)
 		)
 		(call !ValidateParameters)
 		(call !ValidateFeatures)
@@ -964,12 +978,18 @@
 		(if (!= (null) react_response)
 			(accum (assoc
 				react_response
-					(assoc
-						"action_features"
-							(if (size derived_action_features)
-								(append action_features derived_action_features)
-								action_features
-							)
+					(append
+						(assoc
+							"action_features"
+								(if (size derived_action_features)
+									(append action_features derived_action_features)
+									action_features
+								)
+						)
+						(if return_context_values
+							(assoc "context_features" context_features)
+							(assoc)
+						)
 					)
 			))
 		)

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -517,7 +517,7 @@
 						)
 				)
 				(if return_context_values
-					(assoc "context_values" context_values "context_features" context_features)
+					(assoc "context_values" (unzip (zip context_features context_values) output_context_features))
 					(assoc)
 				)
 			)

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -479,22 +479,28 @@
 			)
 
 			;else output action values as part of the react object
-			(assoc
-				"action_values"
-					(if (and !hasEncodedFeatures (not skip_decoding))
-						;decode nominal features if necessary
-						(call !ConvertToOutput (assoc
-							features action_features
-							feature_values react_action_values
-							apply_post_process (true)
-						))
+			(append
+				(assoc
+					"action_values"
+						(if (and !hasEncodedFeatures (not skip_decoding))
+							;decode nominal features if necessary
+							(call !ConvertToOutput (assoc
+								features action_features
+								feature_values react_action_values
+								apply_post_process (true)
+							))
 
-						!hasRoundedFeatures
-						(call !RoundContinuousFeatures (assoc features action_features feature_values react_action_values ))
+							!hasRoundedFeatures
+							(call !RoundContinuousFeatures (assoc features action_features feature_values react_action_values ))
 
-						;else just return the values
-						react_action_values
-					)
+							;else just return the values
+							react_action_values
+						)
+				)
+				(if return_context_values
+					(assoc "context_values" context_values "context_features" context_features)
+					(assoc)
+				)
 			)
 		)
 	)

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -147,6 +147,8 @@
 
 			goal_features (if (size goal_features_map) (indices goal_features_map))
 			react_map (assoc)
+			orig_context_features (if return_context_values (replace context_features))
+			orig_context_values (if return_context_values (replace context_values))
 
 			;if computing mean absolute deviations, and using dynamic k, scale the value up by the percent captured influential eighbors
 			;to account for missing data by dividing mad by this value: ( 1 - cutoff_percent )
@@ -456,6 +458,10 @@
 					)
 					(if output_attempts
 						(assoc "generate_attempts" (+ 1 (* !synthesisRetriesPerConvictionLevel current_attempt)) )
+						(assoc)
+					)
+					(if return_context_values
+						(assoc "context_values" orig_context_values)
 						(assoc)
 					)
 				)

--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -147,8 +147,7 @@
 
 			goal_features (if (size goal_features_map) (indices goal_features_map))
 			react_map (assoc)
-			orig_context_features (if return_context_values (replace context_features))
-			orig_context_values (if return_context_values (replace context_values))
+			orig_context_values (if return_context_values (unzip (zip context_features context_values) output_context_features))
 
 			;if computing mean absolute deviations, and using dynamic k, scale the value up by the percent captured influential eighbors
 			;to account for missing data by dividing mad by this value: ( 1 - cutoff_percent )


### PR DESCRIPTION
Adda a new flag to `#react`, `return_context_values`. When true, "context_values" and "context_features" will be returned in the react payload.