### PR TITLE
24480: Updates time-series logic in handling synchronous timesteps

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -145,6 +145,7 @@
 	#!derivedFeaturesMap (null)
 	#!sourceToDerivedFeatureMap (null)
 	#!featureCustomDerivedMethods (null)
+	#!tsSynchronousCounterFeature (null)
 	#!tsTimeFeature (null)
 	#!tsTimeDeltaFeature (null)
 	#!tsTimeFeatureUniversal (null)
@@ -565,6 +566,9 @@
 
 			;a value used to limit the depth of opcode operations of each usage of (call_sandboxed)
 			!sandboxedOpcodeDepthLimit 50
+
+			;the name of the feature that counts how many additional cases are on the same time value in the series
+			!tsSynchronousCounterFeature ".synchronous_counter"
 
 			;name of the 'time' feature if the model is a time series model
 			!tsTimeFeature (null)

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -220,17 +220,6 @@
 			series_id_features (null)
 		)
 
-
-		(declare (assoc
-			has_synchronous_timesteps
-				(>
-					(size (contained_entities
-						(query_equals time_feature_delta 0)
-					))
-					0
-				)
-		))
-
 		(declare (assoc
 			sync_counter_lag_name (concat !tsSynchronousCounterFeature "_lag_1")
 			necessary_features (values (append series_ordered_by_features [time_feature time_feature_delta !internalLabelSessionTrainingIndex]) (true))
@@ -285,6 +274,16 @@
 						)
 				))
 
+				(declare (assoc
+					has_synchronous_timesteps
+						(>
+							(size (contained_entities
+								(query_in_entity_list series_case_ids)
+								(query_equals time_feature_delta 0)
+							))
+							0
+						)
+				))
 
 				(declare (assoc
 					synchronous_counter_values
@@ -355,10 +354,6 @@
 								(if (> (current_index 1) 0)
 									(get synchronous_counter_values (- (current_index 1) 1))
 								)
-						)
-
-						(if (and (= (null) sync_counter_lag) (!= 0 (current_index)))
-							(+ 23.4)
 						)
 
 						(if (contains_label case_id !tsSynchronousCounterFeature)

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -42,7 +42,7 @@
 			series_ordered_by_features
 				(if feature_attribute_map
 					(get feature_attribute_map "ordered_by_features")
-					[!tsTimeFeature]
+					[!tsTimeFeature !internalLabelSessionTrainingIndex]
 				)
 		))
 
@@ -206,6 +206,156 @@
 			(assign_to_entities (assoc !tsSeriesLimitLength ts_series_length_limit ))
 		)
 	)
