### PR TITLE
24515: Refactors format of derived and custom code to not use labels, MAJOR

### DIFF
--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -681,39 +681,26 @@
 						)
 
 						(= "custom" derive_type)
-						(let
-							(assoc
-								;create a map of label -> value for all the labels referenced in the code
-								parsed_code_string_labels_map (get_all_labels (parse (get attributes (list "auto_derive_on_train" "code"))))
-								raw_code_string (get attributes (list "auto_derive_on_train" "code"))
-							)
-							(declare (assoc
-								;parse code to determine which features are being sourced from
-								sourced_features (indices parsed_code_string_labels_map)
-							))
-
-							(map
-								(lambda
-									(let
-										(assoc
-											source_feature_name (current_value 1)
-											derived_features_list (get source_to_derived_feature_map (current_value 1))
-										)
-										(if (= (null) derived_features_list)
-											(assign (assoc derived_features_list (list)))
-										)
-										(accum (assoc
-											source_to_derived_feature_map (associate source_feature_name (replace (append derived_features_list feature)))
-										))
+						(map
+							(lambda
+								(let
+									(assoc
+										source_feature_name (current_value 1)
+										derived_features_list (get source_to_derived_feature_map (current_value 1))
 									)
+									(if (= (null) derived_features_list)
+										(assign (assoc derived_features_list (list)))
+									)
+									(accum (assoc
+										source_to_derived_feature_map (associate source_feature_name (replace (append derived_features_list feature)))
+									))
 								)
-								sourced_features
 							)
+							(call !FeaturesInCustomCode (assoc code (get attributes ["auto_derive_on_train" "code"]) ))
 						)
 					)
 				)
 			)
-
 		))
 		derived_features_map
 	)
@@ -933,7 +920,7 @@
 
 	;output a list of all features referenced in custom code that uses (call !get_val {f <feature name>}) to pull feature values
 	;parameters:
-	; code: custom code to parse and to determine all referenced features
+	; code: custom code string to parse and to determine all referenced features
 	#!FeaturesInCustomCode
 	(let
 		(assoc referenced_features [])

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -918,18 +918,18 @@
 		feature_attributes
 	))
 
-	;output a list of all features referenced in custom code that uses (call get_val {feature <feature name>})
+	;output a list of all features referenced in custom code that uses (call value {feature <feature name>})
 	;to pull feature values by feature name and lag
 	;parameters:
 	; code_string: custom code string to parse and to determine all referenced features
 	#!FeaturesInCustomCode
 	(let
 		(assoc referenced_features [])
-		;recurse through the code and accumulate all feature names from any calls to get_val
+		;recurse through the code and accumulate all feature names from any calls to value
 		(rewrite
 			(lambda
 				(if (= "call" (get_type_string (current_value)))
-					(if (= (lambda get_val) (first (current_value)))
+					(if (= (lambda value) (first (current_value)))
 						(accum (assoc referenced_features (get (current_value 1) [1 "feature"]) ))
 						(current_value)
 					)
@@ -942,7 +942,7 @@
 		(values referenced_features (true))
 	)
 
-	;output the maximum lag value referenced in custom code that uses (call get_val {feature <feature name> lag <lag value>})
+	;output the maximum lag value referenced in custom code that uses (call value {feature <feature name> lag <lag value>})
 	;to pull feature values by feature name and lag
 	;parameters:
 	; code_string: custom code string to parse and to determine max lag value
@@ -952,7 +952,7 @@
 		(rewrite
 			(lambda
 				(if (= "call" (get_type_string (current_value)))
-					(if (= (lambda get_val) (first (current_value)))
+					(if (= (lambda value) (first (current_value)))
 						(if (> (get (current_value ) [1 "lag"]) max_lag)
 							(assign (assoc max_lag (get (current_value 1) [1 "lag"]) ))
 							(current_value)
@@ -977,7 +977,7 @@
 			(lambda
 				(if (and
 						(= "call" (get_type_string (current_value)))
-						(= (lambda get_val) (first (current_value)))
+						(= (lambda value) (first (current_value)))
 						(= 0 (+ (or (get (current_value ) [1 "lag"]))) )
 					)
 					(accum (assoc zero_lag_features (get (current_value 1) [1 "feature"]) ))

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -918,7 +918,7 @@
 		feature_attributes
 	))
 
-	;output a list of all features referenced in custom code that uses (call get_val {f <feature name>})
+	;output a list of all features referenced in custom code that uses (call get_val {feature <feature name>})
 	;to pull feature values by feature name and lag
 	;parameters:
 	; code_string: custom code string to parse and to determine all referenced features
@@ -930,7 +930,7 @@
 			(lambda
 				(if (= "call" (get_type_string (current_value)))
 					(if (= (lambda get_val) (first (current_value)))
-						(accum (assoc referenced_features (get (current_value 1) [1 "f"]) ))
+						(accum (assoc referenced_features (get (current_value 1) [1 "feature"]) ))
 						(current_value)
 					)
 					(current_value)
@@ -942,7 +942,7 @@
 		(values referenced_features (true))
 	)
 
-	;output the maximum lag value referenced in custom code that uses (call get_val {f <feature name> lag <lag value>})
+	;output the maximum lag value referenced in custom code that uses (call get_val {feature <feature name> lag <lag value>})
 	;to pull feature values by feature name and lag
 	;parameters:
 	; code_string: custom code string to parse and to determine max lag value
@@ -980,7 +980,7 @@
 						(= (lambda get_val) (first (current_value)))
 						(= 0 (+ (or (get (current_value ) [1 "lag"]))) )
 					)
-					(accum (assoc zero_lag_features (get (current_value 1) [1 "f"]) ))
+					(accum (assoc zero_lag_features (get (current_value 1) [1 "feature"]) ))
 					(current_value)
 				)
 			)

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -969,7 +969,7 @@
 
 	;returns list of all zero lag features specified in the code
 	;parameters:
-	; code_string: custom code string to pars to determine all features with zero lags
+	; code_string: custom code string to parse to determine all features with zero lags
 	#!ZeroLagFeaturesInCustomCode
 	(let
 		(assoc zero_lag_features [])

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -918,18 +918,18 @@
 		feature_attributes
 	))
 
-	;output a list of all features referenced in custom code that uses (call !get_val {f <feature name>})
+	;output a list of all features referenced in custom code that uses (call get_val {f <feature name>})
 	;to pull feature values by feature name and lag
 	;parameters:
 	; code_string: custom code string to parse and to determine all referenced features
 	#!FeaturesInCustomCode
 	(let
 		(assoc referenced_features [])
-		;recurse through the code and accumulate all feature names from any calls to !get_val
+		;recurse through the code and accumulate all feature names from any calls to get_val
 		(rewrite
 			(lambda
 				(if (= "call" (get_type_string (current_value)))
-					(if (= (lambda !get_val) (first (current_value)))
+					(if (= (lambda get_val) (first (current_value)))
 						(accum (assoc referenced_features (get (current_value 1) [1 "f"]) ))
 						(current_value)
 					)
@@ -942,7 +942,7 @@
 		(values referenced_features (true))
 	)
 
-	;output the maximum lag value referenced in custom code that uses (call !get_val {f <feature name> lag <lag value>})
+	;output the maximum lag value referenced in custom code that uses (call get_val {f <feature name> lag <lag value>})
 	;to pull feature values by feature name and lag
 	;parameters:
 	; code_string: custom code string to parse and to determine max lag value
@@ -952,7 +952,7 @@
 		(rewrite
 			(lambda
 				(if (= "call" (get_type_string (current_value)))
-					(if (= (lambda !get_val) (first (current_value)))
+					(if (= (lambda get_val) (first (current_value)))
 						(if (> (get (current_value ) [1 "lag"]) max_lag)
 							(assign (assoc max_lag (get (current_value 1) [1 "lag"]) ))
 							(current_value)
@@ -977,7 +977,7 @@
 			(lambda
 				(if (and
 						(= "call" (get_type_string (current_value)))
-						(= (lambda !get_val) (first (current_value)))
+						(= (lambda get_val) (first (current_value)))
 						(= 0 (+ (or (get (current_value ) [1 "lag"]))) )
 					)
 					(accum (assoc zero_lag_features (get (current_value 1) [1 "f"]) ))

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -696,7 +696,7 @@
 									))
 								)
 							)
-							(call !FeaturesInCustomCode (assoc code (get attributes ["auto_derive_on_train" "code"]) ))
+							(call !FeaturesInCustomCode (assoc code_string (get attributes ["auto_derive_on_train" "code"]) ))
 						)
 					)
 				)
@@ -912,15 +912,16 @@
 				constraint (get (current_value 1) ["bounds" "constraint"])
 			)
 			(if constraint
-				(call !FeaturesInCustomCode (assoc code constraint))
+				(call !FeaturesInCustomCode (assoc code_string constraint))
 			)
 		))
 		feature_attributes
 	))
 
-	;output a list of all features referenced in custom code that uses (call !get_val {f <feature name>}) to pull feature values
+	;output a list of all features referenced in custom code that uses (call !get_val {f <feature name>})
+	;to pull feature values by feature name and lag
 	;parameters:
-	; code: custom code string to parse and to determine all referenced features
+	; code_string: custom code string to parse and to determine all referenced features
 	#!FeaturesInCustomCode
 	(let
 		(assoc referenced_features [])
@@ -935,9 +936,56 @@
 					(current_value)
 				)
 			)
-			(parse code)
+			(parse code_string)
 		)
 		;output accumulated referenced features
 		(values referenced_features (true))
+	)
+
+	;output the maximum lag value referenced in custom code that uses (call !get_val {f <feature name> lag <lag value>})
+	;to pull feature values by feature name and lag
+	;parameters:
+	; code_string: custom code string to parse and to determine max lag value
+	#!MaxLagInCustomCode
+	(let
+		(assoc max_lag 0)
+		(rewrite
+			(lambda
+				(if (= "call" (get_type_string (current_value)))
+					(if (= (lambda !get_val) (first (current_value)))
+						(if (> (get (current_value ) [1 "lag"]) max_lag)
+							(assign (assoc max_lag (get (current_value 1) [1 "lag"]) ))
+							(current_value)
+						)
+						(current_value)
+					)
+					(current_value)
+				)
+			)
+			(parse code_string)
+		)
+		max_lag
+	)
+
+	;returns list of all zero lag features specified in the code
+	;parameters:
+	; code_string: custom code string to pars to determine all features with zero lags
+	#!ZeroLagFeaturesInCustomCode
+	(let
+		(assoc zero_lag_features [])
+		(rewrite
+			(lambda
+				(if (and
+						(= "call" (get_type_string (current_value)))
+						(= (lambda !get_val) (first (current_value)))
+						(= 0 (+ (or (get (current_value ) [1 "lag"]))) )
+					)
+					(accum (assoc zero_lag_features (get (current_value 1) [1 "f"]) ))
+					(current_value)
+				)
+			)
+			(parse code_string)
+		)
+		(values zero_lag_features (true))
 	)
 )

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -621,7 +621,7 @@
 				)
 				;cache the referenced features in the constraint
 				(if (contains_index bounds_map "constraint")
-					(assoc "constraint_features" (get constraint_referenced_features_map feature) )
+					(assoc "constraint_features" (zip (get constraint_referenced_features_map feature)) )
 					(assoc)
 				)
 			)

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -619,6 +619,11 @@
 						(assoc)
 					)
 				)
+				;cache the referenced features in the constraint
+				(if (contains_index bounds_map "constraint")
+					(assoc "constraint_features" (get constraint_referenced_features_map feature) )
+					(assoc)
+				)
 			)
 		))
 		boundaries_map
@@ -906,12 +911,46 @@
 			)
 			(if constraint
 				;keep feature if it isn't referenced in the constraint
-				(not (contains_index
-					(get_all_labels (parse constraint))
-					feature
-				))
+				(not (contains_value (get constraint_referenced_features_map feature) feature))
 			)
 		))
 		(indices feature_attributes)
+	)
+
+	#!ComposeConstraintReferencedFeaturesMap
+	(filter (map
+		(lambda (let
+			(assoc
+				feature (current_index 1)
+				constraint (get (current_value 1) ["bounds" "constraint"])
+			)
+			(if constraint
+				(call !FeaturesInCustomCode (assoc code constraint))
+			)
+		))
+		feature_attributes
+	))
+
+	;output a list of all features referenced in custom code that uses (call !get_val {f <feature name>}) to pull feature values
+	;parameters:
+	; code: custom code to parse and to determine all referenced features
+	#!FeaturesInCustomCode
+	(let
+		(assoc referenced_features [])
+		;recurse through the code and accumulate all feature names from any calls to !get_val
+		(rewrite
+			(lambda
+				(if (= "call" (get_type_string (current_value)))
+					(if (= (lambda !get_val) (first (current_value)))
+						(accum (assoc referenced_features (get (current_value 1) [1 "f"]) ))
+						(current_value)
+					)
+					(current_value)
+				)
+			)
+			(parse code)
+		)
+		;output accumulated referenced features
+		(values referenced_features (true))
 	)
 )

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -17,7 +17,7 @@
 			;		'allowed': list of explicitly allowed values to be output. Example: ["low", "medium", "high"]
 			;		'allow_null': flag, allow nulls to be output, per their distribution in the data. Defaults to true (false for time feature)
 			;		'constraint': code, whose logic has to evaluate to true for value to be considered valid.
-			;			Same format as 'derived_feature_code. Example: "(> #f1 0 #f2 0)"
+			;			Same format as 'derived_feature_code'. Example: "(> (call !get_val {f \"f1\"}) (call !get_val {f \"f2\"}) )"
 			;       'observed_min': number, string, or date string, the minimum value observed in the data
 			;       'observed_max': number, string, or date string, the maximum value observed in the data
 			;
@@ -74,7 +74,7 @@
 			;
 			;	'auto_derive_on_train': assoc, defines how to create and derive all the values for this feature from
 			;							the trained dataset. For full list of specific 'auto_derive_on_train' feature
-			;							attributes refer the comments at the top of the derive.amlg module.
+			;							attributes refer the comments at the top of the derive_features.amlg module.
 			;
 			;	'derived_feature_code': string, code defining how the value for this feature could be derived if this feature
 			;							is specified as a "derived_context_feature" or a "derived_action_feature" during
@@ -83,13 +83,20 @@
 			;							Each row is comprised of all the combined context and action features. Referencing
 			;							data in these rows uses 0-based indexing, where the current row index is 0, the
 			;							previous row's is 1, etc. Specified code may do simple logic and numeric operations
-			;							on feature values referenced via feature name and row offset.
+			;							on feature values referenced via feature name and row offset. Format to get feature
+			;							value is: (call !get_val { f "feature_name" lag lag_value }) where lag and lag_value
+			;							are optional and only needed if lag > 0.
 			;							Examples:
-			;							"#x 1" - Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).
-			;							"(- #y 0 #x 1)" - Feature 'y' value from current (offset 0) row minus feature 'x' value from previous (offset 1) row.
+			;							"(call !get_val {f \"x\" lag 1})" - Use value for feature 'x' from the previous row (offset of 1, one lag value).
+			;							"(- (call !get_val {f \"y\"})  (call !get_val {f \"x\" lag 1}) )" - Feature 'y' value from
+			;								current (offset 0) row minus feature 'x' value from previous (offset 1) row.
+			;
+			;							Note: Feature names must be explicitly specified as the 'f' parameter and not as output from logic.
+			;							This example code will not work: "(call !get_val {f (call !get_val {f \"another\"}) })" because
+			;							the feature name is determined dynamically from the value of 'another' feature and not specified directly.
 			;
 			;	'post_process': string, custom Amalgam code that is called on resulting values of this feature during react operations.
-			;					Example: "(set_digits #x 0 3.1 (list 1 0) 2 3 (false))"
+			;					Same format as 'derived_feature_code'. Example: "(set_digits (call !get_val {f \"x\"})  3.1 [1 0] 2 3 (false))"
 			;
 			;	'non_sensitive': boolean, flag a categorical nominal feature as non-sensitive. It is recommended that
 			;					all nominal features be represented with either an 'int-id' subtype or another

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -17,7 +17,7 @@
 			;		'allowed': list of explicitly allowed values to be output. Example: ["low", "medium", "high"]
 			;		'allow_null': flag, allow nulls to be output, per their distribution in the data. Defaults to true (false for time feature)
 			;		'constraint': code, whose logic has to evaluate to true for value to be considered valid.
-			;			Same format as 'derived_feature_code'. Example: "(> (call get_val {f \"f1\"}) (call get_val {f \"f2\"}) )"
+			;			Same format as 'derived_feature_code'. Example: "(> (call get_val {feature \"f1\"}) (call get_val {feature \"f2\"}) )"
 			;       'observed_min': number, string, or date string, the minimum value observed in the data
 			;       'observed_max': number, string, or date string, the maximum value observed in the data
 			;
@@ -84,19 +84,19 @@
 			;							data in these rows uses 0-based indexing, where the current row index is 0, the
 			;							previous row's is 1, etc. Specified code may do simple logic and numeric operations
 			;							on feature values referenced via feature name and row offset. Format to get feature
-			;							value is: (call get_val { f "feature_name" lag lag_value }) where lag and lag_value
+			;							value is: (call get_val {feature "feature_name" lag lag_value }) where lag and lag_value
 			;							are optional and only needed if lag > 0.
 			;							Examples:
-			;							"(call get_val {f \"x\" lag 1})" - Use value for feature 'x' from the previous row (offset of 1, one lag value).
-			;							"(- (call get_val {f \"y\"})  (call get_val {f \"x\" lag 1}) )" - Feature 'y' value from
+			;							"(call get_val {feature \"x\" lag 1})" - Use value for feature 'x' from the previous row (offset of 1, one lag value).
+			;							"(- (call get_val {feature \"y\"})  (call get_val {feature \"x\" lag 1}) )" - Feature 'y' value from
 			;								current (offset 0) row minus feature 'x' value from previous (offset 1) row.
 			;
