### PR TITLE
24329: Fixes an issue where returned context values contains feature names rather than values

### DIFF
--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -564,7 +564,7 @@
 								))
 
 
-								(current_value)
+								(get context_values (current_index))
 							)
 						)
 						context_features


### PR DESCRIPTION
This is a specific edge case when requesting context values and using case_indices, preserve_context_values, and pre_process_code_map