+
+	;helper method to derive the values for the synchronous counter feature for all trained cases/series
+	;parameters:
+	;  time_feature: the name of the time feature
+	;  time_feature_delta: the name of the time feature's delta
+	;  series_ordered_by_features: the ordered list of feature names to sort the series data by in increasing order
+	;  series_id_features: the ordered list of feature names to identify each unique series
+	#!CreateSynchronousCounterFeature
+	(declare
+		(assoc
+			time_feature (null)
+			time_feature_delta (null)
+			series_ordered_by_features (null)
+			series_id_features (null)
+		)
+
+		(declare (assoc
+			necessary_features (values (append series_ordered_by_features [time_feature time_feature_delta !sessionTrainingIndex]) (true))
+		))
+
+		(declare (assoc
+			necessary_feature_index_map (zip necessary_features (indices necessary_features))
+		))
+
+		;process each series individually
+		;pull all the values for the necessary_features, sort them, and then derive this feature based on the specified code
+		(map
+			(lambda (let
+				;(current_value) is in the format of (list (query_equals "series_feature_name" value) ... ) for all series_feature_name
+				(assoc series_case_ids (contained_entities (current_value 1)) )
+
+				;series_data is all the necessary_features's values along with the training index and case_id appended as the last two columns
+				;when the data is sorted, ties will be broken by the training index to assist with consistency
+				(declare (assoc
+					series_data
+						(map
+							(lambda
+								;append two features: session index and case_id
+								(append
+									;series_ordered_by_features should include the time feature and the sessionTrainingIndex
+									(retrieve_from_entity (current_value) necessary_features)
+									(current_value)
+								)
+							)
+							series_case_ids
+						)
+				))
+
+				;sort the series data according to the specified features if ordering has been provided
+				(if (size series_ordered_by_features)
+					(assign (assoc
+						series_data
+							(call !MultiSortList (assoc
+								data series_data
+								column_order_indices
+									(unzip necessary_feature_index_map series_ordered_by_features)
+							))
+					))
+				)
+
+				;store the case ids in the new sorted order of series_data
+				(assign (assoc
+					series_case_ids
+						(map
+							(lambda (last (current_value)))
+							series_data
+						)
+				))
+
+
+				(declare (assoc
+					synchronous_counter_values
+						(let
+							(assoc
+								prev_counter 0
+								time_delta_index (get necessary_feature_index_map time_feature_delta)
+							)
+
+							(map
+								(lambda
+									(if (> prev_counter 0)
+										;if prev counter is already greater than 0, just decrement
+										(seq
+											(accum (assoc prev_counter -1))
+											prev_counter
+										)
+
+										;otherwise the last time value must be "finished" and onto the next
+										;must count the number of values until time_delta is positive again
+
+										(seq
+											(assign (assoc
+												prev_counter
+													;if the next case is on the same time value, must count how many cases are also on it.
+													(if (=
+															(get series_data [(+ (current_index 2) 1) time_delta_index])
+															0
+														)
+														;in this while loop (current_index 1) is the index in series_data
+														;(current_index) is the (while) index. So (+ (current_index 1) (current_index) 1) is
+														;the index of series_data being checked
+														(while
+															;while the "next" time delta is still zero, continue
+															(=
+																(get series_data [(+ (current_index 3) (current_index 1) 1) time_delta_index])
+																0
+															)
+															(+ 1 (current_index))
+														)
+
+														;otherwise this is the only case on this time value
+														0
+													)
+
+											))
+											prev_counter
+										)
+
+									)
+								)
+								series_data
+							)
+						)
+				))
+
+				(map
+					(lambda (let
+						(assoc case_id (current_index 1) )
+						(if (contains_label case_id !tsSynchronousCounterFeature)
+							(assign_to_entities
+								case_id
+								(associate !tsSynchronousCounterFeature (current_value))
+							)
+							;else these labels don't exist yet, need to append them to the entity
+							(accum_entity_roots
+								case_id
+								(zip_labels [!tsSynchronousCounterFeature] [(current_value 1)])
+							)
+						)
+					))
+					(zip series_case_ids synchronous_counter_values)
+				)
+			))
+
+			;generates a list of queries for each unique series id (where each series id may be a conjuction of several features)
+			(call !GenerateUniqueSeriesQueries (assoc series_id_features series_id_features ))
+		)
+
+
+	) ;end !CreateSynchronousCounterFeature
 
 	;derives the feature value for the specified feature provided the data to derive from
 	;parameters:

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -222,21 +222,16 @@
 			series_id_features (null)
 		)
 