-			;							Note: Feature names must be explicitly specified as the 'f' parameter and not as output from logic.
-			;							This example code will not work: "(call get_val {f (call get_val {f \"another\"}) })" because
+			;							Note: Feature names must be explicitly specified as the 'feature' parameter and not as output from logic.
+			;							This example code will not work: "(call get_val {feature (call get_val {feature \"another\"}) })" because
 			;							the feature name is determined dynamically from the value of 'another' feature and not specified directly.
 			;
 			;	'post_process': string, custom Amalgam code that is called on resulting values of this feature during react operations.
-			;					Same format as 'derived_feature_code'. Example: "(set_digits (call get_val {f \"x\"})  3.1 [1 0] 2 3 (false))"
+			;					Same format as 'derived_feature_code'. Example: "(set_digits (call get_val {feature \"x\"})  3.1 [1 0] 2 3 (false))"
 			;
 			;	'non_sensitive': boolean, flag a categorical nominal feature as non-sensitive. It is recommended that
 			;					all nominal features be represented with either an 'int-id' subtype or another
@@ -682,8 +682,8 @@
 							code_string (get attributes (list "auto_derive_on_train" "code"))
 							get_val
 								(lambda
-									(if (and (>= (- series_row_index lag) 0) (contains_index feat_index_map f))
-										(get series_data (list (- series_row_index lag) (get feat_index_map f)) )
+									(if (and (>= (- series_row_index lag) 0) (contains_index feat_index_map feature))
+										(get series_data (list (- series_row_index lag) (get feat_index_map feature)) )
 									)
 								)
 						))
@@ -709,8 +709,8 @@
 									(lambda
 										;feature label offsets must all be 0 to derive valid values since we can only pull data from the
 										;one existing 'row' of data that is provided for computation. Any values other than 0 output a null.
-										(if (and (= lag 0) (contains_index feature_values_map f))
-											(get feature_values_map f)
+										(if (and (= lag 0) (contains_index feature_values_map feature))
+											(get feature_values_map feature)
 										)
 									)
 							))
@@ -719,16 +719,16 @@
 								code_string raw_code_string
 								get_val
 									(lambda
-										(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map f))
+										(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map feature))
 											(let
 												(assoc
-													val (get series_data [ (- series_row_index lag) (get feature_index_map f) ] )
+													val (get series_data [ (- series_row_index lag) (get feature_index_map feature) ] )
 												)
 
 												;encode datetime by converting string date time into seconds since epoch
-												(if (contains_index !featureDateTimeMap f)
+												(if (contains_index !featureDateTimeMap feature)
 													(if (!= (null) val)
-														(call !ConvertDateToEpoch (assoc date val feature f))
+														(call !ConvertDateToEpoch (assoc "date" val "feature" feature))
 													)
 													;not a datetime, return continuous value
 													val

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -507,6 +507,38 @@
 							custom_derived_features_map
 						)
 				))
+
+				;add a list of all features referenced by the derived code into "code_features"
+				(assign (assoc
+					feature_attributes
+						(map
+							(lambda
+								(if (contains_index custom_derived_features_map (current_index))
+									(if (contains_index (current_value) "auto_derive_on_train")
+										(set
+											(current_value)
+											["auto_derive_on_train" "code_features"]
+											(call !FeaturesInCustomCode (assoc
+												code_string (get (current_value 1) ["auto_derive_on_train" "code"])
+											))
+										)
+
+										;else feature attribute has "derived_feature_code"
+										(set
+											(current_value)
+											"code_features"
+											(call !FeaturesInCustomCode (assoc
+												code_string (get (current_value 1) "derived_feature_code")
+											))
+										)
+									)
+									(current_value)
+								)
+							)
+							feature_attributes
+						)
+				))
+
 				(assign (assoc
 					;filter features, leaving only those with custom derivations
 					custom_derived_features_map
@@ -635,13 +667,10 @@
 					train_derived_method
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get attributes (list "auto_derive_on_train" "code"))
-							label_to_code
+							!get_val
 								(lambda
-									(if (and (>= (- series_row_index label_value) 0) (contains_index feat_index_map label_name))
-										;pull the feature value
-										(get series_data (list (- series_row_index label_value) (get feat_index_map label_name)) )
-
-										(null)
+									(if (and (>= (- series_row_index lag) 0) (contains_index feat_index_map f))
+										(get series_data (list (- series_row_index lag) (get feat_index_map f)) )
 									)
 								)
 						))
@@ -651,17 +680,10 @@
 			;if feature has custom specified derived code, compute and cache it
 			(if (contains_index attributes "derived_feature_code")
 				(let
-					(assoc
-						;create a map of label -> value for all the labels referenced in the code
-						parsed_code_string_labels_map (get_all_labels (parse (get attributes "derived_feature_code")))
-						raw_code_string (get attributes "derived_feature_code")
-					)
-
-					;grab the the largest value in the code to find the max lag
-					(declare (assoc max_row_lag (apply "max" (values parsed_code_string_labels_map))))
+					(assoc raw_code_string (get attributes "derived_feature_code") )
 
 					;add the max_row_lag attribute to this feature attribute
-					(assign "feature_attributes" (list feature "max_row_lag") max_row_lag)
+					(assign "feature_attributes" [ feature "max_row_lag" ] (call !MaxLagInCustomCode (assoc code_string raw_code_string)) )
 
 					;cache the parsed single and series react derived custom code methods for this feature
 					(assoc
@@ -670,41 +692,35 @@
 						"react"
 							(call !ParseDerivedFeatureCode (assoc
 								code_string raw_code_string
-								label_to_code
+								!get_val
 									(lambda
 										;feature label offsets must all be 0 to derive valid values since we can only pull data from the
 										;one existing 'row' of data that is provided for computation. Any values other than 0 output a null.
-										(if (and (= label_value 0) (contains_index feature_values_map label_name))
-											(get feature_values_map label_name)
-											(null)
+										(if (and (= lag 0) (contains_index feature_values_map f))
+											(get feature_values_map f)
 										)
 									)
 							))
 						"series_react"
 							(call !ParseDerivedFeatureCode (assoc
 								code_string raw_code_string
-								label_to_code
+								!get_val
 									(lambda
-										(if (and (>= (- series_row_index label_value) 0) (contains_index feature_index_map label_name))
+										(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map f))
 											(let
 												(assoc
-													val
-														(get series_data (list (- series_row_index label_value) (get feature_index_map label_name)) )
+													val (get series_data [ (- series_row_index lag) (get feature_index_map f) ] )
 												)
 
 												;encode datetime by converting string date time into seconds since epoch
-												(if (contains_index !featureDateTimeMap label_name)
+												(if (contains_index !featureDateTimeMap f)
 													(if (!= (null) val)
-														(call !ConvertDateToEpoch (assoc date val feature label_name))
+														(call !ConvertDateToEpoch (assoc date val feature f))
 													)
-
 													;not a datetime, return continuous value
 													val
 												)
 											)
-
-											;invalid input
-											(null)
 										)
 									)
 							))

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -281,6 +281,8 @@
 			)
 		)
 
+		(declare (assoc constraint_referenced_features_map (call !ComposeConstraintReferencedFeaturesMap) ))
+
 		(declare (assoc invalid_constraint_features (call !ComposeInvalidConstraintFeatures) ))
 
 		(if (size invalid_constraint_features)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -17,7 +17,7 @@
 			;		'allowed': list of explicitly allowed values to be output. Example: ["low", "medium", "high"]
 			;		'allow_null': flag, allow nulls to be output, per their distribution in the data. Defaults to true (false for time feature)
 			;		'constraint': code, whose logic has to evaluate to true for value to be considered valid.
-			;			Same format as 'derived_feature_code'. Example: "(> (call get_val {feature \"f1\"}) (call get_val {feature \"f2\"}) )"
+			;			Same format as 'derived_feature_code'. Example: "(> (call value {feature \"f1\"}) (call value {feature \"f2\"}) )"
 			;       'observed_min': number, string, or date string, the minimum value observed in the data
 			;       'observed_max': number, string, or date string, the maximum value observed in the data
 			;
@@ -84,19 +84,19 @@
 			;							data in these rows uses 0-based indexing, where the current row index is 0, the
 			;							previous row's is 1, etc. Specified code may do simple logic and numeric operations
 			;							on feature values referenced via feature name and row offset. Format to get feature
-			;							value is: (call get_val {feature "feature_name" lag lag_value }) where lag and lag_value
+			;							value is: (call value {feature "feature_name" lag lag_value }) where lag and lag_value
 			;							are optional and only needed if lag > 0.
 			;							Examples:
-			;							"(call get_val {feature \"x\" lag 1})" - Use value for feature 'x' from the previous row (offset of 1, one lag value).
-			;							"(- (call get_val {feature \"y\"})  (call get_val {feature \"x\" lag 1}) )" - Feature 'y' value from
+			;							"(call value {feature \"x\" lag 1})" - Use value for feature 'x' from the previous row (offset of 1, one lag value).
+			;							"(- (call value {feature \"y\"})  (call value {feature \"x\" lag 1}) )" - Feature 'y' value from
 			;								current (offset 0) row minus feature 'x' value from previous (offset 1) row.
 			;
 			;							Note: Feature names must be explicitly specified as the 'feature' parameter and not as output from logic.
-			;							This example code will not work: "(call get_val {feature (call get_val {feature \"another\"}) })" because
+			;							This example code will not work: "(call value {feature (call value {feature \"another\"}) })" because
 			;							the feature name is determined dynamically from the value of 'another' feature and not specified directly.
 			;
 			;	'post_process': string, custom Amalgam code that is called on resulting values of this feature during react operations.
-			;					Same format as 'derived_feature_code'. Example: "(set_digits (call get_val {feature \"x\"})  3.1 [1 0] 2 3 (false))"
+			;					Same format as 'derived_feature_code'. Example: "(set_digits (call value {feature \"x\"})  3.1 [1 0] 2 3 (false))"
 			;
 			;	'non_sensitive': boolean, flag a categorical nominal feature as non-sensitive. It is recommended that
 			;					all nominal features be represented with either an 'int-id' subtype or another
@@ -680,7 +680,7 @@
 					train_derived_method
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get attributes (list "auto_derive_on_train" "code"))
-							get_val
+							value
 								(lambda
 									(if (and (>= (- series_row_index lag) 0) (contains_index feat_index_map feature))
 										(get series_data (list (- series_row_index lag) (get feat_index_map feature)) )
@@ -705,7 +705,7 @@
 						"react"
 							(call !ParseDerivedFeatureCode (assoc
 								code_string raw_code_string
-								get_val
+								value
 									(lambda
 										;feature label offsets must all be 0 to derive valid values since we can only pull data from the
 										;one existing 'row' of data that is provided for computation. Any values other than 0 output a null.
@@ -717,7 +717,7 @@
 						"series_react"
 							(call !ParseDerivedFeatureCode (assoc
 								code_string raw_code_string
-								get_val
+								value
 									(lambda
 										(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map feature))
 											(let

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -17,7 +17,7 @@
 			;		'allowed': list of explicitly allowed values to be output. Example: ["low", "medium", "high"]
 			;		'allow_null': flag, allow nulls to be output, per their distribution in the data. Defaults to true (false for time feature)
 			;		'constraint': code, whose logic has to evaluate to true for value to be considered valid.
-			;			Same format as 'derived_feature_code'. Example: "(> (call !get_val {f \"f1\"}) (call !get_val {f \"f2\"}) )"
+			;			Same format as 'derived_feature_code'. Example: "(> (call get_val {f \"f1\"}) (call get_val {f \"f2\"}) )"
 			;       'observed_min': number, string, or date string, the minimum value observed in the data
 			;       'observed_max': number, string, or date string, the maximum value observed in the data
 			;
@@ -84,19 +84,19 @@
 			;							data in these rows uses 0-based indexing, where the current row index is 0, the
 			;							previous row's is 1, etc. Specified code may do simple logic and numeric operations
 			;							on feature values referenced via feature name and row offset. Format to get feature
-			;							value is: (call !get_val { f "feature_name" lag lag_value }) where lag and lag_value
+			;							value is: (call get_val { f "feature_name" lag lag_value }) where lag and lag_value
 			;							are optional and only needed if lag > 0.
 			;							Examples:
-			;							"(call !get_val {f \"x\" lag 1})" - Use value for feature 'x' from the previous row (offset of 1, one lag value).
-			;							"(- (call !get_val {f \"y\"})  (call !get_val {f \"x\" lag 1}) )" - Feature 'y' value from
+			;							"(call get_val {f \"x\" lag 1})" - Use value for feature 'x' from the previous row (offset of 1, one lag value).
+			;							"(- (call get_val {f \"y\"})  (call get_val {f \"x\" lag 1}) )" - Feature 'y' value from
 			;								current (offset 0) row minus feature 'x' value from previous (offset 1) row.
 			;
 			;							Note: Feature names must be explicitly specified as the 'f' parameter and not as output from logic.
-			;							This example code will not work: "(call !get_val {f (call !get_val {f \"another\"}) })" because
+			;							This example code will not work: "(call get_val {f (call get_val {f \"another\"}) })" because
 			;							the feature name is determined dynamically from the value of 'another' feature and not specified directly.
 			;
 			;	'post_process': string, custom Amalgam code that is called on resulting values of this feature during react operations.
-			;					Same format as 'derived_feature_code'. Example: "(set_digits (call !get_val {f \"x\"})  3.1 [1 0] 2 3 (false))"
+			;					Same format as 'derived_feature_code'. Example: "(set_digits (call get_val {f \"x\"})  3.1 [1 0] 2 3 (false))"
 			;
 			;	'non_sensitive': boolean, flag a categorical nominal feature as non-sensitive. It is recommended that
 			;					all nominal features be represented with either an 'int-id' subtype or another
@@ -680,7 +680,7 @@
 					train_derived_method
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get attributes (list "auto_derive_on_train" "code"))
-							!get_val
+							get_val
 								(lambda
 									(if (and (>= (- series_row_index lag) 0) (contains_index feat_index_map f))
 										(get series_data (list (- series_row_index lag) (get feat_index_map f)) )
@@ -705,7 +705,7 @@
 						"react"
 							(call !ParseDerivedFeatureCode (assoc
 								code_string raw_code_string
-								!get_val
+								get_val
 									(lambda
 										;feature label offsets must all be 0 to derive valid values since we can only pull data from the
 										;one existing 'row' of data that is provided for computation. Any values other than 0 output a null.
@@ -717,7 +717,7 @@
 						"series_react"
 							(call !ParseDerivedFeatureCode (assoc
 								code_string raw_code_string
-								!get_val
+								get_val
 									(lambda
 										(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map f))
 											(let

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -514,7 +514,10 @@
 						(map
 							(lambda
 								(if (contains_index custom_derived_features_map (current_index))
-									(if (contains_index (current_value) "auto_derive_on_train")
+									(if (and
+											(contains_index (current_value) "auto_derive_on_train")
+											(contains_index (get (current_value) "auto_derive_on_train") "code")
+										)
 										(set
 											(current_value)
 											["auto_derive_on_train" "code_features"]
@@ -523,7 +526,7 @@
 											))
 										)
 
-										;else feature attribute has "derived_feature_code"
+										(contains_index (current_value) "derived_feature_code")
 										(set
 											(current_value)
 											"code_features"
@@ -531,6 +534,9 @@
 												code_string (get (current_value 1) "derived_feature_code")
 											))
 										)
+
+										;else progress features have auto_derive_on_train but do not specify "code" and should be left as-is
+										(current_value)
 									)
 									(current_value)
 								)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -734,7 +734,7 @@
 					[(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [action_feature "derived_feature_code"])
-							get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
+							get_val (lambda (if (= lag 0) (get case feature) ) )
 						))
 						{"case" (append case_values_map values_for_derivation_map)}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -70,11 +70,6 @@
 
 		(if derive_action_feature
 			(seq
-				(declare (assoc
-					features_for_derivation (indices (get_all_labels (parse (get !featureAttributes [action_feature "derived_feature_code"]) )))
-					;will be used to indicate which features to predict for derivation
-				))
-
 				(if !tsTimeFeature
 					(let
 						(assoc
@@ -90,7 +85,7 @@
 											)
 										)
 									)
-									features_for_derivation
+									(get !featureAttributes [action_feature "code_features"])
 								))
 						)
 
@@ -739,15 +734,7 @@
 					[(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [action_feature "derived_feature_code"])
-							label_to_code
-								(lambda
-									(if (= (lambda label_value) 0)
-										;pull the feature value
-										(get case (lambda label_name))
-
-										(null)
-									)
-								)
+							!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
 						))
 						{"case" (append case_values_map values_for_derivation_map)}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -734,7 +734,7 @@
 					[(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [action_feature "derived_feature_code"])
-							!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
+							get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
 						))
 						{"case" (append case_values_map values_for_derivation_map)}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/contributions.amlg
+++ b/howso/contributions.amlg
@@ -734,7 +734,7 @@
 					[(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [action_feature "derived_feature_code"])
-							get_val (lambda (if (= lag 0) (get case feature) ) )
+							value (lambda (if (= lag 0) (get case feature) ) )
 						))
 						{"case" (append case_values_map values_for_derivation_map)}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -289,24 +289,24 @@
 		)
 	)
 
-	;rewrites the code in code_string by replacing all instances of (call get_val { f <feature> lag <lag> }) with inlined
-	;code from the get_val method, replacing all 'f' with the actual feature and all 'lag' with the actual lag value
+	;rewrites the code in code_string by replacing all instances of (call get_val {feature <feature> lag <lag> }) with inlined
+	;code from the get_val method, replacing all 'feature' with the actual feature and all 'lag' with the actual lag value
 	#!ParseDerivedFeatureCode
 	(rewrite
 		(lambda
 			(if (= "call" (get_type_string (current_value)))
 				(if (= (lambda get_val) (first (current_value)))
-					;if this node is (call get_val { f .. lag ...}), rewrite it
+					;if this node is (call get_val {feature .. lag ...}), rewrite it
 					;by pulling out the actual feature and lag values and inlining the code from the !get_val_method
 					(let
 						(assoc
-							feature (get (current_value 1) [1 "f"])
+							feature (get (current_value 1) [1 "feature"])
 							lag (+ (or (get (current_value 1) [1 "lag"]) ) )
 						)
 						(rewrite
 							(lambda
-								;replace instance of 'f' with actual string value, not a reference, by concatenating
-								(if (= (current_value) (lambda f))
+								;replace instance of 'feature' with actual string value, not a reference, by concatenating
+								(if (= (current_value) (lambda feature))
 									(concat feature)
 
 									;replace instance of 'lag' with actual lag value, not a reference, by using get_value
@@ -509,7 +509,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								get_val (lambda (if (= lag 0) (get case f) ) )
+								get_val (lambda (if (= lag 0) (get case feature) ) )
 							))
 						)
 						feature_pre_process_code_map
@@ -524,7 +524,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								get_val (lambda (if (= lag 0) (get case f) ) )
+								get_val (lambda (if (= lag 0) (get case feature) ) )
 							))
 						)
 						feature_post_process_code_map

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -20,9 +20,7 @@
 				(values
 					(apply "append" (map
 						(lambda
-							(indices (get_all_labels
-								(parse (get !featureAttributes [(current_value 1) "auto_derive_on_train" "code"]) )
-							))
+							(get !featureAttributes [(current_value 1) "auto_derive_on_train" "code_features"] )
 						)
 						derived_features
 					))
@@ -291,53 +289,38 @@
 		)
 	)
 
-	;constrains code to the specified list of allowed_opcodes
-	; then it finds any node that has a label and replaces it by a copy of label_to_code,
-	; replacing label_value with the value at the label and label_name with the label name
+	;rewrites the code in code_string by replacing all instances of (call !get_val { f <feature> lag <lag> }) with inlined
+	;code from the !get_val method, replacing all 'f' with the actual feature and all 'lag' with the actual lag value
 	#!ParseDerivedFeatureCode
-	(declare
-		(assoc
-			code_string (null)
-			label_to_code (null)
-		)
-
-		(declare (assoc code (parse code_string)))
-
-		(rewrite
-			(lambda (let
-				(assoc
-					node (current_value 1)
-					label_name (first (get_labels (current_value 1)))
-				)
-
-				(if
-					;if not a label, just use
-					(not label_name)
-					node
-
-					;else need to rewrite label_to_code
-					(rewrite
-						(lambda (let
-							(assoc to_replace_node (current_value 1))
-							(if
-								;replaces instance of 'label_value' found in the passed in label_to_code with the actual node value (i.e., offset)
-								(= to_replace_node (lambda label_value))
-								(get_value node)
-
-								;replaces instance of 'label_name' found in the passed in label_to_code with the actual name of the label (i.e., feature)
-								(= to_replace_node (lambda label_name))
-								(concat label_name)
-
-								to_replace_node
+	(rewrite
+		(lambda
+			(if (= "call" (get_type_string (current_value)))
+				(if (= (lambda !get_val) (first (current_value)))
+					;if this node is (call !get_val { f .. lag ...}), rewrite it
+					;by pulling out the actual feature and lag values and inlining the code from the !get_val_method
+					(let
+						(assoc
+							feature (get (current_value 1) [1 "f"])
+							lag (+ (or (get (current_value 1) [1 "lag"]) ) )
+						)
+						(rewrite
+							(lambda
+								(if (= (current_value) (lambda f))
+									feature
+									(= (current_value) (lambda lag))
+									lag
+									(current_value)
+								)
 							)
-							;to_replace_node
-						))
-						label_to_code
+							!get_val
+						)
 					)
+					(current_value)
 				)
-			))
-			code
+				(current_value)
+			)
 		)
+		(parse code_string)
 	)
 
 	;Derive feature values from the provided features and values using either each derived feature's custom code string or predefined operations and output a list of computed values.
@@ -522,13 +505,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								label_to_code
-									(lambda
-										(if (= (lambda label_value) 0)
-											;pull the feature value
-											(get case (lambda label_name))
-										)
-									)
+								!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
 							))
 						)
 						feature_pre_process_code_map
@@ -543,13 +520,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								label_to_code
-									(lambda
-										(if (= (lambda label_value) 0)
-											;pull the feature value
-											(get case (lambda label_name))
-										)
-									)
+								!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
 							))
 						)
 						feature_post_process_code_map

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -289,14 +289,14 @@
 		)
 	)
 
-	;rewrites the code in code_string by replacing all instances of (call get_val {feature <feature> lag <lag> }) with inlined
-	;code from the get_val method, replacing all 'feature' with the actual feature and all 'lag' with the actual lag value
+	;rewrites the code in code_string by replacing all instances of (call value {feature <feature> lag <lag> }) with inlined
+	;code from the value method, replacing all 'feature' with the actual feature and all 'lag' with the actual lag value
 	#!ParseDerivedFeatureCode
 	(rewrite
 		(lambda
 			(if (= "call" (get_type_string (current_value)))
-				(if (= (lambda get_val) (first (current_value)))
-					;if this node is (call get_val {feature .. lag ...}), rewrite it
+				(if (= (lambda value) (first (current_value)))
+					;if this node is (call value {feature .. lag ...}), rewrite it
 					;by pulling out the actual feature and lag values and inlining the code from the !get_val_method
 					(let
 						(assoc
@@ -316,7 +316,7 @@
 									(current_value)
 								)
 							)
-							get_val
+							value
 						)
 					)
 					(current_value)
@@ -509,7 +509,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								get_val (lambda (if (= lag 0) (get case feature) ) )
+								value (lambda (if (= lag 0) (get case feature) ) )
 							))
 						)
 						feature_pre_process_code_map
@@ -524,7 +524,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								get_val (lambda (if (= lag 0) (get case feature) ) )
+								value (lambda (if (= lag 0) (get case feature) ) )
 							))
 						)
 						feature_post_process_code_map

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -305,10 +305,14 @@
 						)
 						(rewrite
 							(lambda
+								;replace instance of 'f' with actual string value, not a reference, by concatenating
 								(if (= (current_value) (lambda f))
-									feature
+									(concat feature)
+
+									;replace instance of 'lag' with actual lag value, not a reference, by using get_value
 									(= (current_value) (lambda lag))
-									lag
+									(get_value lag)
+
 									(current_value)
 								)
 							)

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -509,7 +509,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
+								!get_val (lambda (if (= lag 0) (get case f) ) )
 							))
 						)
 						feature_pre_process_code_map
@@ -524,7 +524,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
+								!get_val (lambda (if (= lag 0) (get case f) ) )
 							))
 						)
 						feature_post_process_code_map

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -289,14 +289,14 @@
 		)
 	)
 
