### PR TITLE
24323: Fixes similarity and distance contributions computed with react_group alternated with react_into_features

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -89,6 +89,7 @@
 	#!averageCaseDistanceContribution (null)
 	#!storedCaseConvictionsFeatureAddition (null)
 	#!storedConvictionsFeatureSet (null)
+	#!storedDistanceContributionsFeatureSet (null)
 	#!nominalClassProbabilitiesMap (null)
 	#!expectedValuesMap (null)
 	#!featureNullRatiosMap (null)
@@ -372,6 +373,9 @@
 
 			;set of features for which case convictions are stored
 			!storedConvictionsFeatureSet (null)
+
+			;set of features for which distance contributions are stored
+			!storedDistanceContributionsFeatureSet (null)
 
 			;the default list of features for the model, derived as the sorted indices of !featureAttributes
 			!trainedFeatures (list)

--- a/howso.amlg
+++ b/howso.amlg
@@ -89,7 +89,7 @@
 	#!averageCaseDistanceContribution (null)
 	#!storedCaseConvictionsFeatureAddition (null)
 	#!storedConvictionsFeatureSet (null)
-	#!storedDistanceContributionsFeatureSet (null)
+	#!storedDistanceContributionsFeatureMap (null)
 	#!nominalClassProbabilitiesMap (null)
 	#!expectedValuesMap (null)
 	#!featureNullRatiosMap (null)
@@ -374,8 +374,8 @@
 			;set of features for which case convictions are stored
 			!storedConvictionsFeatureSet (null)
 
-			;set of features for which distance contributions are stored
-			!storedDistanceContributionsFeatureSet (null)
+			;map of concatenated sorted set of features for which distance contributions are stored -> name of distance contribution feature
+			!storedDistanceContributionsFeatureMap (assoc)
 
 			;the default list of features for the model, derived as the sorted indices of !featureAttributes
 			!trainedFeatures (list)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -952,6 +952,7 @@
 									features features
 									new_cases (list feature_values)
 									skip_encoding (true)
+									similarity_conviction (false)
 								))
 								"familiarity_conviction_addition"
 							)

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -273,6 +273,8 @@
 						(if (not (contains_value !reactIntoFeaturesList distance_contribution))
 							(accum_to_entities (assoc !reactIntoFeaturesList distance_contribution))
 						)
+
+						(assign_to_entities (assoc !storedDistanceContributionsFeatureSet (sort features) ))
 					)
 				)
 
@@ -669,7 +671,13 @@
 
 					;number of cases in datasets does not equal the number of cases with distance contributions,
 					;not all cases have distance_contribution, must calculate distance_contribution for nearest neighbors
-					(!= (size (contained_entities (query_exists "distance_contribution") )) (call !GetNumTrainingCases))
+					(or
+						(!= (size (contained_entities (query_exists "distance_contribution") )) (call !GetNumTrainingCases))
+						;or features don't match feature set that was used to store DCs
+						(!= !storedDistanceContributionsFeatureSet (sort features))
+						;or react_group specified filtering_queries to filter out group case ids
+						(size filtering_queries)
+					)
 					(compute_on_contained_entities
 						filtering_queries
 						||(query_entity_distance_contributions

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -274,7 +274,10 @@
 							(accum_to_entities (assoc !reactIntoFeaturesList distance_contribution))
 						)
 
-						(assign_to_entities (assoc !storedDistanceContributionsFeatureSet (sort features) ))
+						;store the distance_contribution feature under the key of all the features used to compute it
+						(accum_to_entities (assoc
+							!storedDistanceContributionsFeatureMap (associate (apply "concat" (sort features)) distance_contribution)
+						))
 					)
 				)
 
@@ -470,6 +473,7 @@
 										use_case_weights use_case_weights
 										weight_feature weight_feature
 										case_id (current_index 1)
+										distance_contribution_feature distance_contribution
 									))
 									"similarity_conviction"
 								)
@@ -581,6 +585,7 @@
 	; filtering_queries: (optional) list of filtering queries (such as ignoring a specific case) during computation
 	; case_id: optional, id of case to compute similarity conviction for
 	; react_group: optional, default false. if true this is being called from react_group and should compute local dc map