-		(if (=
-				(size (contained_entities
-					(query_equals time_feature_delta 0)
-				))
-				0
-			)
-			(seq
-				(call !StoreCaseValues (assoc
-					case_values_map (zip (call !AllCases) 0)
-					label_name !tsSynchronousCounterFeature
-					overwrite (true)
-				))
-				(conclude)
-			)
-		)
+
+		(declare (assoc
+			has_synchronous_timesteps
+				(>
+					(size (contained_entities
+						(query_equals time_feature_delta 0)
+					))
+					0
+				)
+		))
 
 		(declare (assoc
 			sync_counter_lag_name (concat !tsSynchronousCounterFeature "_lag_1")
@@ -295,56 +290,61 @@
 
 				(declare (assoc
 					synchronous_counter_values
-						(let
-							(assoc
-								prev_counter 0
-								time_delta_index (get necessary_feature_index_map time_feature_delta)
-							)
+						(if has_synchronous_timesteps
+							(let
+								(assoc
+									prev_counter 0
+									time_delta_index (get necessary_feature_index_map time_feature_delta)
+								)
 
-							(map
-								(lambda
-									(if (> prev_counter 0)
-										;if prev counter is already greater than 0, just decrement
-										(seq
-											(accum (assoc prev_counter -1))
-											prev_counter
-										)
-
-										;otherwise the last time value must be "finished" and onto the next
-										;must count the number of values until time_delta is positive again
-
-										(seq
-											(assign (assoc
+								(map
+									(lambda
+										(if (> prev_counter 0)
+											;if prev counter is already greater than 0, just decrement
+											(seq
+												(accum (assoc prev_counter -1))
 												prev_counter
-													;if the next case is on the same time value, must count how many cases are also on it.
-													(if (=
-															(get series_data [(+ (current_index 2) 1) time_delta_index])
-															0
-														)
-														;in this while loop (current_index 1) is the index in series_data
-														;(current_index) is the (while) index. So (+ (current_index 1) (current_index) 1) is
-														;the index of series_data being checked
-														(while
-															;while the "next" time delta is still zero, continue
-															(=
-																(get series_data [(+ (current_index 3) (current_index 1) 1) time_delta_index])
+											)
+
+											;otherwise the last time value must be "finished" and onto the next
+											;must count the number of values until time_delta is positive again
+
+											(seq
+												(assign (assoc
+													prev_counter
+														;if the next case is on the same time value, must count how many cases are also on it.
+														(if (=
+																(get series_data [(+ (current_index 2) 1) time_delta_index])
 																0
 															)
-															(+ 1 (current_index))
+															;in this while loop (current_index 1) is the index in series_data
+															;(current_index) is the (while) index. So (+ (current_index 1) (current_index) 1) is
+															;the index of series_data being checked
+															(while
+																;while the "next" time delta is still zero, continue
+																(=
+																	(get series_data [(+ (current_index 3) (current_index 1) 1) time_delta_index])
+																	0
+																)
+																(+ 1 (current_index))
+															)
+
+															;otherwise this is the only case on this time value
+															0
 														)
 
-														;otherwise this is the only case on this time value
-														0
-													)
+												))
+												prev_counter
+											)
 
-											))
-											prev_counter
 										)
-
 									)
+									series_data
 								)
-								series_data
 							)
+
+							;otherwise all counter values should be zero
+							(map (lambda 0) series_case_ids)
 						)
 				))
 

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -229,6 +229,10 @@
 			necessary_feature_index_map (zip necessary_features (indices necessary_features))
 		))
 
+		(declare (assoc
+			time_delta_index (get necessary_feature_index_map time_feature_delta)
+		))
+
 		;process each series individually
 		;pull all the values for the necessary_features, sort them, and then derive this feature based on the specified code
 		(map
@@ -291,7 +295,6 @@
 							(let
 								(assoc
 									prev_counter 0
-									time_delta_index (get necessary_feature_index_map time_feature_delta)
 								)
 
 								(map
@@ -305,15 +308,17 @@
 
 											;otherwise the last time value must be "finished" and onto the next
 											;must count the number of values until time_delta is positive again
+											(if (!=
+													(get series_data [(+ (current_index 1) 1) time_delta_index])
+													0
+												)
+												;if the next value is on a different time value, can just return zero
+												0
 
-											(seq
-												(assign (assoc
-													prev_counter
-														;if the next case is on the same time value, must count how many cases are also on it.
-														(if (=
-																(get series_data [(+ (current_index 2) 1) time_delta_index])
-																0
-															)
+												;if the next case is on the same time value, must count how many cases are also on it.
+												(seq
+													(assign (assoc
+														prev_counter
 															;in this while loop (current_index 1) is the index in series_data
 															;(current_index) is the (while) index. So (+ (current_index 1) (current_index) 1) is
 															;the index of series_data being checked
@@ -326,14 +331,10 @@
 																(+ 1 (current_index))
 															)
 
-															;otherwise this is the only case on this time value
-															0
-														)
-
-												))
-												prev_counter
+													))
+													prev_counter
+												)
 											)
-
 										)
 									)
 									series_data

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -222,6 +222,22 @@
 			series_id_features (null)
 		)
 
+		(if (=
+				(size (contained_entities
+					(query_equals time_feature_delta 0)
+				))
+				0
+			)
+			(seq
+				(call !StoreCaseValues (assoc
+					case_values_map (zip (call !AllCases) 0)
+					label_name !tsSynchronousCounterFeature
+					overwrite (true)
+				))
+				(conclude)
+			)
+		)
+
 		(declare (assoc
 			necessary_features (values (append series_ordered_by_features [time_feature time_feature_delta !internalLabelSessionTrainingIndex]) (true))
 		))

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -239,6 +239,7 @@
 		)
 
 		(declare (assoc
+			sync_counter_lag_name (concat !tsSynchronousCounterFeature "_lag_1")
 			necessary_features (values (append series_ordered_by_features [time_feature time_feature_delta !internalLabelSessionTrainingIndex]) (true))
 		))
 
@@ -349,20 +350,38 @@
 
 				(map
 					(lambda (let
-						(assoc case_id (current_index 1) )
+						(assoc
+							case_id (current_value 1)
+							sync_counter (get synchronous_counter_values (current_index 1))
+							sync_counter_lag
+								(if (> (current_index 1) 0)
+									(get synchronous_counter_values (- (current_index 1) 1))
+								)
+						)
+
+						(if (and (= (null) sync_counter_lag) (!= 0 (current_index)))
+							(+ 23.4)
+						)
+
 						(if (contains_label case_id !tsSynchronousCounterFeature)
 							(assign_to_entities
 								case_id
-								(associate !tsSynchronousCounterFeature (current_value 1))
+								(associate
+									!tsSynchronousCounterFeature sync_counter
+									sync_counter_lag_name sync_counter_lag
+								)
 							)
 							;else these labels don't exist yet, need to append them to the entity
 							(accum_entity_roots
 								case_id
-								(zip_labels [!tsSynchronousCounterFeature] [(current_value 1)])
+								(zip_labels
+									[!tsSynchronousCounterFeature sync_counter_lag_name]
+									[sync_counter sync_counter_lag]
+								)
 							)
 						)
 					))
-					(zip series_case_ids synchronous_counter_values)
+					series_case_ids
 				)
 			))
 

--- a/howso/custom_codes.amlg
+++ b/howso/custom_codes.amlg
@@ -223,7 +223,7 @@
 		)
 
 		(declare (assoc
-			necessary_features (values (append series_ordered_by_features [time_feature time_feature_delta !sessionTrainingIndex]) (true))
+			necessary_features (values (append series_ordered_by_features [time_feature time_feature_delta !internalLabelSessionTrainingIndex]) (true))
 		))
 
 		(declare (assoc
@@ -337,7 +337,7 @@
 						(if (contains_label case_id !tsSynchronousCounterFeature)
 							(assign_to_entities
 								case_id
-								(associate !tsSynchronousCounterFeature (current_value))
+								(associate !tsSynchronousCounterFeature (current_value 1))
 							)
 							;else these labels don't exist yet, need to append them to the entity
 							(accum_entity_roots

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -12,8 +12,8 @@
 	;			dataset. Referencing data in rows uses 0-based indexing, where the current row index is 0, the previous row's is 1, etc.
 	;			Specified code may do simple logic and numeric operations on feature values referenced via feature name and row offset.
 	;			Examples:
-	;				"(call val {feature "x" lag 1})" - Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).
-	;				"(- (call val {feature "y" lag 0}) (call val {feature "x" lag 1}))" - Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offest 1) row.
+	;				"(call value {feature "x" lag 1})" - Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).
+	;				"(- (call value {feature "y" lag 0}) (call value {feature "x" lag 1}))" - Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offest 1) row.
 	;		'code': string, Code describing how feature could be derived.
 	;				Same format as 'derived_feature_code' as defined in attributes. Example: "(- (call value {feature \"y\"})  (call value {feature \"x\" lag 1}) )"
 	;		'series_id_features' : (optional) list of feature name(s) of series for which to derive this feature. A series is the conjunction of all

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -83,16 +83,14 @@
 			))
 		)
 
