### PR TITLE
24507: Fixes autoanalyze during reduce data flow

### DIFF
--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -545,6 +545,7 @@
 
 			(call !AutoAnalyzeIfNeeded (assoc
 				skip_auto_analyze skip_auto_analyze
+				in_reduce_data (true)
 			))
 
 			(if thresholds_enabled

--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -550,6 +550,9 @@
 						)
 					use_case_weights (true)
 					weight_feature weight_feature
+
+					;if in reduce_data flow, compute_all set to true to ensure all cases have the value stored for proper data reduction
+					compute_all in_reduce_data
 				))
 			)
 		)


### PR DESCRIPTION
when reduce_data() is kicked off during training w ablation, it may call autoanalyze. 
during analyze, it recomputes influenceWeightEntropy on a sample of cases and nulls it out for the rest for performance, which breaks reduce_data() since it needs them to be computed on all cases for proper reduction.