-	;rewrites the code in code_string by replacing all instances of (call !get_val { f <feature> lag <lag> }) with inlined
-	;code from the !get_val method, replacing all 'f' with the actual feature and all 'lag' with the actual lag value
+	;rewrites the code in code_string by replacing all instances of (call get_val { f <feature> lag <lag> }) with inlined
+	;code from the get_val method, replacing all 'f' with the actual feature and all 'lag' with the actual lag value
 	#!ParseDerivedFeatureCode
 	(rewrite
 		(lambda
 			(if (= "call" (get_type_string (current_value)))
-				(if (= (lambda !get_val) (first (current_value)))
-					;if this node is (call !get_val { f .. lag ...}), rewrite it
+				(if (= (lambda get_val) (first (current_value)))
+					;if this node is (call get_val { f .. lag ...}), rewrite it
 					;by pulling out the actual feature and lag values and inlining the code from the !get_val_method
 					(let
 						(assoc
@@ -316,7 +316,7 @@
 									(current_value)
 								)
 							)
-							!get_val
+							get_val
 						)
 					)
 					(current_value)
@@ -509,7 +509,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								!get_val (lambda (if (= lag 0) (get case f) ) )
+								get_val (lambda (if (= lag 0) (get case f) ) )
 							))
 						)
 						feature_pre_process_code_map
@@ -524,7 +524,7 @@
 							;parse it into code, requires passing case as a map of feature name to value
 							(call !ParseDerivedFeatureCode (assoc
 								code_string (current_value 1)
-								!get_val (lambda (if (= lag 0) (get case f) ) )
+								get_val (lambda (if (= lag 0) (get case f) ) )
 							))
 						)
 						feature_post_process_code_map

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -290,14 +290,25 @@
 	)
 
 	;rewrites the code in code_string by replacing all instances of (call value {feature <feature> lag <lag> }) with inlined
-	;code from the value method, replacing all 'feature' with the actual feature and all 'lag' with the actual lag value
+	;code from the 'value' method, replacing all 'feature' with the actual feature and all 'lag' with the actual lag value
+	;e.g.:
+	;(call !ParseDerivedFeatureCode (assoc
+	;	code_string "(+ (call value {feature \"foo\" lag 2}) (call value {feature \"bar\"}) )"
+	;	value (lambda (if (> lag 0) (get my_map feature) -1))
+	;))
+	; outputs:
+	; (+ (if (> 2 0) (get my_map "foo") -1) (if (> 0 0) (get my_map "bar") -1))
+	;
+	;parameters:
+	; code_string: code to parse as a string
+	; value: method to inline and replace each instance of (call value ...) in the specified code
 	#!ParseDerivedFeatureCode
 	(rewrite
 		(lambda
 			(if (= "call" (get_type_string (current_value)))
 				(if (= (lambda value) (first (current_value)))
 					;if this node is (call value {feature .. lag ...}), rewrite it
-					;by pulling out the actual feature and lag values and inlining the code from the !get_val_method
+					;by pulling out the actual feature and lag values and inlining the code from the 'value' method
 					(let
 						(assoc
 							feature (get (current_value 1) [1 "feature"])

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -15,7 +15,7 @@
 	;				"#x 1" - Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).
 	;				"(- #y 0 #x 1)" - Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offest 1) row.
 	;		'code': string, Code describing how feature could be derived.
-	;				Same format as 'derived_feature_code' as defined in attributes. Example: "(- (call get_val {f \"y\"})  (call get_val {f \"x\" lag 1}) )"
+	;				Same format as 'derived_feature_code' as defined in attributes. Example: "(- (call get_val {feature \"y\"})  (call get_val {feature \"x\" lag 1}) )"
 	;		'series_id_features' : (optional) list of feature name(s) of series for which to derive this feature. A series is the conjunction of all
 	;			the features specified by this attribute.
 	;		'ordered_by_features' : (optional) list of fature name(s) by which to order the series specified by "series_id_features". Series values

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -15,7 +15,7 @@
 	;				"#x 1" - Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).
 	;				"(- #y 0 #x 1)" - Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offest 1) row.
 	;		'code': string, Code describing how feature could be derived.
-	;				Same format as 'derived_feature_code' as defined in attributes. Example: "(- (call get_val {feature \"y\"})  (call get_val {feature \"x\" lag 1}) )"
+	;				Same format as 'derived_feature_code' as defined in attributes. Example: "(- (call value {feature \"y\"})  (call value {feature \"x\" lag 1}) )"
 	;		'series_id_features' : (optional) list of feature name(s) of series for which to derive this feature. A series is the conjunction of all
 	;			the features specified by this attribute.
 	;		'ordered_by_features' : (optional) list of fature name(s) by which to order the series specified by "series_id_features". Series values

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -15,7 +15,7 @@
 	;				"#x 1" - Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).
 	;				"(- #y 0 #x 1)" - Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offest 1) row.
 	;		'code': string, Code describing how feature could be derived.
-	;				Same format as 'derived_feature_code' as defined in attributes. Example: "(- (call !get_val {f \"y\"})  (call !get_val {f \"x\" lag 1}) )"
+	;				Same format as 'derived_feature_code' as defined in attributes. Example: "(- (call get_val {f \"y\"})  (call get_val {f \"x\" lag 1}) )"
 	;		'series_id_features' : (optional) list of feature name(s) of series for which to derive this feature. A series is the conjunction of all
 	;			the features specified by this attribute.
 	;		'ordered_by_features' : (optional) list of fature name(s) by which to order the series specified by "series_id_features". Series values

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -392,10 +392,9 @@
 						series_ordered_by_features
 						(apply "append"
 							(map
-								(lambda (let
-									(assoc raw_code_string (get !featureAttributes (list (current_value 2) "auto_derive_on_train" "code")) )
-									(indices (get_all_labels (parse raw_code_string)))
-								))
+								(lambda
+									(get !featureAttributes [(current_value 1) "auto_derive_on_train" "code_features"])
+								)
 								lag_features
 							)
 						)

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -14,7 +14,8 @@
 	;			Examples:
 	;				"#x 1" - Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).
 	;				"(- #y 0 #x 1)" - Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offest 1) row.
-	;		'code': string, Code describing how feature could be derived. Example: "(- #y 0 #x 1)"
+	;		'code': string, Code describing how feature could be derived.
+	;				Same format as 'derived_feature_code' as defined in attributes. Example: "(- (call !get_val {f \"y\"})  (call !get_val {f \"x\" lag 1}) )"
 	;		'series_id_features' : (optional) list of feature name(s) of series for which to derive this feature. A series is the conjunction of all
 	;			the features specified by this attribute.
 	;		'ordered_by_features' : (optional) list of fature name(s) by which to order the series specified by "series_id_features". Series values

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -302,8 +302,8 @@
 												code_string code_string
 												get_val
 													(lambda
-														(if (and (= lag 0) (contains_index feat_index_map f))
-															(get case (get feat_index_map f))
+														(if (and (= lag 0) (contains_index feat_index_map feature))
+															(get case (get feat_index_map feature))
 														)
 													)
 											))
@@ -335,8 +335,8 @@
 									code_string aggregation_code
 									get_val
 										(lambda
-											(if (and (= lag 0) (contains_index evaluated_map f))
-												(get evaluated_map f)
+											(if (and (= lag 0) (contains_index evaluated_map feature))
+												(get evaluated_map feature)
 											)
 										)
 								))