-		(if (size (contained_entities
-				(query_equals time_feature_delta 0)
-			))
-			(call !CreateSynchronousCounterFeature (assoc
-				time_feature !tsTimeFeature
-				time_feature_delta time_feature_delta
-				series_ordered_by_features [!tsTimeFeature !internalLabelSessionTrainingIndex]
-				series_id_features (get !tsFeaturesMap "series_id_features")
-			))
-		)
+		;In datasets with no synchonous cases, this method will early-out and store
+		;zeros for all cases' synchronous counters (making it a inactive feature)
+		(call !CreateSynchronousCounterFeature (assoc
+			time_feature !tsTimeFeature
+			time_feature_delta time_feature_delta
+			series_ordered_by_features [!tsTimeFeature !internalLabelSessionTrainingIndex]
+			series_id_features (get !tsFeaturesMap "series_id_features")
+		))
 
 		;keep only features that have a custom derivation specified and aren't time_feature_delta which was derived above
 		(assign (assoc

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -83,6 +83,17 @@
 			))
 		)
 
+		(if (size (contained_entities
+				(query_equals time_feature_delta 0)
+			))
+			(call !CreateSynchronousCounterFeature (assoc
+				time_feature !tsTimeFeature
+				time_feature_delta time_feature_delta
+				series_ordered_by_features [!tsTimeFeature !internalLabelSessionTrainingIndex]
+				series_id_features (get !tsFeaturesMap "series_id_features")
+			))
+		)
+
 		;keep only features that have a custom derivation specified and aren't time_feature_delta which was derived above
 		(assign (assoc
 			derived_features
@@ -382,7 +393,7 @@
 
 		(declare (assoc
 			series_id_features (get !tsFeaturesMap "series_id_features")
-			series_ordered_by_features [!tsTimeFeature]
+			series_ordered_by_features [!tsTimeFeature !internalLabelSessionTrainingIndex]
 		))
 		(declare (assoc
 			;list of features that are necessary to be able to derive the specified lag features, i.e., the original non-lagged features

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -790,6 +790,7 @@
 						(list ".series_progress_delta")
 						(list)
 					)
+					(list !tsSynchronousCounterFeature)
 				)
 		))
 

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -790,7 +790,7 @@
 						(list ".series_progress_delta")
 						(list)
 					)