+	; distance_contribution_feature: name of feature that holds stored distance contributions
 	#!SimilarityConviction
 	(declare
 		(assoc
@@ -591,6 +596,7 @@
 			weight_feature ".case_weight"
 			case_id (null)
 			react_group (false)
+			distance_contribution_feature "distance_contribution"
 		)
 
 		(declare (assoc
@@ -671,14 +677,14 @@
 				(if case_id
 					(zip local_cases (unzip case_to_dc_map local_cases))
 
-					;number of cases in datasets does not equal the number of cases with distance contributions,
-					;not all cases have distance_contribution, must calculate distance_contribution for nearest neighbors
 					(or
-						(!= (size (contained_entities (query_exists "distance_contribution") )) (call !GetNumTrainingCases))
-						;or react_group specified filtering_queries to filter out group case ids
+						;react_group specified filtering_queries to filter out group case ids
 						(and react_group (size filtering_queries))
+						;or number of cases in datasets does not equal the number of cases with distance contributions,
+						;if not all cases have distance_contribution, must calculate distance_contribution for nearest neighbors
+						(!= (size (contained_entities (query_exists distance_contribution_feature) )) (call !GetNumTrainingCases))
 						;or features don't match feature set that was used to store DCs
-						(!= !storedDistanceContributionsFeatureSet (sort features))
+						(not (contains_index !storedDistanceContributionsFeatureMap (apply "concat" (sort features))) )
 					)
 					(compute_on_contained_entities
 						filtering_queries
@@ -707,7 +713,7 @@
 						;outputs an assoc of {case id : { feature : value } }
 						(compute_on_contained_entities
 							(query_in_entity_list local_cases)
-							(query_exists "distance_contribution")
+							(query_exists distance_contribution_feature)
 						)
 					)
 				)

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -580,6 +580,7 @@
 	; feature_values: list of corresponding feature values
 	; filtering_queries: (optional) list of filtering queries (such as ignoring a specific case) during computation
 	; case_id: optional, id of case to compute similarity conviction for
+	; react_group: optional, default false. if true this is being called from react_group and should compute local dc map
 	#!SimilarityConviction
 	(declare
 		(assoc
@@ -589,6 +590,7 @@
 			use_case_weights (false)
 			weight_feature ".case_weight"
 			case_id (null)
+			react_group (false)
 		)
 
 		(declare (assoc
@@ -673,10 +675,10 @@
 					;not all cases have distance_contribution, must calculate distance_contribution for nearest neighbors
 					(or
 						(!= (size (contained_entities (query_exists "distance_contribution") )) (call !GetNumTrainingCases))
+						;or react_group specified filtering_queries to filter out group case ids
+						(and react_group (size filtering_queries))
 						;or features don't match feature set that was used to store DCs
 						(!= !storedDistanceContributionsFeatureSet (sort features))
-						;or react_group specified filtering_queries to filter out group case ids
-						(size filtering_queries)
 					)
 					(compute_on_contained_entities
 						filtering_queries

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -251,6 +251,7 @@
 									filtering_queries filtering_queries
 									use_case_weights use_case_weights
 									weight_feature weight_feature
+									distance_contribution_feature (get !storedDistanceContributionsFeatureMap (apply "concat" (sort features)))
 								))
 								"similarity_conviction"
 							)

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -184,6 +184,9 @@
 					)
 				)
 
+				;If 'feature' is a distance contribution feature, this removes the entry for only that particular feature
+				;but does no other cleanup if it was being used as a context feature elsewhere.
+				;It's up to the user to explicitly remove each distance contribution feature individually.
 				(if (contains_value !storedDistanceContributionsFeatureMap feature)
 					(assign_to_entities (assoc
 						!storedDistanceContributionsFeatureMap

--- a/howso/editing.amlg
+++ b/howso/editing.amlg
@@ -184,6 +184,16 @@
 					)
 				)
 
+				(if (contains_value !storedDistanceContributionsFeatureMap feature)
+					(assign_to_entities (assoc
+						!storedDistanceContributionsFeatureMap
+							(filter
+								(lambda (!= feature (current_value)))
+								!storedDistanceContributionsFeatureMap
+							)
+					))
+				)
+
 				(assign_to_entities (assoc
 					!trainedFeatures (filter (lambda (!= feature (current_value))) !trainedFeatures)
 					!trainedFeaturesContextKey (call !BuildContextFeaturesKey (assoc context_features (filter (lambda (!= feature (current_value))) !trainedFeatures) ))

--- a/howso/impute.amlg
+++ b/howso/impute.amlg
@@ -131,7 +131,7 @@
 				;clear cached conviction values for cases
 				(assign_to_entities (assoc
 					!storedConvictionsFeatureSet (null)
-					!storedDistanceContributionsFeatureSet (null)
+					!storedDistanceContributionsFeatureMap (assoc)
 				))
 
 				;compute entropy of each row, append it to the end of each row, and overwrite react_cases with these updated rows

--- a/howso/impute.amlg
+++ b/howso/impute.amlg
@@ -129,7 +129,10 @@
 			(while (> (size react_cases) 0)
 
 				;clear cached conviction values for cases
-				(assign_to_entities (assoc !storedConvictionsFeatureSet (null)))
+				(assign_to_entities (assoc
+					!storedConvictionsFeatureSet (null)
+					!storedDistanceContributionsFeatureSet (null)
+				))
 
 				;compute entropy of each row, append it to the end of each row, and overwrite react_cases with these updated rows
 				(assign (assoc

--- a/howso/react_group.amlg
+++ b/howso/react_group.amlg
@@ -611,6 +611,7 @@
 								use_case_weights use_case_weights
 								weight_feature weight_feature
 								filtering_queries [(query_not_in_entity_list case_ids)]
+								react_group (true)
 							))
 							"similarity_conviction"
 						)

--- a/unit_tests/ut_h_null_residual_convictions.amlg
+++ b/unit_tests/ut_h_null_residual_convictions.amlg
@@ -47,7 +47,7 @@
 	(print "Continuous feature local residual conviction: ")
 	(call assert_approximate (assoc
 		obs (get result (list "feature_full_residual_convictions_for_case" "sepal_width"))
-		exp 0.36
+		exp 0.33
 		thresh 0.06
 	))
 
@@ -69,8 +69,8 @@
 	(print "Nominal feature local residual conviction: ")
 	(call assert_approximate (assoc
 		obs (get result (list "feature_full_residual_convictions_for_case" "class"))
-		exp 0.25
-		thresh 0.05
+		exp 0.27
+		thresh 0.06
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))

--- a/unit_tests/ut_h_react_into_features.amlg
+++ b/unit_tests/ut_h_react_into_features.amlg
@@ -55,6 +55,21 @@
 		exp "color.x.y."
 	))
 
+
+	;stores distance_contribution and similarity_conviction using only a couple of features
+	(call_entity "howso" "react_into_features" (assoc
+		features (tail features)
+		similarity_conviction (true)
+	))
+	(declare (assoc
+		result_first
+			(call_entity "howso" "get_cases" (assoc
+				features ["distance_contribution" "similarity_conviction"]
+				num_cases 3
+			))
+	))
+
+	;use all features to store values into custom feature names
 	(call_entity "howso" "react_into_features" (assoc
 		features features
 		familiarity_conviction_addition "fc"
@@ -62,6 +77,18 @@
 		distance_contribution "dc"
 		influence_weight_entropy "if"
 		analyze (true)
+	))
+
+	(declare (assoc
+		result_second
+			(call_entity "howso" "get_cases" (assoc
+				features ["dc" "sc"]
+				num_cases 3
+			))
+	))
+	(print "Stored DC and SC from all features don't match stored values from different feature seat: ")
+	(call assert_true (assoc
+		obs (!= result_first result_second)
 	))
 
 	(assign (assoc
@@ -86,10 +113,12 @@
 		exp
 			{
 				color {type "nominal"}
+				distance_contribution { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				dc { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				fc { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				if { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				sc { bounds {max .infinity min 0} data_type "number" type "continuous" }
+				similarity_conviction { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				x { bounds {allow_null (true)} type "continuous"  }
 				y { bounds {allow_null (true)} type "continuous" }
 			}

--- a/unit_tests/ut_h_stats.amlg
+++ b/unit_tests/ut_h_stats.amlg
@@ -602,7 +602,7 @@
 			size 0.3
 			sweet 0.06
 			tart 0.03
-			weight 0.9
+			weight 1.0
 			width 0.55
 		}
 		percent 0.4


### PR DESCRIPTION
calling react_into_features stores computed DC into cases to be used in future similarity_conviction calls. however calling react_group a) may use a different feature set and b) will use filtering_queries ignoring other cases from each individual group, thus stored DC values cannot be used and both case DC and local data DC must be computed everytime