@@ -422,8 +422,8 @@
 									code_string (current_value 1)
 									get_val
 										(lambda
-											(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map f))
-												(get series_data (list (- series_row_index lag) (get feature_index_map f)) )
+											(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map feature))
+												(get series_data (list (- series_row_index lag) (get feature_index_map feature)) )
 											)
 										)
 								))

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -300,7 +300,7 @@
 										parsed_code
 											(call !ParseDerivedFeatureCode (assoc
 												code_string code_string
-												!get_val
+												get_val
 													(lambda
 														(if (and (= lag 0) (contains_index feat_index_map f))
 															(get case (get feat_index_map f))
@@ -333,7 +333,7 @@
 							parsed_code
 								(call !ParseDerivedFeatureCode (assoc
 									code_string aggregation_code
-									!get_val
+									get_val
 										(lambda
 											(if (and (= lag 0) (contains_index evaluated_map f))
 												(get evaluated_map f)
@@ -420,7 +420,7 @@
 								;parse it into code, requires passing series data as a list of list of values and feat_index_map
 								(call !ParseDerivedFeatureCode (assoc
 									code_string (current_value 1)
-									!get_val
+									get_val
 										(lambda
 											(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map f))
 												(get series_data (list (- series_row_index lag) (get feature_index_map f)) )

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -300,13 +300,10 @@
 										parsed_code
 											(call !ParseDerivedFeatureCode (assoc
 												code_string code_string
-												label_to_code
+												!get_val
 													(lambda
-														(if (and (= (lambda label_value) 0) (contains_index feat_index_map (lambda label_name)))
-															;pull the feature value
-															(get case (get feat_index_map (lambda label_name)))
-
-															(null)
+														(if (and (= lag 0) (contains_index feat_index_map f)) ;;;^^^TODO: wrap in lambdas?
+															(get case (get feat_index_map f))
 														)
 													)
 											))
@@ -336,13 +333,10 @@
 							parsed_code
 								(call !ParseDerivedFeatureCode (assoc
 									code_string aggregation_code
-									label_to_code
+									!get_val
 										(lambda
-											(if (and (= (lambda label_value) 0) (contains_index evaluated_map (lambda label_name)))
-												;pull the feature value
-												(get evaluated_map (lambda label_name))
-
-												(null)
+											(if (and (= lag 0) (contains_index evaluated_map f)) ;;;^^^TODO: wrap in lambdas?
+												(get evaluated_map f)
 											)
 										)
 								))
@@ -409,12 +403,9 @@
 						(map
 							(lambda
 								;store all the needed features as a set (assoc with nulls)
-								(map
-									(lambda (null))
-									(remove
-										(get_all_labels (parse (get feature_post_process_code_map (current_index))))
-										(current_index)
-									)
+								(remove
+									(zip (call !FeaturesInCustomCode (assoc code_string (current_value 1))) )
+									(current_index)
 								)
 							)
 							feature_post_process_code_map
@@ -429,11 +420,10 @@
 								;parse it into code, requires passing series data as a list of list of values and feat_index_map
 								(call !ParseDerivedFeatureCode (assoc
 									code_string (current_value 1)
-									label_to_code
+									!get_val
 										(lambda
-											(if (and (>= (- series_row_index label_value) 0) (contains_index feature_index_map label_name))
-												;pull the feature value
-												(get series_data (list (- series_row_index label_value) (get feature_index_map label_name)) )
+											(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map f))
+												(get series_data (list (- series_row_index lag) (get feature_index_map f)) )
 											)
 										)
 								))

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -300,7 +300,7 @@
 										parsed_code
 											(call !ParseDerivedFeatureCode (assoc
 												code_string code_string
-												get_val
+												value
 													(lambda
 														(if (and (= lag 0) (contains_index feat_index_map feature))
 															(get case (get feat_index_map feature))
@@ -333,7 +333,7 @@
 							parsed_code
 								(call !ParseDerivedFeatureCode (assoc
 									code_string aggregation_code
-									get_val
+									value
 										(lambda
 											(if (and (= lag 0) (contains_index evaluated_map feature))
 												(get evaluated_map feature)
@@ -420,7 +420,7 @@
 								;parse it into code, requires passing series data as a list of list of values and feat_index_map
 								(call !ParseDerivedFeatureCode (assoc
 									code_string (current_value 1)
-									get_val
+									value
 										(lambda
 											(if (and (>= (- series_row_index lag) 0) (contains_index feature_index_map feature))
 												(get series_data (list (- series_row_index lag) (get feature_index_map feature)) )

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -302,7 +302,7 @@
 												code_string code_string
 												!get_val
 													(lambda
-														(if (and (= lag 0) (contains_index feat_index_map f)) ;;;^^^TODO: wrap in lambdas?
+														(if (and (= lag 0) (contains_index feat_index_map f))
 															(get case (get feat_index_map f))
 														)
 													)
@@ -335,7 +335,7 @@
 									code_string aggregation_code
 									!get_val
 										(lambda
-											(if (and (= lag 0) (contains_index evaluated_map f)) ;;;^^^TODO: wrap in lambdas?
+											(if (and (= lag 0) (contains_index evaluated_map f))
 												(get evaluated_map f)
 											)
 										)

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -288,8 +288,9 @@
 							(set
 								(current_value)
 								"derived_feature_code"
-								;format of: "#\"feature_name\" 1" , feature name wrapped in quotes to handle features with spaces
-								(concat "#\"" (current_index) "\" 1")
+								;format of: (call !get_val {f "feature_name" lag 1 }), feature name wrapped in quotes to handle features with spaces
+								(concat "(call !get_val {f \"" (current_index) "\" lag 1 })")
+
 							)
 
 							;else leave feature attributes as-is since derived_feature_code is already defined
@@ -357,26 +358,26 @@
 		(if
 			(= "lag" derivation_type)
 			(assign (assoc
-				output_string (concat  "#\"" feature "\" " lag_amount )
+				output_string (concat "(call !get_val {f \"" feature "\" lag " lag_amount "})" )
 			))
 
 			(= "delta_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ #\"." feature "_lag_1\" 0" )
+					output_string (concat "(+ (call !get_val {f \"" feature "_lag_1\" }) " )
 				))
 				(if (> order 1)
 					(accum (assoc
 						output_string
 							(apply "concat" (range
-								(lambda (concat " #\"." feature "_delta_" (current_index) "\" 1" ))
+								(lambda (concat " (call !get_val {f \"" feature "_delta_" (current_index) "\" lag 1})" ))
 								1 (- order 1) 1
 							))
 					))
 				)
 				;last order is the current delta value
 				(accum (assoc
-					output_string (concat " #\"." feature "_delta_" order "\" 0)" )
+					output_string (concat " (call !get_val {f \"" feature "_delta_" order "\" }) )" )
 				))
 			)
 
@@ -384,17 +385,17 @@
 			(assign (assoc
 				output_string
 					(if (> order 1)
-						(concat "(- #\"." feature "_delta_" (- order 1) "\" 0 #\"." feature "_delta_" (- order 1) "\" 1)" )
+						(concat "(- (call !get_val {f \"" feature "_delta_" (- order 1) "\" }) (call !get_val {f \"" feature "_delta_" (- order 1) "\" lag 1}) )" )
 
 						;else
-						(concat "(- #\"" feature "\" 0 #\"."feature "_lag_1\" 0)" )
+						(concat "(- (call !get_val {f \"" feature "\" }) (call !get_val {f \""feature "_lag_1\" }) )" )
 					)
 			))
 
 			(= "rate_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ #\"." feature "_lag_1\" 0 (* #\"." time_feature "_delta_1\" 0 #\"." feature "_rate_1\" 0)" )
+					output_string (concat "(+ (call !get_val {f \"" feature "_lag_1\" }) (* (call !get_val {f \"" time_feature "_delta_1\" }) (call !get_val {f \"" feature "_rate_1\" }) )" )
 				))
 				(if (> order 1)
 					(accum (assoc
@@ -402,7 +403,7 @@
 							;Taylor series: (rate_x * time_delta^x) / x!
 							(apply "concat" (range
 								(lambda (concat
-									" (/ (* (pow #\"." time_feature "_delta_1\" 0 " (current_index) ") #\"." feature "_rate_" (current_index)  "\" 0) " (apply "*" (range 1 (current_index)))  ")"
+									" (/ (* (pow (call !get_val {f \"" time_feature "_delta_1\" }) " (current_index) ") (call !get_val {f \"" feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
 								))
 								2 order 1
 							))
@@ -418,10 +419,10 @@
 				output_string
 					(if (> order 1)
 						;diff between previous order rates / time_delta
-						(concat "(/ (- #\"." feature "_rate_" (- order 1) "\" 0 #\"." feature "_rate_" (- order 1) "\" 1) (max #\"." time_feature "_delta_1\" 0 " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call !get_val {f \"" feature "_rate_" (- order 1) "\" }) (call !get_val {f \"" feature "_rate_" (- order 1) "\" lag 1}) ) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 
 						;else
-						(concat "(/ (- #\"" feature "\" 0 #\"." feature "_lag_1\" 0) (max #\"." time_feature "_delta_1\" 0 " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call !get_val {f \"" feature "\" }) (call !get_val {f \"" feature "_lag_1\" }) ) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 					)
 			))
 
@@ -429,14 +430,14 @@
 			(assign (assoc
 				; rate_order[1] + rate_next_order[0] * time_delta
 				output_string
-					(concat "(+ #\"." feature "_rate_" order "\" 1 (* #\"." feature "_rate_" (+ order 1) "\" 0 (max #\"." time_feature "_delta_1\" 0 " !tsMinTimeInterval ")))" )
+					(concat "(+ (call !get_val {f \"" feature "_rate_" order "\" lag 1 }) (* (call !get_val {f \"" feature "_rate_" (+ order 1) "\" }) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
 			))
 
 			(= "delta_derived")
 			(assign (assoc
 				; delta_order[1] + delta_next_order[0]
 				output_string
-					(concat "(+ #\"." feature "_delta_" order "\" 1 #\"." feature "_delta_" (+ order 1) "\" 0)" )
+					(concat "(+ (call !get_val {f \"" feature "_delta_" order "\" lag 1 }) (call !get_val {f \"" feature "_delta_" (+ order 1) "\" }) )" )
 			))
 		)
 
@@ -615,7 +616,7 @@
 					".series_progress"
 						(assoc
 							"type" "continuous"
-							"derived_feature_code" "(min 1 (+ #.series_progress 1 #.series_progress_delta 1))"
+							"derived_feature_code" "(min 1 (+ (call !get_val {f \".series_progress\" lag 1}) (call !get_val {f \".series_progress_delta\" lag 1}) ))"
 							"auto_derive_on_train"
 								(assoc
 									"derive_type" "progress"

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -395,7 +395,7 @@
 			(= "rate_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call !get_val {f \"." feature "_lag_1\" }) (* (call !get_val {f \"" time_feature "_delta_1\" }) (call !get_val {f \"." feature "_rate_1\" }) )" )
+					output_string (concat "(+ (call !get_val {f \"." feature "_lag_1\" }) (* (call !get_val {f \"." time_feature "_delta_1\" }) (call !get_val {f \"." feature "_rate_1\" }) )" )
 				))
 				(if (> order 1)
 					(accum (assoc
@@ -403,7 +403,7 @@
 							;Taylor series: (rate_x * time_delta^x) / x!
 							(apply "concat" (range
 								(lambda (concat
-									" (/ (* (pow (call !get_val {f \"" time_feature "_delta_1\" }) " (current_index) ") (call !get_val {f \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
+									" (/ (* (pow (call !get_val {f \"." time_feature "_delta_1\" }) " (current_index) ") (call !get_val {f \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
 								))
 								2 order 1
 							))
@@ -419,10 +419,10 @@
 				output_string
 					(if (> order 1)
 						;diff between previous order rates / time_delta
-						(concat "(/ (- (call !get_val {f \"." feature "_rate_" (- order 1) "\" }) (call !get_val {f \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call !get_val {f \"." feature "_rate_" (- order 1) "\" }) (call !get_val {f \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call !get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 
 						;else
-						(concat "(/ (- (call !get_val {f \"" feature "\" }) (call !get_val {f \"." feature "_lag_1\" }) ) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call !get_val {f \"" feature "\" }) (call !get_val {f \"." feature "_lag_1\" }) ) (max (call !get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 					)
 			))
 
@@ -430,7 +430,7 @@
 			(assign (assoc
 				; rate_order[1] + rate_next_order[0] * time_delta
 				output_string
-					(concat "(+ (call !get_val {f \"." feature "_rate_" order "\" lag 1 }) (* (call !get_val {f \"." feature "_rate_" (+ order 1) "\" }) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
+					(concat "(+ (call !get_val {f \"." feature "_rate_" order "\" lag 1 }) (* (call !get_val {f \"." feature "_rate_" (+ order 1) "\" }) (max (call !get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
 			))
 
 			(= "delta_derived")

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -288,8 +288,8 @@
 							(set
 								(current_value)
 								"derived_feature_code"
-								;format of: (call get_val {f "feature_name" lag 1 }), feature name wrapped in quotes to handle features with spaces
-								(concat "(call get_val {f \"" (current_index) "\" lag 1 })")
+								;format of: (call get_val {feature "feature_name" lag 1 }), feature name wrapped in quotes to handle features with spaces
+								(concat "(call get_val {feature \"" (current_index) "\" lag 1 })")
 
 							)
 
@@ -358,26 +358,26 @@
 		(if
 			(= "lag" derivation_type)
 			(assign (assoc
-				output_string (concat "(call get_val {f \"" feature "\" lag " lag_amount "})" )
+				output_string (concat "(call get_val {feature \"" feature "\" lag " lag_amount "})" )
 			))
 
 			(= "delta_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call get_val {f \"." feature "_lag_1\" }) " )
+					output_string (concat "(+ (call get_val {feature \"." feature "_lag_1\" }) " )
 				))
 				(if (> order 1)
 					(accum (assoc
 						output_string
 							(apply "concat" (range
-								(lambda (concat " (call get_val {f \"." feature "_delta_" (current_index) "\" lag 1})" ))
+								(lambda (concat " (call get_val {feature \"." feature "_delta_" (current_index) "\" lag 1})" ))
 								1 (- order 1) 1
 							))
 					))
 				)
 				;last order is the current delta value
 				(accum (assoc
-					output_string (concat " (call get_val {f \"." feature "_delta_" order "\" }) )" )
+					output_string (concat " (call get_val {feature \"." feature "_delta_" order "\" }) )" )
 				))
 			)
 
@@ -385,17 +385,17 @@
 			(assign (assoc
 				output_string
 					(if (> order 1)
-						(concat "(- (call get_val {f \"." feature "_delta_" (- order 1) "\" }) (call get_val {f \"." feature "_delta_" (- order 1) "\" lag 1}) )" )
+						(concat "(- (call get_val {feature \"." feature "_delta_" (- order 1) "\" }) (call get_val {feature \"." feature "_delta_" (- order 1) "\" lag 1}) )" )
 
 						;else
-						(concat "(- (call get_val {f \"" feature "\" }) (call get_val {f \"."feature "_lag_1\" }) )" )
+						(concat "(- (call get_val {feature \"" feature "\" }) (call get_val {feature \"."feature "_lag_1\" }) )" )
 					)
 			))
 
 			(= "rate_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call get_val {f \"." feature "_lag_1\" }) (* (call get_val {f \"." time_feature "_delta_1\" }) (call get_val {f \"." feature "_rate_1\" }) )" )
+					output_string (concat "(+ (call get_val {feature \"." feature "_lag_1\" }) (* (call get_val {feature \"." time_feature "_delta_1\" }) (call get_val {feature \"." feature "_rate_1\" }) )" )
 				))
 				(if (> order 1)
 					(accum (assoc
@@ -403,7 +403,7 @@
 							;Taylor series: (rate_x * time_delta^x) / x!
 							(apply "concat" (range
 								(lambda (concat
-									" (/ (* (pow (call get_val {f \"." time_feature "_delta_1\" }) " (current_index) ") (call get_val {f \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
+									" (/ (* (pow (call get_val {feature \"." time_feature "_delta_1\" }) " (current_index) ") (call get_val {feature \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
 								))
 								2 order 1
 							))
@@ -419,10 +419,10 @@
 				output_string
 					(if (> order 1)
 						;diff between previous order rates / time_delta
-						(concat "(/ (- (call get_val {f \"." feature "_rate_" (- order 1) "\" }) (call get_val {f \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call get_val {feature \"." feature "_rate_" (- order 1) "\" }) (call get_val {feature \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call get_val {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 
 						;else
-						(concat "(/ (- (call get_val {f \"" feature "\" }) (call get_val {f \"." feature "_lag_1\" }) ) (max (call get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call get_val {feature \"" feature "\" }) (call get_val {feature \"." feature "_lag_1\" }) ) (max (call get_val {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 					)
 			))
 
@@ -430,14 +430,14 @@
 			(assign (assoc
 				; rate_order[1] + rate_next_order[0] * time_delta
 				output_string
-					(concat "(+ (call get_val {f \"." feature "_rate_" order "\" lag 1 }) (* (call get_val {f \"." feature "_rate_" (+ order 1) "\" }) (max (call get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
+					(concat "(+ (call get_val {feature \"." feature "_rate_" order "\" lag 1 }) (* (call get_val {feature \"." feature "_rate_" (+ order 1) "\" }) (max (call get_val {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
 			))
 
 			(= "delta_derived")
 			(assign (assoc
 				; delta_order[1] + delta_next_order[0]
 				output_string
-					(concat "(+ (call get_val {f \"." feature "_delta_" order "\" lag 1 }) (call get_val {f \"." feature "_delta_" (+ order 1) "\" }) )" )
+					(concat "(+ (call get_val {feature \"." feature "_delta_" order "\" lag 1 }) (call get_val {feature \"." feature "_delta_" (+ order 1) "\" }) )" )
 			))
 		)
 
@@ -616,7 +616,7 @@
 					".series_progress"
 						(assoc
 							"type" "continuous"
-							"derived_feature_code" "(min 1 (+ (call get_val {f \".series_progress\" lag 1}) (call get_val {f \".series_progress_delta\" lag 1}) ))"
+							"derived_feature_code" "(min 1 (+ (call get_val {feature \".series_progress\" lag 1}) (call get_val {feature \".series_progress_delta\" lag 1}) ))"
 							"auto_derive_on_train"
 								(assoc
 									"derive_type" "progress"

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -288,8 +288,8 @@
 							(set
 								(current_value)
 								"derived_feature_code"
-								;format of: (call get_val {feature "feature_name" lag 1 }), feature name wrapped in quotes to handle features with spaces
-								(concat "(call get_val {feature \"" (current_index) "\" lag 1 })")
+								;format of: (call value {feature "feature_name" lag 1 }), feature name wrapped in quotes to handle features with spaces
+								(concat "(call value {feature \"" (current_index) "\" lag 1 })")
 
 							)
 
@@ -358,26 +358,26 @@
 		(if
 			(= "lag" derivation_type)
 			(assign (assoc
-				output_string (concat "(call get_val {feature \"" feature "\" lag " lag_amount "})" )
+				output_string (concat "(call value {feature \"" feature "\" lag " lag_amount "})" )
 			))
 
 			(= "delta_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call get_val {feature \"." feature "_lag_1\" }) " )
+					output_string (concat "(+ (call value {feature \"." feature "_lag_1\" }) " )
 				))
 				(if (> order 1)
 					(accum (assoc
 						output_string
 							(apply "concat" (range
-								(lambda (concat " (call get_val {feature \"." feature "_delta_" (current_index) "\" lag 1})" ))
+								(lambda (concat " (call value {feature \"." feature "_delta_" (current_index) "\" lag 1})" ))
 								1 (- order 1) 1
 							))
 					))
 				)
 				;last order is the current delta value
 				(accum (assoc
-					output_string (concat " (call get_val {feature \"." feature "_delta_" order "\" }) )" )
+					output_string (concat " (call value {feature \"." feature "_delta_" order "\" }) )" )
 				))
 			)
 
@@ -385,17 +385,17 @@
 			(assign (assoc
 				output_string
 					(if (> order 1)
-						(concat "(- (call get_val {feature \"." feature "_delta_" (- order 1) "\" }) (call get_val {feature \"." feature "_delta_" (- order 1) "\" lag 1}) )" )
+						(concat "(- (call value {feature \"." feature "_delta_" (- order 1) "\" }) (call value {feature \"." feature "_delta_" (- order 1) "\" lag 1}) )" )
 
 						;else
-						(concat "(- (call get_val {feature \"" feature "\" }) (call get_val {feature \"."feature "_lag_1\" }) )" )
+						(concat "(- (call value {feature \"" feature "\" }) (call value {feature \"."feature "_lag_1\" }) )" )
 					)
 			))
 
 			(= "rate_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call get_val {feature \"." feature "_lag_1\" }) (* (call get_val {feature \"." time_feature "_delta_1\" }) (call get_val {feature \"." feature "_rate_1\" }) )" )
+					output_string (concat "(+ (call value {feature \"." feature "_lag_1\" }) (* (call value {feature \"." time_feature "_delta_1\" }) (call value {feature \"." feature "_rate_1\" }) )" )
 				))
 				(if (> order 1)
 					(accum (assoc
@@ -403,7 +403,7 @@
 							;Taylor series: (rate_x * time_delta^x) / x!
 							(apply "concat" (range
 								(lambda (concat
-									" (/ (* (pow (call get_val {feature \"." time_feature "_delta_1\" }) " (current_index) ") (call get_val {feature \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
+									" (/ (* (pow (call value {feature \"." time_feature "_delta_1\" }) " (current_index) ") (call value {feature \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
 								))
 								2 order 1
 							))
@@ -419,10 +419,10 @@
 				output_string
 					(if (> order 1)
 						;diff between previous order rates / time_delta
-						(concat "(/ (- (call get_val {feature \"." feature "_rate_" (- order 1) "\" }) (call get_val {feature \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call get_val {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call value {feature \"." feature "_rate_" (- order 1) "\" }) (call value {feature \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call value {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 
 						;else
-						(concat "(/ (- (call get_val {feature \"" feature "\" }) (call get_val {feature \"." feature "_lag_1\" }) ) (max (call get_val {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call value {feature \"" feature "\" }) (call value {feature \"." feature "_lag_1\" }) ) (max (call value {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 					)
 			))
 
@@ -430,14 +430,14 @@
 			(assign (assoc
 				; rate_order[1] + rate_next_order[0] * time_delta
 				output_string
-					(concat "(+ (call get_val {feature \"." feature "_rate_" order "\" lag 1 }) (* (call get_val {feature \"." feature "_rate_" (+ order 1) "\" }) (max (call get_val {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
+					(concat "(+ (call value {feature \"." feature "_rate_" order "\" lag 1 }) (* (call value {feature \"." feature "_rate_" (+ order 1) "\" }) (max (call value {feature \"." time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
 			))
 
 			(= "delta_derived")
 			(assign (assoc
 				; delta_order[1] + delta_next_order[0]
 				output_string
-					(concat "(+ (call get_val {feature \"." feature "_delta_" order "\" lag 1 }) (call get_val {feature \"." feature "_delta_" (+ order 1) "\" }) )" )
+					(concat "(+ (call value {feature \"." feature "_delta_" order "\" lag 1 }) (call value {feature \"." feature "_delta_" (+ order 1) "\" }) )" )
 			))
 		)
 
@@ -616,7 +616,7 @@
 					".series_progress"
 						(assoc
 							"type" "continuous"
-							"derived_feature_code" "(min 1 (+ (call get_val {feature \".series_progress\" lag 1}) (call get_val {feature \".series_progress_delta\" lag 1}) ))"
+							"derived_feature_code" "(min 1 (+ (call value {feature \".series_progress\" lag 1}) (call value {feature \".series_progress_delta\" lag 1}) ))"
 							"auto_derive_on_train"
 								(assoc
 									"derive_type" "progress"

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -364,20 +364,20 @@
 			(= "delta_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call !get_val {f \"" feature "_lag_1\" }) " )
+					output_string (concat "(+ (call !get_val {f \"." feature "_lag_1\" }) " )
 				))
 				(if (> order 1)
 					(accum (assoc
 						output_string
 							(apply "concat" (range
-								(lambda (concat " (call !get_val {f \"" feature "_delta_" (current_index) "\" lag 1})" ))
+								(lambda (concat " (call !get_val {f \"." feature "_delta_" (current_index) "\" lag 1})" ))
 								1 (- order 1) 1
 							))
 					))
 				)
 				;last order is the current delta value
 				(accum (assoc
-					output_string (concat " (call !get_val {f \"" feature "_delta_" order "\" }) )" )
+					output_string (concat " (call !get_val {f \"." feature "_delta_" order "\" }) )" )
 				))
 			)
 
@@ -385,17 +385,17 @@
 			(assign (assoc
 				output_string
 					(if (> order 1)
-						(concat "(- (call !get_val {f \"" feature "_delta_" (- order 1) "\" }) (call !get_val {f \"" feature "_delta_" (- order 1) "\" lag 1}) )" )
+						(concat "(- (call !get_val {f \"." feature "_delta_" (- order 1) "\" }) (call !get_val {f \"." feature "_delta_" (- order 1) "\" lag 1}) )" )
 
 						;else
-						(concat "(- (call !get_val {f \"" feature "\" }) (call !get_val {f \""feature "_lag_1\" }) )" )
+						(concat "(- (call !get_val {f \"" feature "\" }) (call !get_val {f \"."feature "_lag_1\" }) )" )
 					)
 			))
 
 			(= "rate_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call !get_val {f \"" feature "_lag_1\" }) (* (call !get_val {f \"" time_feature "_delta_1\" }) (call !get_val {f \"" feature "_rate_1\" }) )" )
+					output_string (concat "(+ (call !get_val {f \"." feature "_lag_1\" }) (* (call !get_val {f \"" time_feature "_delta_1\" }) (call !get_val {f \"." feature "_rate_1\" }) )" )
 				))
 				(if (> order 1)
 					(accum (assoc
@@ -403,7 +403,7 @@
 							;Taylor series: (rate_x * time_delta^x) / x!
 							(apply "concat" (range
 								(lambda (concat
-									" (/ (* (pow (call !get_val {f \"" time_feature "_delta_1\" }) " (current_index) ") (call !get_val {f \"" feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
+									" (/ (* (pow (call !get_val {f \"" time_feature "_delta_1\" }) " (current_index) ") (call !get_val {f \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
 								))
 								2 order 1
 							))
@@ -419,10 +419,10 @@
 				output_string
 					(if (> order 1)
 						;diff between previous order rates / time_delta
-						(concat "(/ (- (call !get_val {f \"" feature "_rate_" (- order 1) "\" }) (call !get_val {f \"" feature "_rate_" (- order 1) "\" lag 1}) ) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call !get_val {f \"." feature "_rate_" (- order 1) "\" }) (call !get_val {f \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 
 						;else
-						(concat "(/ (- (call !get_val {f \"" feature "\" }) (call !get_val {f \"" feature "_lag_1\" }) ) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call !get_val {f \"" feature "\" }) (call !get_val {f \"." feature "_lag_1\" }) ) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 					)
 			))
 
@@ -430,14 +430,14 @@
 			(assign (assoc
 				; rate_order[1] + rate_next_order[0] * time_delta
 				output_string
-					(concat "(+ (call !get_val {f \"" feature "_rate_" order "\" lag 1 }) (* (call !get_val {f \"" feature "_rate_" (+ order 1) "\" }) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
+					(concat "(+ (call !get_val {f \"." feature "_rate_" order "\" lag 1 }) (* (call !get_val {f \"." feature "_rate_" (+ order 1) "\" }) (max (call !get_val {f \"" time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
 			))
 
 			(= "delta_derived")
 			(assign (assoc
 				; delta_order[1] + delta_next_order[0]
 				output_string
-					(concat "(+ (call !get_val {f \"" feature "_delta_" order "\" lag 1 }) (call !get_val {f \"" feature "_delta_" (+ order 1) "\" }) )" )
+					(concat "(+ (call !get_val {f \"." feature "_delta_" order "\" lag 1 }) (call !get_val {f \"." feature "_delta_" (+ order 1) "\" }) )" )
 			))
 		)
 
@@ -711,6 +711,7 @@
 							feature feature
 							lag_amount (current_value 2)
 						))
+					"code_features" [feature]
 					"non_sensitive" (if (contains_index attributes "non_sensitive") (get attributes "non_sensitive") (true) )
 					"bounds"
 						(set

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -288,8 +288,8 @@
 							(set
 								(current_value)
 								"derived_feature_code"
-								;format of: (call !get_val {f "feature_name" lag 1 }), feature name wrapped in quotes to handle features with spaces
-								(concat "(call !get_val {f \"" (current_index) "\" lag 1 })")
+								;format of: (call get_val {f "feature_name" lag 1 }), feature name wrapped in quotes to handle features with spaces
+								(concat "(call get_val {f \"" (current_index) "\" lag 1 })")
 
 							)
 
@@ -358,26 +358,26 @@
 		(if
 			(= "lag" derivation_type)
 			(assign (assoc
-				output_string (concat "(call !get_val {f \"" feature "\" lag " lag_amount "})" )
+				output_string (concat "(call get_val {f \"" feature "\" lag " lag_amount "})" )
 			))
 
 			(= "delta_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call !get_val {f \"." feature "_lag_1\" }) " )
+					output_string (concat "(+ (call get_val {f \"." feature "_lag_1\" }) " )
 				))
 				(if (> order 1)
 					(accum (assoc
 						output_string
 							(apply "concat" (range
-								(lambda (concat " (call !get_val {f \"." feature "_delta_" (current_index) "\" lag 1})" ))
+								(lambda (concat " (call get_val {f \"." feature "_delta_" (current_index) "\" lag 1})" ))
 								1 (- order 1) 1
 							))
 					))
 				)
 				;last order is the current delta value
 				(accum (assoc
-					output_string (concat " (call !get_val {f \"." feature "_delta_" order "\" }) )" )
+					output_string (concat " (call get_val {f \"." feature "_delta_" order "\" }) )" )
 				))
 			)
 
@@ -385,17 +385,17 @@
 			(assign (assoc
 				output_string
 					(if (> order 1)
-						(concat "(- (call !get_val {f \"." feature "_delta_" (- order 1) "\" }) (call !get_val {f \"." feature "_delta_" (- order 1) "\" lag 1}) )" )
+						(concat "(- (call get_val {f \"." feature "_delta_" (- order 1) "\" }) (call get_val {f \"." feature "_delta_" (- order 1) "\" lag 1}) )" )
 
 						;else
-						(concat "(- (call !get_val {f \"" feature "\" }) (call !get_val {f \"."feature "_lag_1\" }) )" )
+						(concat "(- (call get_val {f \"" feature "\" }) (call get_val {f \"."feature "_lag_1\" }) )" )
 					)
 			))
 
 			(= "rate_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ (call !get_val {f \"." feature "_lag_1\" }) (* (call !get_val {f \"." time_feature "_delta_1\" }) (call !get_val {f \"." feature "_rate_1\" }) )" )
+					output_string (concat "(+ (call get_val {f \"." feature "_lag_1\" }) (* (call get_val {f \"." time_feature "_delta_1\" }) (call get_val {f \"." feature "_rate_1\" }) )" )
 				))
 				(if (> order 1)
 					(accum (assoc
@@ -403,7 +403,7 @@
 							;Taylor series: (rate_x * time_delta^x) / x!
 							(apply "concat" (range
 								(lambda (concat
-									" (/ (* (pow (call !get_val {f \"." time_feature "_delta_1\" }) " (current_index) ") (call !get_val {f \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
+									" (/ (* (pow (call get_val {f \"." time_feature "_delta_1\" }) " (current_index) ") (call get_val {f \"." feature "_rate_" (current_index)  "\" }) ) " (apply "*" (range 1 (current_index)))  ")"
 								))
 								2 order 1
 							))
@@ -419,10 +419,10 @@
 				output_string
 					(if (> order 1)
 						;diff between previous order rates / time_delta
-						(concat "(/ (- (call !get_val {f \"." feature "_rate_" (- order 1) "\" }) (call !get_val {f \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call !get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call get_val {f \"." feature "_rate_" (- order 1) "\" }) (call get_val {f \"." feature "_rate_" (- order 1) "\" lag 1}) ) (max (call get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 
 						;else
-						(concat "(/ (- (call !get_val {f \"" feature "\" }) (call !get_val {f \"." feature "_lag_1\" }) ) (max (call !get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
+						(concat "(/ (- (call get_val {f \"" feature "\" }) (call get_val {f \"." feature "_lag_1\" }) ) (max (call get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval "))" )
 					)
 			))
 
@@ -430,14 +430,14 @@
 			(assign (assoc
 				; rate_order[1] + rate_next_order[0] * time_delta
 				output_string
-					(concat "(+ (call !get_val {f \"." feature "_rate_" order "\" lag 1 }) (* (call !get_val {f \"." feature "_rate_" (+ order 1) "\" }) (max (call !get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
+					(concat "(+ (call get_val {f \"." feature "_rate_" order "\" lag 1 }) (* (call get_val {f \"." feature "_rate_" (+ order 1) "\" }) (max (call get_val {f \"." time_feature "_delta_1\" }) " !tsMinTimeInterval ")))" )
 			))
 
 			(= "delta_derived")
 			(assign (assoc
 				; delta_order[1] + delta_next_order[0]
 				output_string
-					(concat "(+ (call !get_val {f \"." feature "_delta_" order "\" lag 1 }) (call !get_val {f \"." feature "_delta_" (+ order 1) "\" }) )" )
+					(concat "(+ (call get_val {f \"." feature "_delta_" order "\" lag 1 }) (call get_val {f \"." feature "_delta_" (+ order 1) "\" }) )" )
 			))
 		)
 
@@ -616,7 +616,7 @@
 					".series_progress"
 						(assoc
 							"type" "continuous"
-							"derived_feature_code" "(min 1 (+ (call !get_val {f \".series_progress\" lag 1}) (call !get_val {f \".series_progress_delta\" lag 1}) ))"
+							"derived_feature_code" "(min 1 (+ (call get_val {f \".series_progress\" lag 1}) (call get_val {f \".series_progress_delta\" lag 1}) ))"
 							"auto_derive_on_train"
 								(assoc
 									"derive_type" "progress"

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -785,7 +785,7 @@
 												[(call_sandboxed
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !featureAttributes [action_feature "derived_feature_code"])
-														get_val (lambda (if (= lag 0) (get case f) ) )
+														get_val (lambda (if (= lag 0) (get case feature) ) )
 													))
 													{"case" (append (zip react_context_features corresponding_context_values) values_for_derivation_map)}
 													!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -785,7 +785,7 @@
 												[(call_sandboxed
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !featureAttributes [action_feature "derived_feature_code"])
-														!get_val (lambda (if (= lag 0) (get case f) ) )
+														get_val (lambda (if (= lag 0) (get case f) ) )
 													))
 													{"case" (append (zip react_context_features corresponding_context_values) values_for_derivation_map)}
 													!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -785,7 +785,7 @@
 												[(call_sandboxed
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !featureAttributes [action_feature "derived_feature_code"])
-														!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
+														!get_val (lambda (if (= lag 0) (get case f) ) )
 													))
 													{"case" (append (zip react_context_features corresponding_context_values) values_for_derivation_map)}
 													!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -785,7 +785,7 @@
 												[(call_sandboxed
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !featureAttributes [action_feature "derived_feature_code"])
-														get_val (lambda (if (= lag 0) (get case feature) ) )
+														value (lambda (if (= lag 0) (get case feature) ) )
 													))
 													{"case" (append (zip react_context_features corresponding_context_values) values_for_derivation_map)}
 													!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/influences.amlg
+++ b/howso/influences.amlg
@@ -252,10 +252,9 @@
 					features_for_derivation_map
 						(map
 							(lambda
-								(indices (filter
-									;filter out derivation code that reaches to previous rows of a series
-									(lambda (= (current_value) 0))
-									(get_all_labels (parse (get !featureAttributes [(current_index 1) "derived_feature_code"]) ))
+								;keep only features with a lag of 0 (those referencing current case)
+								(call !ZeroLagFeaturesInCustomCode (assoc
+									code_string (get !featureAttributes [(current_index 2) "derived_feature_code"])
 								))
 							)
 							(keep (zip action_features) features_to_derive)
@@ -786,15 +785,7 @@
 												[(call_sandboxed
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !featureAttributes [action_feature "derived_feature_code"])
-														label_to_code
-															(lambda
-																(if (= (lambda label_value) 0)
-																	;pull the feature value
-																	(get case (lambda label_name))
-
-																	(null)
-																)
-															)
+														!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
 													))
 													{"case" (append (zip react_context_features corresponding_context_values) values_for_derivation_map)}
 													!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/io.amlg
+++ b/howso/io.amlg
@@ -183,7 +183,7 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														get_val (lambda (if (and (= lag 0) (= orig_feature feature)) original_value ) )
+														value (lambda (if (and (= lag 0) (= orig_feature feature)) original_value ) )
 													))
 											))
 											(call_sandboxed parsed_code

--- a/howso/io.amlg
+++ b/howso/io.amlg
@@ -183,7 +183,7 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														get_val (lambda (if (and (= lag 0) (= feature f)) original_value ) )
+														get_val (lambda (if (and (= lag 0) (= orig_feature feature)) original_value ) )
 													))
 											))
 											(call_sandboxed parsed_code
@@ -191,7 +191,7 @@
 													(zip post_process_features post_process_values)
 													(assoc
 														original_value original_value
-														feature feature
+														orig_feature feature
 													)
 												)
 												!sandboxedComputeLimit

--- a/howso/io.amlg
+++ b/howso/io.amlg
@@ -183,7 +183,7 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														!get_val (lambda (if (and (= lag 0) (= feature f)) original_value ) )
+														get_val (lambda (if (and (= lag 0) (= feature f)) original_value ) )
 													))
 											))
 											(call_sandboxed parsed_code

--- a/howso/io.amlg
+++ b/howso/io.amlg
@@ -183,8 +183,7 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														!get_val
-															(lambda (if (and (= lag 0) (= feature f)) original_value ) ) ;;;^^^TODO: wrap in lambdas?
+														!get_val (lambda (if (and (= lag 0) (= feature f)) original_value ) )
 													))
 											))
 											(call_sandboxed parsed_code

--- a/howso/io.amlg
+++ b/howso/io.amlg
@@ -183,16 +183,8 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														label_to_code
-															(lambda
-																(if (and (= (lambda label_value) 0) (= feature (lambda label_name)))
-																	;pull the feature value
-																	original_value
-
-																	;else
-																	(null)
-																)
-															)
+														!get_val
+															(lambda (if (and (= lag 0) (= feature f)) original_value ) ) ;;;^^^TODO: wrap in lambdas?
 													))
 											))
 											(call_sandboxed parsed_code

--- a/howso/react_utilities.amlg
+++ b/howso/react_utilities.amlg
@@ -933,7 +933,7 @@
 			(lambda
 				(if
 					(size (remove
-						(get_all_labels (parse (get !featureAttributes [(current_value 1) "derived_feature_code"])))
+						(zip (get !featureAttributes [(current_value 1) "code_features"]) )
 						available_features
 					))
 					(accum (assoc
@@ -944,7 +944,7 @@
 								(apply "concat" (trunc (weave
 									(map
 										(lambda (concat "\"" (current_value) "\""))
-										(indices (get_all_labels (parse (get !featureAttributes [(current_value 3) "derived_feature_code"]))))
+										(get !featureAttributes [(current_value 3) "code_features"])
 									)
 									"\, "
 								)))

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1136,7 +1136,7 @@
 					(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [feature "derived_feature_code"])
-							get_val (lambda (if (= lag 0) (get case f) ) )
+							get_val (lambda (if (= lag 0) (get case feature) ) )
 						))
 						{"case" values_for_derivation_map}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1136,7 +1136,7 @@
 					(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [feature "derived_feature_code"])
-							get_val (lambda (if (= lag 0) (get case feature) ) )
+							value (lambda (if (= lag 0) (get case feature) ) )
 						))
 						{"case" values_for_derivation_map}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -368,13 +368,12 @@
 				features_for_derivation_map
 					(map
 						(lambda
-							(indices (filter
-								;filter out derivation code that reaches to previous rows of a series
-								(lambda (= (current_value) 0))
-								(get_all_labels (parse (get !featureAttributes [(current_index 1) "derived_feature_code"]) ))
+							;keep only features with a lag of 0 (those referencing current case)
+							(call !ZeroLagFeaturesInCustomCode (assoc
+								code_string (get !featureAttributes [(current_index 2) "derived_feature_code"])
 							))
 						)
-						features_to_derive
+						(zip features_to_derive)
 					)
 			))
 		)
@@ -1137,15 +1136,7 @@
 					(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [feature "derived_feature_code"])
-							label_to_code
-								(lambda
-									(if (= (lambda label_value) 0)
-										;pull the feature value
-										(get case (lambda label_name))
-
-										(null)
-									)
-								)
+							!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
 						))
 						{"case" values_for_derivation_map}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1136,7 +1136,7 @@
 					(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [feature "derived_feature_code"])
-							!get_val (lambda (if (= lag 0) (get case f) ) ) ;;;^^^TODO: (lambda lag) and (lambda f) ?
+							!get_val (lambda (if (= lag 0) (get case f) ) )
 						))
 						{"case" values_for_derivation_map}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/residuals.amlg
+++ b/howso/residuals.amlg
@@ -1136,7 +1136,7 @@
 					(call_sandboxed
 						(call !ParseDerivedFeatureCode (assoc
 							code_string (get !featureAttributes [feature "derived_feature_code"])
-							!get_val (lambda (if (= lag 0) (get case f) ) )
+							get_val (lambda (if (= lag 0) (get case f) ) )
 						))
 						{"case" values_for_derivation_map}
 						!sandboxedComputeLimit !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)

--- a/howso/synthesis_bounds.amlg
+++ b/howso/synthesis_bounds.amlg
@@ -256,7 +256,7 @@
 				(not
 					(call_sandboxed (parse constraint) (assoc
 						data_map (append current_case_data_map (associate feature new_feature_value))
-						get_val (lambda (get data_map feature) )
+						value (lambda (get data_map feature) )
 					)) (* (size context_features) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)
 				)
 				(assign (assoc out_of_bounds (true) ))
@@ -371,7 +371,7 @@
 							(not
 								(call_sandboxed (parse constraint) (assoc
 									data_map (append current_case_data_map (associate feature new_feature_value))
-									get_val
+									value
 										(lambda
 											(if (contains_index data_map feature)
 												(let

--- a/howso/synthesis_bounds.amlg
+++ b/howso/synthesis_bounds.amlg
@@ -93,7 +93,7 @@
 						)
 				))
 
-				;custom specified constraint
+				;create an assoc of feature -> custom specified constraint passed into this particular react
 				(declare (assoc
 					custom_constraints_map
 						(filter
@@ -102,7 +102,7 @@
 						)
 				))
 
-				;recompute the constraint_features for each custom constraint
+				;recompute the constraint_features for each custom constraint that was specified for this particular react
 				(if (size custom_constraints_map)
 					(assign (assoc
 						feature_bounds_map

--- a/howso/synthesis_bounds.amlg
+++ b/howso/synthesis_bounds.amlg
@@ -256,7 +256,7 @@
 				(not
 					(call_sandboxed (parse constraint) (assoc
 						data_map (append current_case_data_map (associate feature new_feature_value))
-						!get_val (lambda (get data_map f) )
+						get_val (lambda (get data_map f) )
 					)) (* (size context_features) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)
 				)
 				(assign (assoc out_of_bounds (true) ))
@@ -371,7 +371,7 @@
 							(not
 								(call_sandboxed (parse constraint) (assoc
 									data_map (append current_case_data_map (associate feature new_feature_value))
-									!get_val
+									get_val
 										(lambda
 											(if (contains_index data_map f)
 												(let

--- a/howso/synthesis_bounds.amlg
+++ b/howso/synthesis_bounds.amlg
@@ -75,22 +75,53 @@
 		;if custom feature bounds map is specified and it has datetime features, ensure that epoch min/max will be calculated for these
 		;custom datetimes by setting those features' has_epoch_bounds flag to false
 		(if feature_bounds_map
-			(assign (assoc
-				feature_bounds_map
-					(map
-						(lambda
-							(if (contains_index !featureDateTimeMap (current_index))
-								(append
-									(current_value)
-									(assoc "has_epoch_bounds" (false))
-								)
+			(seq
+				(assign (assoc
+					feature_bounds_map
+						(map
+							(lambda
+								(if (contains_index !featureDateTimeMap (current_index))
+									(append
+										(current_value)
+										(assoc "has_epoch_bounds" (false))
+									)
 
-								(current_value)
+									(current_value)
+								)
 							)
+							feature_bounds_map
 						)
+				))
+
+				;custom specified constraint
+				(declare (assoc
+					custom_constraints_map
+						(filter
+							(lambda (contains_index (current_value) "constraint"))
+							feature_bounds_map
+						)
+				))
+
+				;recompute the constraint_features for each custom constraint
+				(if (size custom_constraints_map)
+					(assign (assoc
 						feature_bounds_map
-					)
-			))
+							(append
+								feature_bounds_map
+								(map
+									(lambda
+										(set
+											(current_value)
+											"constraint_features"
+											(call !FeaturesInCustomCode (assoc code (get (current_value 1) "constraint")))
+										)
+									)
+									custom_constraints_map
+								)
+							)
+					))
+				)
+			)
 		)
 
 		;overwrite the model !featureBoundsMap with the passed in react-specific one
@@ -200,7 +231,7 @@
 			constraint (get feature_bounds_map (list feature "constraint"))
 		)
 		;only check constraint if all features referenced in the constraint have been generated
-		(if (!= 0 (size (remove (get_all_labels (parse constraint)) (append context_features feature))))
+		(if (!= 0 (size (remove (get feature_bounds_map [feature "constraint_features"]) (append context_features feature))) )
 			(conclude (false))
 		)
 		(declare (assoc
@@ -209,7 +240,6 @@
 			out_of_bounds (false)
 			data_map (assoc)
 			retry_desired_conviction (/ desired_conviction 2)
-			parsed_code (null)
 			allow_null (get feature_bounds_map (list feature "allow_null"))
 		))
 
@@ -219,35 +249,15 @@
 				(conclude (conclude (false)))
 			)
 
-			(assign (assoc
-				data_map (append current_case_data_map (associate feature new_feature_value))
-				out_of_bounds (false)
-			))
-
-			(assign (assoc
-				parsed_code
-					(call !ParseDerivedFeatureCode (assoc
-						code_string constraint
-						label_to_code
-							(lambda
-								(if (and (= (lambda label_value) 0) (contains_index data_map (lambda label_name)))
-									;pull the feature value
-									(get data_map (lambda label_name))
-
-									;else feature hasn't been generated yet
-									(null)
-								)
-							)
-					))
-			))
+			(assign (assoc out_of_bounds (false) ))
 
 			;considered out of bounds if constraint is not satisfied
 			(if
 				(not
-					(call_sandboxed parsed_code
-						(assoc data_map data_map)
-						(* (size context_features) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)
-					)
+					(call_sandboxed (parse constraint) (assoc
+						data_map (append current_case_data_map (associate feature new_feature_value))
+						!get_val (lambda (get data_map f) )
+					)) (* (size context_features) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)
 				)
 				(assign (assoc out_of_bounds (true) ))
 			)
@@ -318,7 +328,7 @@
 
 		(if constraint
 			;only check constraint if all features referenced in the constraint have been generated
-			(if (!= 0 (size (remove (get_all_labels (parse constraint)) (append context_features feature))))
+			(if (!= 0 (size (remove (get feature_bounds_map [feature "constraint_features"]) (append context_features feature))))
 				(assign (assoc constraint (null) ))
 			)
 		)
@@ -356,48 +366,32 @@
 				(if constraint
 					;if it's a null and nulls are allowed, don't check constraint
 					(if (or (not allow_null) (!= (null) new_feature_value))
-						(let
-							(assoc
-								data_map (append current_case_data_map (associate feature new_feature_value))
-							)
-
-							(declare (assoc
-								parsed_code
-									(call !ParseDerivedFeatureCode (assoc
-										code_string constraint
-										label_to_code
-											(lambda
-												(if (and (= (lambda label_value) 0) (contains_index data_map (lambda label_name)))
-													;pull the feature value
-													(let
-														(assoc val (get data_map (lambda label_name)) )
-														;encode datetime by converting string date time into seconds since epoch
-														(if (contains_index !featureDateTimeMap label_name)
-															(if (!= (null) val)
-																(call !ConvertDateToEpoch (assoc date val feature label_name))
-															)
-															;else not a datetime, return continuous value
-															val
+						;considered out of bounds if constraint is not satisfied
+						(if
+							(not
+								(call_sandboxed (parse constraint) (assoc
+									data_map (append current_case_data_map (associate feature new_feature_value))
+									!get_val
+										(lambda
+											(if (contains_index data_map f)
+												(let
+													(assoc val (get data_map f) )
+													;encode datetime by converting string date time into seconds since epoch
+													(if (contains_index !featureDateTimeMap f)
+														(if (!= (null) val)
+															(call !ConvertDateToEpoch (assoc date val feature f))
 														)
+														;else not a datetime, return continuous value
+														val
 													)
-
-													;else feature hasn't been generated yet
-													(null)
 												)
 											)
-									))
-							))
-
-							;considered out of bounds if constraint is not satisfied
-							(if
-								(not
-									(call_sandboxed parsed_code
-										(assoc data_map data_map)
-										(* (size context_features) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)
-									)
-								)
-								(assign (assoc out_of_bounds (true) ))
+										)
+									!ConvertDateToEpoch !ConvertDateToEpoch
+									!featureDateTimeMap !featureDateTimeMap
+								)) (* (size context_features) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)
 							)
+							(assign (assoc out_of_bounds (true) ))
 						)
 					)
 				)

--- a/howso/synthesis_bounds.amlg
+++ b/howso/synthesis_bounds.amlg
@@ -113,7 +113,7 @@
 										(set
 											(current_value)
 											"constraint_features"
-											(zip (call !FeaturesInCustomCode (assoc code (get (current_value 1) "constraint"))) )
+											(zip (call !FeaturesInCustomCode (assoc code_string (get (current_value 1) "constraint"))) )
 										)
 									)
 									custom_constraints_map

--- a/howso/synthesis_bounds.amlg
+++ b/howso/synthesis_bounds.amlg
@@ -113,7 +113,7 @@
 										(set
 											(current_value)
 											"constraint_features"
-											(call !FeaturesInCustomCode (assoc code (get (current_value 1) "constraint")))
+											(zip (call !FeaturesInCustomCode (assoc code (get (current_value 1) "constraint"))) )
 										)
 									)
 									custom_constraints_map

--- a/howso/synthesis_bounds.amlg
+++ b/howso/synthesis_bounds.amlg
@@ -256,7 +256,7 @@
 				(not
 					(call_sandboxed (parse constraint) (assoc
 						data_map (append current_case_data_map (associate feature new_feature_value))
-						get_val (lambda (get data_map f) )
+						get_val (lambda (get data_map feature) )
 					)) (* (size context_features) !sandboxedComputeLimit) !sandboxedMemoryLimit !sandboxedOpcodeDepthLimit (false)
 				)
 				(assign (assoc out_of_bounds (true) ))
@@ -373,13 +373,13 @@
 									data_map (append current_case_data_map (associate feature new_feature_value))
 									get_val
 										(lambda
-											(if (contains_index data_map f)
+											(if (contains_index data_map feature)
 												(let
-													(assoc val (get data_map f) )
+													(assoc val (get data_map feature) )
 													;encode datetime by converting string date time into seconds since epoch
-													(if (contains_index !featureDateTimeMap f)
+													(if (contains_index !featureDateTimeMap feature)
 														(if (!= (null) val)
-															(call !ConvertDateToEpoch (assoc date val feature f))
+															(call !ConvertDateToEpoch (assoc "date" val "feature" feature))
 														)
 														;else not a datetime, return continuous value
 														val

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -94,16 +94,8 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														label_to_code
-															(lambda
-																(if (and (= (lambda label_value) 0) (= feature (lambda label_name)))
-																	;pull the feature value
-																	original_value
-
-																	;else
-																	(null)
-																)
-															)
+														!get_val
+															(lambda (if (and (= lag 0) (= feature f)) original_value ) ) ;;;^^^TODO: wrap in lambda?
 													))
 											)
 											(call_sandboxed parsed_code

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -94,7 +94,7 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														!get_val (lambda (if (and (= lag 0) (= feature f)) original_value ) )
+														get_val (lambda (if (and (= lag 0) (= feature f)) original_value ) )
 													))
 											)
 											(call_sandboxed parsed_code

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -94,8 +94,7 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														!get_val
-															(lambda (if (and (= lag 0) (= feature f)) original_value ) ) ;;;^^^TODO: wrap in lambda?
+														!get_val (lambda (if (and (= lag 0) (= feature f)) original_value ) )
 													))
 											)
 											(call_sandboxed parsed_code

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -94,7 +94,7 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														get_val (lambda (if (and (= lag 0) (= original_feature feature)) original_value ) )
+														value (lambda (if (and (= lag 0) (= original_feature feature)) original_value ) )
 													))
 											)
 											(call_sandboxed parsed_code

--- a/howso/synthesis_validation.amlg
+++ b/howso/synthesis_validation.amlg
@@ -94,7 +94,7 @@
 												parsed_code
 													(call !ParseDerivedFeatureCode (assoc
 														code_string (get !postProcessMap feature)
-														get_val (lambda (if (and (= lag 0) (= feature f)) original_value ) )
+														get_val (lambda (if (and (= lag 0) (= original_feature feature)) original_value ) )
 													))
 											)
 											(call_sandboxed parsed_code
@@ -102,7 +102,7 @@
 													(zip post_process_features post_process_values)
 													(assoc
 														original_value original_value
-														feature feature
+														original_feature feature
 													)
 												)
 												!sandboxedComputeLimit

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -137,6 +137,12 @@
 												type "string"
 												description "The Amalgam code used to derive the feature value."
 											)
+										code_features
+											(assoc
+												type "list"
+												values "string"
+												description "A list of features needed to derive code"
+											)
 										series_id_features
 											(assoc
 												type "list"
@@ -166,6 +172,12 @@
 										"- ``\"#x 1\"``: Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).\n"
 										"- ``\"(- #y 0 #x 1)\"``: Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offset 1) row.\n"
 									)
+							)
+						code_features
+							(assoc
+								type "list"
+								values "string"
+								description "A list of features needed to derive code"
 							)
 						post_process
 							(assoc

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -267,15 +267,15 @@
 											(keep !sourceToDerivedFeatureMap features)
 										))
 										;the derivation code only uses values from within the same case (not other cases in the series)
-										;(get_all_labels) returns a map of all labels to their values from the code, in this case all feature names to their  offsets,
 										;offsets other than zero indicate deriving from values of another row within a series
 										;tackling this problem for TS data is TODO: 21518
 										(=
-											[0]
-											(values
-												(get_all_labels (parse (get !featureAttributes (list (current_value 1) "auto_derive_on_train" "code"))))
-												(true)
+											(size
+												(call !ZeroLagFeaturesInCustomCode (assoc
+													code_string (get !featureAttributes [(current_value 2) "auto_derive_on_train" "code"])
+												))
 											)
+											(size (get !featureAttributes [(current_value 1) "auto_derive_on_train" "code_features"]))
 										)
 									)
 								)
@@ -291,7 +291,7 @@
 									derived_feature (current_value 1)
 									necessary_features
 										;the labels (feature names) used in the derivation code
-										(indices (get_all_labels (parse (get !featureAttributes (list (current_value 2) "auto_derive_on_train" "code")))))
+										(get !featureAttributes [(current_value 2) "auto_derive_on_train" "code_features"])
 								)
 
 								(declare (assoc

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -516,7 +516,7 @@
 "106.0.0"
 	(seq
 		;method to convert old derived code to new format
-		;eg: "(+ #feat_a 0  #feat_b 2)" converts to "(+ (call get_val {f \"feat_a\"}) (call get_val {f \"feat_b\" lag 2}) )"
+		;eg: "(+ #feat_a 0  #feat_b 2)" converts to "(+ (call get_val {feature \"feat_a\"}) (call get_val {feature \"feat_b\" lag 2}) )"
 		(declare (assoc
 			update_code_method
 				(lambda (let
@@ -527,10 +527,10 @@
 							(lambda (let
 								(assoc label (first (get_labels (current_value 1))) )
 
-								;if this node is a label, replace it with the new code that is in the format  (call get_val {f feature lag lag_value})
+								;if this node is a label, replace it with the new code that is in the format  (call get_val {feature feature lag lag_value})
 								(if (contains_index feature_lag_map label)
 									(parse (concat
-										"(call get_val {f \"" label
+										"(call get_val {feature \"" label
 										(if (> (get feature_lag_map label) 0)
 											(concat "\" lag " (get feature_lag_map label) )
 											"\""

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -516,7 +516,7 @@
 "106.0.0"
 	(seq
 		;method to convert old derived code to new format
-		;eg: "(+ #feat_a 0  #feat_b 2)" converts to "(+ (call get_val {feature \"feat_a\"}) (call get_val {feature \"feat_b\" lag 2}) )"
+		;eg: "(+ #feat_a 0  #feat_b 2)" converts to "(+ (call value {feature \"feat_a\"}) (call value {feature \"feat_b\" lag 2}) )"
 		(declare (assoc
 			update_code_method
 				(lambda (let
@@ -527,10 +527,10 @@
 							(lambda (let
 								(assoc label (first (get_labels (current_value 1))) )
 
-								;if this node is a label, replace it with the new code that is in the format  (call get_val {feature feature lag lag_value})
+								;if this node is a label, replace it with the new code that is in the format  (call value {feature feature lag lag_value})
 								(if (contains_index feature_lag_map label)
 									(parse (concat
-										"(call get_val {feature \"" label
+										"(call value {feature \"" label
 										(if (> (get feature_lag_map label) 0)
 											(concat "\" lag " (get feature_lag_map label) )
 											"\""

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -515,15 +515,19 @@
 	(call !UpdateDefinedFeatures)
 "106.0.0"
 	(seq
+		;method to convert old derived code to new format
+		;eg: "(+ #feat_a 0  #feat_b 2)" converts to "(+ (call !get_val {f \"feat_a\"}) (call !get_val {f \"feat_b\" lag 2}) )"
 		(declare (assoc
 			update_code_method
 				(lambda (let
+					;create an assoc of feature -> lag value
 					(assoc feature_lag_map (get_all_labels (parse code_string)) )
 					(unparse
 						(rewrite
 							(lambda (let
 								(assoc label (first (get_labels (current_value 1))) )
 
+								;if this node is a label, replace it with the new code that is in the format  (call !get_val {f feature lag lag_value})
 								(if (contains_index feature_lag_map label)
 									(parse (concat
 										"(call !get_val {f \"" label
@@ -542,6 +546,7 @@
 				))
 		))
 
+		;overwrite all the derived code in feature attributes by calling the update_code_method on any code that is found
 		(assign_to_entities (assoc
 			!featureAttributes
 				(map

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -516,7 +516,7 @@
 "106.0.0"
 	(seq
 		;method to convert old derived code to new format
-		;eg: "(+ #feat_a 0  #feat_b 2)" converts to "(+ (call !get_val {f \"feat_a\"}) (call !get_val {f \"feat_b\" lag 2}) )"
+		;eg: "(+ #feat_a 0  #feat_b 2)" converts to "(+ (call get_val {f \"feat_a\"}) (call get_val {f \"feat_b\" lag 2}) )"
 		(declare (assoc
 			update_code_method
 				(lambda (let
@@ -527,10 +527,10 @@
 							(lambda (let
 								(assoc label (first (get_labels (current_value 1))) )
 
-								;if this node is a label, replace it with the new code that is in the format  (call !get_val {f feature lag lag_value})
+								;if this node is a label, replace it with the new code that is in the format  (call get_val {f feature lag lag_value})
 								(if (contains_index feature_lag_map label)
 									(parse (concat
-										"(call !get_val {f \"" label
+										"(call get_val {f \"" label
 										(if (> (get feature_lag_map label) 0)
 											(concat "\" lag " (get feature_lag_map label) )
 											"\""

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -513,4 +513,98 @@
 	))
 "100.1.1"
 	(call !UpdateDefinedFeatures)
+"106.0.0"
+	(seq
+		(declare (assoc
+			update_code_method
+				(lambda (let
+					(assoc feature_lag_map (get_all_labels (parse code_string)) )
+					(unparse
+						(rewrite
+							(lambda (let
+								(assoc label (first (get_labels (current_value 1))) )
+
+								(if (contains_index feature_lag_map label)
+									(parse (concat
+										"(call !get_val {f \"" label
+										(if (> (get feature_lag_map label) 0)
+											(concat "\" lag " (get feature_lag_map label) )
+											"\""
+										)
+										" })"
+									))
+									(current_value)
+								)
+							))
+							(parse code_string)
+						)
+					)
+				))
+		))
+
+		(assign_to_entities (assoc
+			!featureAttributes
+				(map
+					(lambda (if
+						;rewrite old label-based code into the method-based format
+						(or
+							(!= (null) (get (current_value) ["auto_derive_on_train" "code"]))
+							(!= (null) (get (current_value) "derived_feature_code"))
+							(!= (null) (get (current_value) "post_process"))
+						)
+						(let
+							(assoc attributes (current_value 1))
+							(if (!= (null) (get attributes ["auto_derive_on_train" "code"]))
+								(assign (assoc
+									attributes
+										(set
+											attributes
+											["auto_derive_on_train" "code_features"]
+												(indices (get_all_labels
+													(parse (get attributes ["auto_derive_on_train" "code"]))
+												))
+											["auto_derive_on_train" "code"]
+												(call update_code_method (assoc
+													code_string (get attributes ["auto_derive_on_train" "code"])
+												))
+										)
+								))
+							)
+							(if (!= (null) (get attributes "derived_feature_code"))
+								(assign (assoc
+									attributes
+										(set
+											attributes
+											"code_features"
+												(indices (get_all_labels
+													(parse (get attributes "derived_feature_code"))
+												))
+											"derived_feature_code"
+												(call update_code_method (assoc
+													code_string (get attributes "derived_feature_code")
+												))
+										)
+								))
+							)
+							(if (!= (null) (get attributes "post_process"))
+								(assign (assoc
+									attributes
+										(set attributes "post_process"
+											(call update_code_method (assoc
+												code_string (get attributes "post_process")
+											))
+										)
+								))
+							)
+							attributes
+						)
+
+						;else leave attributes alone
+						(current_value)
+					))
+					!featureAttributes
+				)
+		))
+	)
+
 ))

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -20,7 +20,7 @@
 										"min" 0
 										"max" 300
 										"allow_null" (false)
-										"constraint" "(= #z 0 100)"
+										"constraint" "(= (call !get_val {f \"z\"}) 100)"
 									)
 							)
 						"z"
@@ -59,7 +59,7 @@
 								"min" 0
 								"max" 300
 								;z should always be bigger then the sum of x and y
-								"constraint" "(> #z 0 (+ #x 0 #y 0))"
+								"constraint" "(> (call !get_val {f \"z\"}) (+ (call !get_val {f \"x\"}) (call !get_val {f \"y\"})))"
 								"allow_null" (false)
 							)
 					)
@@ -69,7 +69,7 @@
 						;w has to be "B" if z is > 170
 						"bounds"
 							(assoc
-								"constraint" "(if (> #z 0 170) (= #w 0 \"B\") (true))"
+								"constraint" "(if (> (call !get_val {f \"z\"}) 170) (= (call !get_val {f \"w\"}) \"B\") (true))"
 								"allow_null" (true)
 							)
 					)
@@ -219,7 +219,7 @@
 								"min" 0
 								"max" 300
 								;z should always be bigger then the sum of x and y
-								"constraint" "(> #z 0 (+ #x 0 #y 0))"
+								"constraint" "(> (call !get_val {f \"z\"}) (+ (call !get_val {f \"x\"}) (call !get_val {f \"y\"})))"
 								"allow_null" (false)
 							)
 						"data_type" "number"
@@ -230,7 +230,7 @@
 						;w has to be "B" if z is > 170
 						"bounds"
 							(assoc
-								"constraint" "(if (> #z 0 170) (= #w 0 \"B\") (true))"
+								"constraint" "(if (> (call !get_val {f \"z\"}) 170) (= (call !get_val {f \"w\"}) \"B\") (true))"
 								"allow_null" (true)
 							)
 					)

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -20,7 +20,7 @@
 										"min" 0
 										"max" 300
 										"allow_null" (false)
-										"constraint" "(= (call get_val {feature \"z\"}) 100)"
+										"constraint" "(= (call value {feature \"z\"}) 100)"
 									)
 							)
 						"z"
@@ -59,7 +59,7 @@
 								"min" 0
 								"max" 300
 								;z should always be bigger then the sum of x and y
-								"constraint" "(> (call get_val {feature \"z\"}) (+ (call get_val {feature \"x\"}) (call get_val {feature \"y\"})))"
+								"constraint" "(> (call value {feature \"z\"}) (+ (call value {feature \"x\"}) (call value {feature \"y\"})))"
 								"allow_null" (false)
 							)
 					)
@@ -69,7 +69,7 @@
 						;w has to be "B" if z is > 170
 						"bounds"
 							(assoc
-								"constraint" "(if (> (call get_val {feature \"z\"}) 170) (= (call get_val {feature \"w\"}) \"B\") (true))"
+								"constraint" "(if (> (call value {feature \"z\"}) 170) (= (call value {feature \"w\"}) \"B\") (true))"
 								"allow_null" (true)
 							)
 					)
@@ -219,7 +219,7 @@
 								"min" 0
 								"max" 300
 								;z should always be bigger then the sum of x and y
-								"constraint" "(> (call get_val {feature \"z\"}) (+ (call get_val {feature \"x\"}) (call get_val {feature \"y\"})))"
+								"constraint" "(> (call value {feature \"z\"}) (+ (call value {feature \"x\"}) (call value {feature \"y\"})))"
 								"allow_null" (false)
 							)
 						"data_type" "number"
@@ -230,7 +230,7 @@
 						;w has to be "B" if z is > 170
 						"bounds"
 							(assoc
-								"constraint" "(if (> (call get_val {feature \"z\"}) 170) (= (call get_val {feature \"w\"}) \"B\") (true))"
+								"constraint" "(if (> (call value {feature \"z\"}) 170) (= (call value {feature \"w\"}) \"B\") (true))"
 								"allow_null" (true)
 							)
 					)

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -20,7 +20,7 @@
 										"min" 0
 										"max" 300
 										"allow_null" (false)
-										"constraint" "(= (call get_val {f \"z\"}) 100)"
+										"constraint" "(= (call get_val {feature \"z\"}) 100)"
 									)
 							)
 						"z"
@@ -59,7 +59,7 @@
 								"min" 0
 								"max" 300
 								;z should always be bigger then the sum of x and y
-								"constraint" "(> (call get_val {f \"z\"}) (+ (call get_val {f \"x\"}) (call get_val {f \"y\"})))"
+								"constraint" "(> (call get_val {feature \"z\"}) (+ (call get_val {feature \"x\"}) (call get_val {feature \"y\"})))"
 								"allow_null" (false)
 							)
 					)
@@ -69,7 +69,7 @@
 						;w has to be "B" if z is > 170
 						"bounds"
 							(assoc
-								"constraint" "(if (> (call get_val {f \"z\"}) 170) (= (call get_val {f \"w\"}) \"B\") (true))"
+								"constraint" "(if (> (call get_val {feature \"z\"}) 170) (= (call get_val {feature \"w\"}) \"B\") (true))"
 								"allow_null" (true)
 							)
 					)
@@ -219,7 +219,7 @@
 								"min" 0
 								"max" 300
 								;z should always be bigger then the sum of x and y
-								"constraint" "(> (call get_val {f \"z\"}) (+ (call get_val {f \"x\"}) (call get_val {f \"y\"})))"
+								"constraint" "(> (call get_val {feature \"z\"}) (+ (call get_val {feature \"x\"}) (call get_val {feature \"y\"})))"
 								"allow_null" (false)
 							)
 						"data_type" "number"
@@ -230,7 +230,7 @@
 						;w has to be "B" if z is > 170
 						"bounds"
 							(assoc
-								"constraint" "(if (> (call get_val {f \"z\"}) 170) (= (call get_val {f \"w\"}) \"B\") (true))"
+								"constraint" "(if (> (call get_val {feature \"z\"}) 170) (= (call get_val {feature \"w\"}) \"B\") (true))"
 								"allow_null" (true)
 							)
 					)

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -20,7 +20,7 @@
 										"min" 0
 										"max" 300
 										"allow_null" (false)
-										"constraint" "(= (call !get_val {f \"z\"}) 100)"
+										"constraint" "(= (call get_val {f \"z\"}) 100)"
 									)
 							)
 						"z"
@@ -59,7 +59,7 @@
 								"min" 0
 								"max" 300
 								;z should always be bigger then the sum of x and y
-								"constraint" "(> (call !get_val {f \"z\"}) (+ (call !get_val {f \"x\"}) (call !get_val {f \"y\"})))"
+								"constraint" "(> (call get_val {f \"z\"}) (+ (call get_val {f \"x\"}) (call get_val {f \"y\"})))"
 								"allow_null" (false)
 							)
 					)
@@ -69,7 +69,7 @@
 						;w has to be "B" if z is > 170
 						"bounds"
 							(assoc
-								"constraint" "(if (> (call !get_val {f \"z\"}) 170) (= (call !get_val {f \"w\"}) \"B\") (true))"
+								"constraint" "(if (> (call get_val {f \"z\"}) 170) (= (call get_val {f \"w\"}) \"B\") (true))"
 								"allow_null" (true)
 							)
 					)
@@ -219,7 +219,7 @@
 								"min" 0
 								"max" 300
 								;z should always be bigger then the sum of x and y
-								"constraint" "(> (call !get_val {f \"z\"}) (+ (call !get_val {f \"x\"}) (call !get_val {f \"y\"})))"
+								"constraint" "(> (call get_val {f \"z\"}) (+ (call get_val {f \"x\"}) (call get_val {f \"y\"})))"
 								"allow_null" (false)
 							)
 						"data_type" "number"
@@ -230,7 +230,7 @@
 						;w has to be "B" if z is > 170
 						"bounds"
 							(assoc
-								"constraint" "(if (> (call !get_val {f \"z\"}) 170) (= (call !get_val {f \"w\"}) \"B\") (true))"
+								"constraint" "(if (> (call get_val {f \"z\"}) 170) (= (call get_val {f \"w\"}) \"B\") (true))"
 								"allow_null" (true)
 							)
 					)

--- a/unit_tests/ut_h_derive_custom.amlg
+++ b/unit_tests/ut_h_derive_custom.amlg
@@ -40,9 +40,9 @@
 			(assoc
 				"sender" (assoc "type" "nominal" )
 				"reciever" (assoc "type" "nominal" )
-				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" (true)) "derived_feature_code" "(* (call !get_val {f \"mult\"}) (call !get_val {f \"number\"})")
+				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" (true)) "derived_feature_code" "(* (call get_val {f \"mult\"}) (call get_val {f \"number\"})")
 				"number" (assoc "type" "continuous" "decimal_places"  0 "bounds" (assoc "min"  5.0 "max"  50 "allow_null" (true)))
-				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 (call !get_val {f \"number\"}))")
+				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 (call get_val {f \"number\"}))")
 				".time_delta"
 					(assoc
 						"type" "continuous"
@@ -51,7 +51,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender")
 								"ordered_by_features" (list "time" )
-								"code" "(- (call !get_val {f \"time\"}) (call !get_val {f \"time\" lag 1}))"
+								"code" "(- (call get_val {f \"time\"}) (call get_val {f \"time\" lag 1}))"
 							)
 						"bounds" (assoc "allow_null" (false))
 						"decimal_places" 0
@@ -64,7 +64,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
-								"code" "(+ (- (call !get_val {f \"time\"}) (call !get_val {f \"time\" lag 1})) (call !get_val {f \"number\"}))"
+								"code" "(+ (- (call get_val {f \"time\"}) (call get_val {f \"time\" lag 1})) (call get_val {f \"number\"}))"
 							)
 
 					)
@@ -77,7 +77,7 @@
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
 					            ; pick some senders and some recievers.
-								"code" "(if (and (< (call !get_val {f \".session_training_index\"}) 10) (< (rand) 0.8)) (call !get_val {f \"sender\"}) (call !get_val {f \"reciever\"}) )"
+								"code" "(if (and (< (call get_val {f \".session_training_index\"}) 10) (< (rand) 0.8)) (call get_val {f \"sender\"}) (call get_val {f \"reciever\"}) )"
 							)
 					)
 				".custom4"
@@ -88,7 +88,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
-								"code" "(if (= \"mike\" (call !get_val {f \"sender\"})) \"M\" \"C\")"
+								"code" "(if (= \"mike\" (call get_val {f \"sender\"})) \"M\" \"C\")"
 							)
 					)
 			)

--- a/unit_tests/ut_h_derive_custom.amlg
+++ b/unit_tests/ut_h_derive_custom.amlg
@@ -40,9 +40,9 @@
 			(assoc
 				"sender" (assoc "type" "nominal" )
 				"reciever" (assoc "type" "nominal" )
-				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" (true)) "derived_feature_code" "(* (call get_val {feature \"mult\"}) (call get_val {feature \"number\"})")
+				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" (true)) "derived_feature_code" "(* (call value {feature \"mult\"}) (call value {feature \"number\"})")
 				"number" (assoc "type" "continuous" "decimal_places"  0 "bounds" (assoc "min"  5.0 "max"  50 "allow_null" (true)))
-				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 (call get_val {feature \"number\"}))")
+				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 (call value {feature \"number\"}))")
 				".time_delta"
 					(assoc
 						"type" "continuous"
@@ -51,7 +51,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender")
 								"ordered_by_features" (list "time" )
-								"code" "(- (call get_val {feature \"time\"}) (call get_val {feature \"time\" lag 1}))"
+								"code" "(- (call value {feature \"time\"}) (call value {feature \"time\" lag 1}))"
 							)
 						"bounds" (assoc "allow_null" (false))
 						"decimal_places" 0
@@ -64,7 +64,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
-								"code" "(+ (- (call get_val {feature \"time\"}) (call get_val {feature \"time\" lag 1})) (call get_val {feature \"number\"}))"
+								"code" "(+ (- (call value {feature \"time\"}) (call value {feature \"time\" lag 1})) (call value {feature \"number\"}))"
 							)
 
 					)
@@ -77,7 +77,7 @@
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
 					            ; pick some senders and some recievers.
-								"code" "(if (and (< (call get_val {feature \".session_training_index\"}) 10) (< (rand) 0.8)) (call get_val {feature \"sender\"}) (call get_val {feature \"reciever\"}) )"
+								"code" "(if (and (< (call value {feature \".session_training_index\"}) 10) (< (rand) 0.8)) (call value {feature \"sender\"}) (call value {feature \"reciever\"}) )"
 							)
 					)
 				".custom4"
@@ -88,7 +88,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
-								"code" "(if (= \"mike\" (call get_val {feature \"sender\"})) \"M\" \"C\")"
+								"code" "(if (= \"mike\" (call value {feature \"sender\"})) \"M\" \"C\")"
 							)
 					)
 			)

--- a/unit_tests/ut_h_derive_custom.amlg
+++ b/unit_tests/ut_h_derive_custom.amlg
@@ -40,9 +40,9 @@
 			(assoc
 				"sender" (assoc "type" "nominal" )
 				"reciever" (assoc "type" "nominal" )
-				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" (true)) "derived_feature_code" "(* (call get_val {f \"mult\"}) (call get_val {f \"number\"})")
+				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" (true)) "derived_feature_code" "(* (call get_val {feature \"mult\"}) (call get_val {feature \"number\"})")
 				"number" (assoc "type" "continuous" "decimal_places"  0 "bounds" (assoc "min"  5.0 "max"  50 "allow_null" (true)))
-				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 (call get_val {f \"number\"}))")
+				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 (call get_val {feature \"number\"}))")
 				".time_delta"
 					(assoc
 						"type" "continuous"
@@ -51,7 +51,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender")
 								"ordered_by_features" (list "time" )
-								"code" "(- (call get_val {f \"time\"}) (call get_val {f \"time\" lag 1}))"
+								"code" "(- (call get_val {feature \"time\"}) (call get_val {feature \"time\" lag 1}))"
 							)
 						"bounds" (assoc "allow_null" (false))
 						"decimal_places" 0
@@ -64,7 +64,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
-								"code" "(+ (- (call get_val {f \"time\"}) (call get_val {f \"time\" lag 1})) (call get_val {f \"number\"}))"
+								"code" "(+ (- (call get_val {feature \"time\"}) (call get_val {feature \"time\" lag 1})) (call get_val {feature \"number\"}))"
 							)
 
 					)
@@ -77,7 +77,7 @@
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
 					            ; pick some senders and some recievers.
-								"code" "(if (and (< (call get_val {f \".session_training_index\"}) 10) (< (rand) 0.8)) (call get_val {f \"sender\"}) (call get_val {f \"reciever\"}) )"
+								"code" "(if (and (< (call get_val {feature \".session_training_index\"}) 10) (< (rand) 0.8)) (call get_val {feature \"sender\"}) (call get_val {feature \"reciever\"}) )"
 							)
 					)
 				".custom4"
@@ -88,7 +88,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
-								"code" "(if (= \"mike\" (call get_val {f \"sender\"})) \"M\" \"C\")"
+								"code" "(if (= \"mike\" (call get_val {feature \"sender\"})) \"M\" \"C\")"
 							)
 					)
 			)

--- a/unit_tests/ut_h_derive_custom.amlg
+++ b/unit_tests/ut_h_derive_custom.amlg
@@ -40,9 +40,9 @@
 			(assoc
 				"sender" (assoc "type" "nominal" )
 				"reciever" (assoc "type" "nominal" )
-				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" (true)) "derived_feature_code" "(* #mult 0 #number 0")
+				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" (true)) "derived_feature_code" "(* (call !get_val {f \"mult\"}) (call !get_val {f \"number\"})")
 				"number" (assoc "type" "continuous" "decimal_places"  0 "bounds" (assoc "min"  5.0 "max"  50 "allow_null" (true)))
-				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 #number 0)")
+				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 (call !get_val {f \"number\"}))")
 				".time_delta"
 					(assoc
 						"type" "continuous"
@@ -51,7 +51,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender")
 								"ordered_by_features" (list "time" )
-								"code" "(- #time 0 #time 1)"
+								"code" "(- (call !get_val {f \"time\"}) (call !get_val {f \"time\" lag 1}))"
 							)
 						"bounds" (assoc "allow_null" (false))
 						"decimal_places" 0
@@ -64,7 +64,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
-								"code" "(+ (- #time 0 #time 1) #number 0)"
+								"code" "(+ (- (call !get_val {f \"time\"}) (call !get_val {f \"time\" lag 1})) (call !get_val {f \"number\"}))"
 							)
 
 					)
@@ -77,7 +77,7 @@
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
 					            ; pick some senders and some recievers.
-								"code" "(if (and (< #.session_training_index 10) (< (rand) 0.8)) #sender 0 #reciever 0)"
+								"code" "(if (and (< (call !get_val {f \".session_training_index\"}) 10) (< (rand) 0.8)) (call !get_val {f \"sender\"}) (call !get_val {f \"reciever\"}) )"
 							)
 					)
 				".custom4"
@@ -88,7 +88,7 @@
 								"derive_type" "custom"
 								"series_id_features" (list "sender" "reciever")
 								"ordered_by_features" (list "time" "number")
-								"code" "(if (= \"mike\" #sender 0) \"M\" \"C\")"
+								"code" "(if (= \"mike\" (call !get_val {f \"sender\"})) \"M\" \"C\")"
 							)
 					)
 			)

--- a/unit_tests/ut_h_evaluate.amlg
+++ b/unit_tests/ut_h_evaluate.amlg
@@ -55,11 +55,11 @@
     (declare (assoc
         features_to_code_map
             (assoc
-                "age" "(+ 2 (call get_val {feature \"age\"}) )"
-                "y" "(concat \"TEST:\" (call get_val {feature \"y\"}) )"
+                "age" "(+ 2 (call value {feature \"age\"}) )"
+                "y" "(concat \"TEST:\" (call value {feature \"y\"}) )"
             )
 
-        aggregation_code "(apply \"+\" (call get_val {feature \"age\"}) )"
+        aggregation_code "(apply \"+\" (call value {feature \"age\"}) )"
         start_time (system_time)
     ))
 

--- a/unit_tests/ut_h_evaluate.amlg
+++ b/unit_tests/ut_h_evaluate.amlg
@@ -55,11 +55,11 @@
     (declare (assoc
         features_to_code_map
             (assoc
-                "age" "(+ 2 #age 0)"
-                "y" "(concat \"TEST:\" #y 0)"
+                "age" "(+ 2 (call !get_val {f \"age\"}) )"
+                "y" "(concat \"TEST:\" (call !get_val {f \"y\"}) )"
             )
 
-        aggregation_code "(apply \"+\" #age 0)"
+        aggregation_code "(apply \"+\" (call !get_val {f \"age\"}) )"
         start_time (system_time)
     ))
 

--- a/unit_tests/ut_h_evaluate.amlg
+++ b/unit_tests/ut_h_evaluate.amlg
@@ -55,11 +55,11 @@
     (declare (assoc
         features_to_code_map
             (assoc
-                "age" "(+ 2 (call !get_val {f \"age\"}) )"
-                "y" "(concat \"TEST:\" (call !get_val {f \"y\"}) )"
+                "age" "(+ 2 (call get_val {f \"age\"}) )"
+                "y" "(concat \"TEST:\" (call get_val {f \"y\"}) )"
             )
 
-        aggregation_code "(apply \"+\" (call !get_val {f \"age\"}) )"
+        aggregation_code "(apply \"+\" (call get_val {f \"age\"}) )"
         start_time (system_time)
     ))
 

--- a/unit_tests/ut_h_evaluate.amlg
+++ b/unit_tests/ut_h_evaluate.amlg
@@ -55,11 +55,11 @@
     (declare (assoc
         features_to_code_map
             (assoc
-                "age" "(+ 2 (call get_val {f \"age\"}) )"
-                "y" "(concat \"TEST:\" (call get_val {f \"y\"}) )"
+                "age" "(+ 2 (call get_val {feature \"age\"}) )"
+                "y" "(concat \"TEST:\" (call get_val {feature \"y\"}) )"
             )
 
-        aggregation_code "(apply \"+\" (call get_val {f \"age\"}) )"
+        aggregation_code "(apply \"+\" (call get_val {feature \"age\"}) )"
         start_time (system_time)
     ))
 

--- a/unit_tests/ut_h_migration.amlg
+++ b/unit_tests/ut_h_migration.amlg
@@ -94,7 +94,6 @@
 			(lambda
 				(if (and (= 1 0) (contains_index feature_values_map "stock") )
 					(get feature_values_map "stock")
-					(null)
 				)
 			)
 	))
@@ -106,7 +105,6 @@
 			(lambda
 				(if (and (>= (- series_row_index 1) 0) (contains_index feat_index_map "time"))
 					(get series_data (list (- series_row_index 1) (get feat_index_map "time")) )
-					(null)
 				)
 			)
 	))

--- a/unit_tests/ut_h_post_process.amlg
+++ b/unit_tests/ut_h_post_process.amlg
@@ -27,7 +27,7 @@
 		(call_entity "howso" "set_feature_attributes" (assoc
 			feature_attributes
 				(assoc
-					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ (call get_val {f \"petal_length\" }) 40.0)")
+					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ (call get_val {feature \"petal_length\" }) 40.0)")
 					"sepal_length" (assoc "type" "continuous")
 					"sepal_width" (assoc "type" "continuous")
 					"petal_width"
@@ -35,7 +35,7 @@
 							"type" "continuous"
 							; Assigning a post_process that stores digits 1,3,2,0 in base 4 between digits 2 and 5 (indexed from most significant digit)
 							; into the value of petal_width after synth.
-							"post_process" "(set_digits (call get_val {f \"petal_width\"})  4 (list 1 3 2 0) 2 5 (false))"
+							"post_process" "(set_digits (call get_val {feature \"petal_width\"})  4 (list 1 3 2 0) 2 5 (false))"
 							"decimal_places" 8
 						)
 					"target"

--- a/unit_tests/ut_h_post_process.amlg
+++ b/unit_tests/ut_h_post_process.amlg
@@ -27,7 +27,7 @@
 		(call_entity "howso" "set_feature_attributes" (assoc
 			feature_attributes
 				(assoc
-					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ #petal_length 0 40.0)")
+					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ (call !get_val {f \"petal_length\" }) 40.0)")
 					"sepal_length" (assoc "type" "continuous")
 					"sepal_width" (assoc "type" "continuous")
 					"petal_width"
@@ -35,7 +35,7 @@
 							"type" "continuous"
 							; Assigning a post_process that stores digits 1,3,2,0 in base 4 between digits 2 and 5 (indexed from most significant digit)
 							; into the value of petal_width after synth.
-							"post_process" "(set_digits #petal_width 0 4 (list 1 3 2 0) 2 5 (false))"
+							"post_process" "(set_digits (call !get_val {f \"petal_width\"})  4 (list 1 3 2 0) 2 5 (false))"
 							"decimal_places" 8
 						)
 					"target"

--- a/unit_tests/ut_h_post_process.amlg
+++ b/unit_tests/ut_h_post_process.amlg
@@ -27,7 +27,7 @@
 		(call_entity "howso" "set_feature_attributes" (assoc
 			feature_attributes
 				(assoc
-					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ (call get_val {feature \"petal_length\" }) 40.0)")
+					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ (call value {feature \"petal_length\" }) 40.0)")
 					"sepal_length" (assoc "type" "continuous")
 					"sepal_width" (assoc "type" "continuous")
 					"petal_width"
@@ -35,7 +35,7 @@
 							"type" "continuous"
 							; Assigning a post_process that stores digits 1,3,2,0 in base 4 between digits 2 and 5 (indexed from most significant digit)
 							; into the value of petal_width after synth.
-							"post_process" "(set_digits (call get_val {feature \"petal_width\"})  4 (list 1 3 2 0) 2 5 (false))"
+							"post_process" "(set_digits (call value {feature \"petal_width\"})  4 (list 1 3 2 0) 2 5 (false))"
 							"decimal_places" 8
 						)
 					"target"

--- a/unit_tests/ut_h_post_process.amlg
+++ b/unit_tests/ut_h_post_process.amlg
@@ -27,7 +27,7 @@
 		(call_entity "howso" "set_feature_attributes" (assoc
 			feature_attributes
 				(assoc
-					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ (call !get_val {f \"petal_length\" }) 40.0)")
+					"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ (call get_val {f \"petal_length\" }) 40.0)")
 					"sepal_length" (assoc "type" "continuous")
 					"sepal_width" (assoc "type" "continuous")
 					"petal_width"
@@ -35,7 +35,7 @@
 							"type" "continuous"
 							; Assigning a post_process that stores digits 1,3,2,0 in base 4 between digits 2 and 5 (indexed from most significant digit)
 							; into the value of petal_width after synth.
-							"post_process" "(set_digits (call !get_val {f \"petal_width\"})  4 (list 1 3 2 0) 2 5 (false))"
+							"post_process" "(set_digits (call get_val {f \"petal_width\"})  4 (list 1 3 2 0) 2 5 (false))"
 							"decimal_places" 8
 						)
 					"target"

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -82,7 +82,7 @@
 
 				".custom_nominal"
 					(assoc
-						"derived_feature_code" "(concat (call !get_val {f \"stock\" }) \"_custom\")"
+						"derived_feature_code" "(concat (call get_val {f \"stock\" }) \"_custom\")"
 						"type" "nominal"
 					)
 			)

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -82,7 +82,7 @@
 
 				".custom_nominal"
 					(assoc
-						"derived_feature_code" "(concat (call get_val {f \"stock\" }) \"_custom\")"
+						"derived_feature_code" "(concat (call get_val {feature \"stock\" }) \"_custom\")"
 						"type" "nominal"
 					)
 			)

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -82,7 +82,7 @@
 
 				".custom_nominal"
 					(assoc
-						"derived_feature_code" "(concat #stock 0 \"_custom\""
+						"derived_feature_code" "(concat (call !get_val {f \"stock\" }) \"_custom\")"
 						"type" "nominal"
 					)
 			)

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -82,7 +82,7 @@
 
 				".custom_nominal"
 					(assoc
-						"derived_feature_code" "(concat (call get_val {feature \"stock\" }) \"_custom\")"
+						"derived_feature_code" "(concat (call value {feature \"stock\" }) \"_custom\")"
 						"type" "nominal"
 					)
 			)

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -110,7 +110,7 @@
 			(assoc
 				auto_derive_on_train (assoc derive_type "progress" series_id_features (list "stock") )
 				bounds (assoc min 0)
-				derived_feature_code "(min 1 (+ #.series_progress 1 #.series_progress_delta 1))"
+				derived_feature_code "(min 1 (+ (call !get_val {f \".series_progress\" lag 1}) (call !get_val {f \".series_progress_delta\" lag 1}) ))"
 				max_row_lag 1
 				type "continuous"
 			)

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -111,7 +111,7 @@
 				auto_derive_on_train (assoc derive_type "progress" series_id_features (list "stock") )
 				bounds (assoc min 0)
 				code_features [".series_progress" ".series_progress_delta"]
-				derived_feature_code "(min 1 (+ (call !get_val {f \".series_progress\" lag 1}) (call !get_val {f \".series_progress_delta\" lag 1}) ))"
+				derived_feature_code "(min 1 (+ (call get_val {f \".series_progress\" lag 1}) (call get_val {f \".series_progress_delta\" lag 1}) ))"
 				max_row_lag 1
 				type "continuous"
 			)

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -110,6 +110,7 @@
 			(assoc
 				auto_derive_on_train (assoc derive_type "progress" series_id_features (list "stock") )
 				bounds (assoc min 0)
+				code_features [".series_progress" ".series_progress_delta"]
 				derived_feature_code "(min 1 (+ (call !get_val {f \".series_progress\" lag 1}) (call !get_val {f \".series_progress_delta\" lag 1}) ))"
 				max_row_lag 1
 				type "continuous"

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -111,7 +111,7 @@
 				auto_derive_on_train (assoc derive_type "progress" series_id_features (list "stock") )
 				bounds (assoc min 0)
 				code_features [".series_progress" ".series_progress_delta"]
-				derived_feature_code "(min 1 (+ (call get_val {feature \".series_progress\" lag 1}) (call get_val {feature \".series_progress_delta\" lag 1}) ))"
+				derived_feature_code "(min 1 (+ (call value {feature \".series_progress\" lag 1}) (call value {feature \".series_progress_delta\" lag 1}) ))"
 				max_row_lag 1
 				type "continuous"
 			)

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -111,7 +111,7 @@
 				auto_derive_on_train (assoc derive_type "progress" series_id_features (list "stock") )
 				bounds (assoc min 0)
 				code_features [".series_progress" ".series_progress_delta"]
-				derived_feature_code "(min 1 (+ (call get_val {f \".series_progress\" lag 1}) (call get_val {f \".series_progress_delta\" lag 1}) ))"
+				derived_feature_code "(min 1 (+ (call get_val {feature \".series_progress\" lag 1}) (call get_val {feature \".series_progress_delta\" lag 1}) ))"
 				max_row_lag 1
 				type "continuous"
 			)


### PR DESCRIPTION
replaces instances of feature references in derivation code from the generic format of **#"feature name" <lag_value>**
to: **(call value{ feature "feature_name" _lag lag_value_ })** where lag and lag_value are optional and only needed if lag > 0
e,g.:
 "(+ #\\"my feature\\" 0  #feat_b 2)"   
 is now: 
 "(+ (call value {feature \\"my feature\\"}) (call value {feature \\"feat_b\\" lag 2}) )"