-					(list !tsSynchronousCounterFeature)
+					[!tsSynchronousCounterFeature]
 				)
 		))
 

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -91,7 +91,6 @@
 											progress (/ (- (current_value 1) first_value) range)
 											;delta is the % change,  don't allow 0, use the fixed delta instead
 											delta (or (/ (- (current_value 1) previous_value) range) fixed_delta)
-											;TODO:CADE should this be able to be zero?? I figure so
 										)
 
 										;if the series is of length 1, set progress and delta to be 1 and prevent a divide by 0

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -522,44 +522,45 @@
 								num_orders (if (contains_index ts_attributes "order") (get ts_attributes "order") 1)
 							)
 
-							(if (= "delta" (get ts_attributes "type"))
-								(let
-									(assoc
-										delta_sub_feature_names
-											(range
-												(lambda (concat "." feature "_delta_" (current_index)) )
-												1 num_orders 1
-											)
-									)
-
-									(accum (assoc derived_feature_attributes (call !MakeDeltaFeatureAttributes) ))
-
-									;time feature deltas are ordered first, in descending order
-									(if (= feature time_feature)
-										(assign (assoc
-											delta_features (append (reverse delta_sub_feature_names) delta_features)
-											train_delta_features (append (reverse delta_sub_feature_names) train_delta_features)
-										))
-
-										(seq
-											(accum (assoc
-												train_delta_features delta_sub_feature_names
-												;append all feature names for orders that do not need to be derived, i.e., > derived_orders
-												delta_features (unzip delta_sub_feature_names (range derived_orders (- num_orders 1)))
-											))
-											;prepend features names for orders <= derived_orders to the front of the list in in descending order
-											(assign (assoc
-												derived_order_features
-													(append
-														(reverse (filter (lambda (< (current_index) derived_orders)) delta_sub_feature_names) )
-														derived_order_features
-													)
-											))
+							;deltas
+							(let
+								(assoc
+									delta_sub_feature_names
+										(range
+											(lambda (concat "." feature "_delta_" (current_index)) )
+											1 num_orders 1
 										)
-									)
 								)
 
-								(= "rate" (get ts_attributes "type"))
+								(accum (assoc derived_feature_attributes (call !MakeDeltaFeatureAttributes) ))
+
+								;time feature deltas are ordered first, in descending order
+								(if (= feature time_feature)
+									(assign (assoc
+										delta_features (append (reverse delta_sub_feature_names) delta_features)
+										train_delta_features (append (reverse delta_sub_feature_names) train_delta_features)
+									))
+
+									(seq
+										(accum (assoc
+											train_delta_features delta_sub_feature_names
+											;append all feature names for orders that do not need to be derived, i.e., > derived_orders
+											delta_features (unzip delta_sub_feature_names (range derived_orders (- num_orders 1)))
+										))
+										;prepend features names for orders <= derived_orders to the front of the list in in descending order
+										(assign (assoc
+											derived_order_features
+												(append
+													(reverse (filter (lambda (< (current_index) derived_orders)) delta_sub_feature_names) )
+													derived_order_features
+												)
+										))
+									)
+								)
+							)
+
+							(if (!= feature time_feature)
+								;rates. Made for all continuous features except the time feature
 								(let
 									(assoc
 										rate_sub_feature_names

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -640,6 +640,15 @@
 							"bounds" (assoc "min" 0.0 "allow_null" (false))
 							"decimal_places" 0
 						)
+					".synchronous_counter_lag_1"
+						(assoc
+							"type" "continuous"
+							"bounds" (assoc "min" 0.0)
+							"decimal_places" 0
+							"derived_feature_code" "#.synchronous_counter 1"
+							"ts_type" "lag"
+							"parent" ".synchronous_counter"
+						)
 				)
 		))
 

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -91,6 +91,7 @@
 											progress (/ (- (current_value 1) first_value) range)
 											;delta is the % change,  don't allow 0, use the fixed delta instead
 											delta (or (/ (- (current_value 1) previous_value) range) fixed_delta)
+											;TODO:CADE should this be able to be zero?? I figure so
 										)
 
 										;if the series is of length 1, set progress and delta to be 1 and prevent a divide by 0
@@ -635,8 +636,9 @@
 					".synchronous_counter"
 						(assoc
 							"type" "continuous"
-							"derived_feature_code" "(if (> #.synchonous_counter 0 0) (- #.synchronous_counter 0 1) (null))"
-							"bounds" (assoc "min" 0.0)
+							;if previous case's counter is greater than 0 decrement, otherwise generate a new value
+							"bounds" (assoc "min" 0.0 "allow_null" (false))
+							"decimal_places" 0
 						)
 				)
 		))

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -394,7 +394,7 @@
 			(= "rate_accumulation" derivation_type)
 			(seq
 				(assign (assoc
-					output_string (concat "(+ #\"." feature "_lag_1\" 0 (* #\"." time_feature "_delta_1\" 0 #\"." feature "_rate_1\" 0)" )
+					output_string (concat "(if (> #\"." time_feature "_delta_1\" 0 0) (+ #\"." feature "_lag_1\" 0 (* #\"." time_feature "_delta_1\" 0 #\"." feature "_rate_1\" 0)" )
 				))
 				(if (> order 1)
 					(accum (assoc
@@ -409,7 +409,7 @@
 					))
 				)
 				(accum (assoc
-					output_string ")"
+					output_string (concat ") (+ #\"." feature "_lag_1\" 0 #\"." feature "_delta_1\" 0))")
 				))
 			)
 
@@ -559,7 +559,8 @@
 								)
 							)
 
-							(if (!= feature time_feature)
+
+							(if (= "rate" (get ts_attributes "type"))
 								;rates. Made for all continuous features except the time feature
 								(let
 									(assoc

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -523,7 +523,7 @@
 								num_orders (if (contains_index ts_attributes "order") (get ts_attributes "order") 1)
 							)
 
-							;deltas
+							;always compute deltas, even for rate-type TS features
 							(let
 								(assoc
 									delta_sub_feature_names

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -635,6 +635,7 @@
 					".synchronous_counter"
 						(assoc
 							"type" "continuous"
+							"derived_feature_code" "(if (> #.synchonous_counter 0 0) (- #.synchronous_counter 0 1) (null))"
 							"bounds" (assoc "min" 0.0)
 						)
 				)

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -631,6 +631,12 @@
 							"type" "continuous"
 							"bounds" (assoc "min" 0.0 "max" 1.0)
 						)
+					;counter for following cases with the same time value within the same series
+					".synchronous_counter"
+						(assoc
+							"type" "continuous"
+							"bounds" (assoc "min" 0.0)
+						)
 				)
 		))
 

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -421,6 +421,7 @@
 			;track progress length of series being generated if it's a stop condition in the series_stop_map
 			track_progress (contains_index series_stop_map ".series_progress")
 			total_progress 0
+			prev_sync_counter (null)
 			max_order (null)
 			modified_feature_bounds_map (assoc)
 			derived_context_features derived_context_features
@@ -574,6 +575,7 @@
 						retries 0
 						previous_row_failed (false)
 						series_failed (false)
+						prev_sync_counter (null)
 					))
 
 					(if output_details
@@ -725,6 +727,32 @@
 					;if first case of series and using continue_series, start with computed series_progress
 					(if (and use_initial_context_features initial_existing_progress)
 						(assign (assoc current_case_map (set current_case_map ".series_progress" initial_existing_progress)))
+					)
+
+					;SYNCHRONOUS COUNTER LOGIC
+					(if (> last_series_index 0)
+						(seq
+							(assign (assoc
+								prev_sync_counter
+									(get
+										(zip features (get series_data -2)) ;not the current case, but the previous case
+										!tsSynchronousCounterFeature
+									)
+							))
+
+							(if (> prev_sync_counter 0)
+								;if previously greater than zero, decrement and set this case to that value (add it to context as well)
+								;and set time delta to zero + remove from action
+								(accum (assoc
+									current_case_map
+										(associate
+											!tsSynchronousCounterFeature (- prev_sync_counter 1)
+											!tsTimeDeltaFeature 0
+										)
+									react_context_features [!tsTimeDeltaFeature !tsSynchronousCounterFeature]
+								))
+							)
+						)
 					)
 
 					;filter out action (rate and delta) features that are dependent on lags that were skipped due to referencing rows that have not been synthed yet
@@ -1650,6 +1678,30 @@
 					)
 				)
 		))
+
+		;more synchronous counter logic
+		;if prev_sync_counter is 0, then we need to make sure we generate a nonzero time-delta
+		(if (= prev_sync_counter 0)
+			(assign (assoc
+				modified_feature_bounds_map
+					(set
+						modified_feature_bounds_map
+						[!tsTimeDeltaFeature "min"]
+						(if (contains_index !featureDateTimeMap !tsTimeFeature)
+							(/ (get !featureDateTimeMap [!tsTimeFeature "min_nonzero_delta"]) 2)
+							(get
+								(first (compute_on_contained_entities
+									(query_not_equals !tsTimeDeltaFeature 0)
+									(query_min !tsTimeDeltaFeature)
+									(query_exists !tsTimeDeltaFeature)
+								))
+								!tsTimeDeltaFeature
+							)
+						)
+					)
+			))
+		)
+
 
 		(assign (assoc
 			react_output

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -253,7 +253,8 @@
 									(not (contains_value features (current_value)))
 									(!= (null) (get !featureAttributes [(current_value 1) "derived_feature_code"]) )
 									(= (null) (get !featureAttributes [(current_value 1) "auto_derive_on_train"]) )
-									(!= (current_value) ".series_progress_delta")
+									;both of these features are derived manually
+									(not (contains_value [".series_progress_delta" ".synchronous_counter_lag_1"] (current_value)))
 								)
 							)
 							!trainedFeatures

--- a/howso/train_ts_ablation.amlg
+++ b/howso/train_ts_ablation.amlg
@@ -175,7 +175,7 @@
 		))
 		(declare (assoc
 			series_id_features (get !tsFeaturesMap "series_id_features")
-			series_ordered_by_features [!tsTimeFeature]
+			series_ordered_by_features [!tsTimeFeature !internalLabelSessionTrainingIndex]
 			;check if the incoming cases are group sorted by series_id
 			needs_grouping
 				(call !DoesDataNeedGroupingById (assoc

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -169,8 +169,8 @@
 										"code may do simple logic and numeric operations on feature values referenced via feature name and row offset\n\n"
 										"Examples:\n"
 
-										"- ``\"(call val {feature \"x\" lag 1})``: Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).\n"
-										"- ``\"(- (call val {feature \"y\" lag 0}) (call val {feature \"x\" lag 1}))\"``: Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offset 1) row.\n"
+										"- ``\"(call value {feature \"x\" lag 1})``: Use the value for feature 'x' from the previously processed row (offset of 1, one lag value).\n"
+										"- ``\"(- (call value {feature \"y\" lag 0}) (call value {feature \"x\" lag 1}))\"``: Feature 'y' value from current (offset 0) row  minus feature 'x' value from previous (offset 1) row.\n"
 									)
 							)
 						code_features

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -611,5 +611,26 @@
 				)
 		))
 	)
+"106.0.1"
+	(seq
+		(if !tsTimeFeature
+			(seq
+				;re-assign feature attributes to create the synchronous counter feature attributes
+				(call set_feature_attributes (assoc
+					feature_attributes (get (call get_feature_attributes) (list 1 "payload"))
+				))
+
+				;create the synchronous counter feature and populate its values
+				(call !CreateSynchronousCounterFeature (assoc
+					time_feature !tsTimeFeature
+					time_feature_delta (concat "." !tsTimeFeature "_delta_1")
+					series_ordered_by_features [!tsTimeFeature !internalLabelSessionTrainingIndex]
+					series_id_features (get !tsFeaturesMap "series_id_features")
+				))
+			)
+		)
+
+
+	)
 
 ))

--- a/unit_tests/ut_h_derive_start_end.amlg
+++ b/unit_tests/ut_h_derive_start_end.amlg
@@ -49,7 +49,6 @@
 		cases data
 		features features
 		session "session"
-		;derived_features (null)  ;should auto populate
 	))
 
 	(declare (assoc

--- a/unit_tests/ut_h_shared_deviations_series.amlg
+++ b/unit_tests/ut_h_shared_deviations_series.amlg
@@ -95,7 +95,7 @@
 
 	(declare (assoc
 		shared_feature_deviations
-			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2..value_rate_1.stock.time.value." ".none" "featureDeviations"))
+			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(declare (assoc shared_feature_deviations (get shared_deviations_hp_map deviations_param_path)))
@@ -158,7 +158,7 @@
 	(call_entity "howso" "analyze" (assoc use_deviations (true)))
 
 	(assign (assoc shared_feature_deviations
-		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2..value_rate_1.stock.time.value." ".none" "featureDeviations"))
+		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(print "Series lag features with no shared deviations are different: .value_lag_1 and .value_lag_2.")

--- a/unit_tests/ut_h_shared_deviations_series.amlg
+++ b/unit_tests/ut_h_shared_deviations_series.amlg
@@ -95,7 +95,7 @@
 
 	(declare (assoc
 		shared_feature_deviations
-			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2..value_rate_1.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(declare (assoc shared_feature_deviations (get shared_deviations_hp_map deviations_param_path)))
@@ -158,7 +158,7 @@
 	(call_entity "howso" "analyze" (assoc use_deviations (true)))
 
 	(assign (assoc shared_feature_deviations
-		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2..value_rate_1.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(print "Series lag features with no shared deviations are different: .value_lag_1 and .value_lag_2.")

--- a/unit_tests/ut_h_shared_deviations_series.amlg
+++ b/unit_tests/ut_h_shared_deviations_series.amlg
@@ -95,7 +95,7 @@
 
 	(declare (assoc
 		shared_feature_deviations
-			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..synchronous_counter..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(declare (assoc shared_feature_deviations (get shared_deviations_hp_map deviations_param_path)))
@@ -158,7 +158,7 @@
 	(call_entity "howso" "analyze" (assoc use_deviations (true)))
 
 	(assign (assoc shared_feature_deviations
-		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..synchronous_counter..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(print "Series lag features with no shared deviations are different: .value_lag_1 and .value_lag_2.")

--- a/unit_tests/ut_h_shared_deviations_series.amlg
+++ b/unit_tests/ut_h_shared_deviations_series.amlg
@@ -95,7 +95,7 @@
 
 	(declare (assoc
 		shared_feature_deviations
-			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..synchronous_counter..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(declare (assoc shared_feature_deviations (get shared_deviations_hp_map deviations_param_path)))
@@ -158,7 +158,7 @@
 	(call_entity "howso" "analyze" (assoc use_deviations (true)))
 
 	(assign (assoc shared_feature_deviations
-		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..synchronous_counter..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(print "Series lag features with no shared deviations are different: .value_lag_1 and .value_lag_2.")

--- a/unit_tests/ut_h_synchronous_cases.amlg
+++ b/unit_tests/ut_h_synchronous_cases.amlg
@@ -61,11 +61,35 @@
 	))
 	(call_entity "howso" "analyze")
 
+	(declare (assoc
+		cases
+			(get
+				(call_entity "howso" "get_cases" (assoc
+					features [".synchronous_counter" ".synchronous_counter_lag_1"]
+					session "session"
+				))
+				[1 "payload" "cases"]
+			)
+	))
+	(print "Synchronous counter values are derived correctly: ")
+	(call assert_same (assoc
+		obs (trunc cases 6)
+		exp
+			[
+				[0 (null)]
+				[0 0]
+				[0 0]
+				[0 0]
+				[1 0]
+				[0 1]
+			]
+	))
+
 	(assign (assoc
 		result
 			(call_entity "howso" "react_series" (assoc
 				desired_conviction (null)
-				action_features ["store" "day_of_week" "time" "value"]
+				action_features ["store" "day_of_week" "time" "value" ".synchronous_counter"]
 				continue_series (true)
 				series_context_features ["store" "day_of_week" "time" "value"]
 				series_context_values
@@ -91,6 +115,12 @@
 	(print "These rows should also have the same rounded time values: ")
 	(call assert_true (assoc
 		obs (= (get generated_series [2 2]) (get generated_series [3 2]))
+	))
+
+	(print "The first Thursday should have a synchronous counter value of 1: ")
+	(call assert_same (assoc
+		exp 1
+		obs (get generated_series [2 4])
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name))

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -235,14 +235,16 @@
 		))
 
 		(assoc
-			delta_features (list ".date_delta_1")
+			delta_features (list ".date_delta_1" ".f1_delta_1" ".f2_delta_1" ".f2_delta_2" ".f3_delta_1")
 			derived_order_features (list)
 			lag_features (list ".date_lag_1" ".f1_lag_1" ".f2_lag_1" ".f3_lag_1")
 			rate_features (list ".f1_rate_1" ".f3_rate_1" ".f2_rate_1" ".f2_rate_2")
 			ts_derived_features
 				(list
 					".series_progress" ".series_progress_delta" ".date_lag_1" ".f3_lag_1" ".f1_lag_1" ".f2_lag_1"
-					".date_delta_1"  ".f3_rate_1" ".f1_rate_1" ".f2_rate_1" ".f2_rate_2"
+					".date_delta_1"
+					".f1_delta_1" ".f2_delta_1" ".f2_delta_2" ".f3_delta_1"
+					".f1_rate_1" ".f2_rate_1" ".f3_rate_1" ".f2_rate_2"
 				)
 			series_id_features (list "ID")
 		)


### PR DESCRIPTION
The following changes are included:

- Continouous TS features with the "rate" type also get deltas derived so that values can be generated when the time-delta is zero.
- The ".synchronous_counter" feature has been added to help model the amount of following cases on same time-value in a series.
- 
