### PR TITLE
24555: Adds support to predict cluster id in react, MINOR

### DIFF
--- a/howso/clustering.amlg
+++ b/howso/clustering.amlg
@@ -408,4 +408,82 @@
 		)
 	)
 
+
+	;Helper method for react's !GenerateReaction to prepare the prediction of cluster id by computing
+	;the DC and SC of the case to use in the contexts for the prediction
+	#!PreparePredictionClusterId
+	(let
+		(assoc
+			computed_sc_map
+				(if existing_case_id
+					(zip
+						["distance_contribution" "similarity_conviction"]
+						(retrieve_from_entity existing_case_id
+							[
+							(get !clusteringParametersMap "distance_contribution_feature")
+							(get !clusteringParametersMap "similarity_conviction_feature")
+							]
+						)
+					)
+
+					;else compute DC and SC
+					(call !SimilarityConviction (assoc
+						features context_features
+						feature_values (unzip case_values_map context_features)
+						filtering_queries filtering_queries
+						use_case_weights use_case_weights
+						weight_feature weight_feature
+						distance_contribution_feature (get !clusteringParametersMap "distance_contribution_feature")
+					))
+				)
+		)
+
+		;place these computed DC and SC values into details
+		(if details
+			(accum (assoc
+				details
+					{
+						"non_clustered_distance_contribution" (get computed_sc_map "distance_contribution")
+						"non_clustered_similarity_conviction" (get computed_sc_map "similarity_conviction")
+					}
+			))
+			(assign (assoc
+				details
+					{
+						"non_clustered_distance_contribution" (get computed_sc_map "distance_contribution")
+						"non_clustered_similarity_conviction" (get computed_sc_map "similarity_conviction")
+					}
+			))
+		)
+
+		;output the cluster id stored in the case
+		(if existing_case_id
+			(conclude
+				(retrieve_from_entity existing_case_id (get !clusteringParametersMap "feature"))
+			)
+		)
+
+		(declare (assoc
+			unmodified_context_features (replace context_features)
+			unmodified_context_values (replace context_values)
+		))
+
+		;add computed action DC and SC into contexts
+		(assign (assoc
+			restore_contexts (true)
+			context_features
+				(append
+					context_features
+					(get !clusteringParametersMap "distance_contribution_feature")
+					(get !clusteringParametersMap "similarity_conviction_feature")
+				)
+			context_values
+				(append
+					context_values
+					(get computed_sc_map "distance_contribution")
+					(get computed_sc_map "similarity_conviction")
+				)
+		))
+	)
+
 )

--- a/howso/clustering.amlg
+++ b/howso/clustering.amlg
@@ -429,7 +429,7 @@
 					;else compute DC and SC
 					(call !SimilarityConviction (assoc
 						features context_features
-						feature_values (unzip case_values_map context_features)
+						feature_values context_values
 						filtering_queries filtering_queries
 						use_case_weights use_case_weights
 						weight_feature weight_feature
@@ -463,7 +463,7 @@
 			)
 		)
 
-		(declare (assoc
+		(assign (assoc
 			unmodified_context_features (replace context_features)
 			unmodified_context_values (replace context_values)
 		))

--- a/howso/clustering.amlg
+++ b/howso/clustering.amlg
@@ -314,7 +314,7 @@
 								;if this neighbor's neighbors are in a different cluster, first check if this neighbor is eligible to be assigned to it
 								;if eligible, interpolate based on influence weight to see which cluster this neighbor should be assigned to.
 								;Iither there are multiple cluster ids, in which case the neighbor may be assigned to another one
-								;or here's only one and it doesn't match this cluster_id, in which case the neighbor may be assigned to that other one
+								;or there's only one and it doesn't match this cluster_id, in which case the neighbor may be assigned to that other one
 								(if (or
 										(> (size unique_neighbor_clusters) 1)
 										(and
@@ -334,7 +334,7 @@
 
 										;check to see if this neighbor is eligible: if there are any unclustered shared neighbors between this case and this neighbor,
 										;if there are any unclustered 'other' neighbors, check if any of them are also in the list of direct neighbors being processed
-										;if so, this neighbor should not be automitaclly assigned to a different cluster since at least some of these shared neighbors
+										;if so, this neighbor should not be automatically assigned to a different cluster since at least some of these shared neighbors
 										;are also unclustered thus that decision can't be made yet.
 										(if (size unclustered_other_neighbors)
 											(if (size (filter

--- a/howso/conviction.amlg
+++ b/howso/conviction.amlg
@@ -652,6 +652,16 @@
 							"clustering_inclusion_relative_threshold" clustering_inclusion_relative_threshold
 						)
 				))
+				(accum_to_entities (assoc
+					!nominalsMap (associate clustering)
+					!categoricalFeaturesSet (associate clustering)
+					!numericNominalFeaturesMap (associate clustering "number")
+				))
+				(call !CacheExpectedValuesAndProbabilities (assoc
+					features [clustering]
+					use_case_weights use_case_weights
+					weight_feature weight_feature
+				))
 			)
 		)
 

--- a/howso/details.amlg
+++ b/howso/details.amlg
@@ -445,6 +445,17 @@
 			))
 		)
 
+		;action dc and sc were computed, output them in details
+		(if (contains_index details "non_clustered_distance_contribution")
+			(accum (assoc
+				output
+					(assoc
+						"non_clustered_distance_contribution" (get details "non_clustered_distance_contribution")
+						"non_clustered_similarity_conviction" (get details "non_clustered_similarity_conviction")
+					)
+			))
+		)
+
 		;return the output audit data
 		output
 	)

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1509,6 +1509,8 @@
 				)
 			has_details (false)
 			restore_contexts (false)
+			unmodified_context_features (null)
+			unmodified_context_values (null)
 		)
 
 		;for all time series where the time feature is a context,

--- a/howso/react.amlg
+++ b/howso/react.amlg
@@ -1508,6 +1508,7 @@
 					(false)
 				)
 			has_details (false)
+			restore_contexts (false)
 		)
 
 		;for all time series where the time feature is a context,
@@ -1542,6 +1543,17 @@
 				context_values context_values
 				hyperparam_map hyperparam_map
 			))
+		)
+
+		;if the action feature being predicted is the cluster id feature, compute and use SC and DC in the context of the react
+		(if (size !clusteringParametersMap)
+			(if (= (first action_features) (get !clusteringParametersMap "feature"))
+				(if existing_case_id
+					(conclude (call !PreparePredictionClusterId))
+
+					(call !PreparePredictionClusterId)
+				)
+			)
 		)
 
 		(declare (assoc
@@ -1599,6 +1611,14 @@
 						dt_parameter (get hyperparam_map "dt")
 						query_label "!ReactionQuery"
 					))
+			))
+		)
+
+		;if contexts were modified by clustering, restore them to their original unmodified values
+		(if restore_contexts
+			(assign (assoc
+				context_features unmodified_context_features
+				context_values unmodified_context_values
 			))
 		)
 

--- a/howso/react_discriminative.amlg
+++ b/howso/react_discriminative.amlg
@@ -81,6 +81,7 @@
 
 			;local variables, should not be passed in as a parameter
 			valid_weight_feature (false)
+			existing_case_id (null)
 		)
 
 		;determine the case to ignore based on specified case_indices and use that cases's values by preserve_feature_values
@@ -140,6 +141,8 @@
 						(assign (assoc context_values (unzip context_values_map context_features) ))
 					)
 				)
+
+				(assign (assoc existing_case_id (replace ignore_case) ))
 
 				;if it should not be left out, treat it like it wasn't specified
 				(if (not leave_case_out)

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -82,6 +82,18 @@
 								values "number"
 								description "The computed similarity conviction for each given case."
 							}
+						"non_clustered_distance_contribution"
+							{
+								type "list"
+								values "number"
+								description "The computed distance contribution for each given case without its cluster id."
+							}
+						"non_clustered_similarity_conviction"
+							{
+								type "list"
+								values "number"
+								description "The computed similarity conviction for each given case without its cluster id."
+							}
 						"outlying_feature_values"
 							{
 								type "list"

--- a/unit_tests/ut_h_clustering.amlg
+++ b/unit_tests/ut_h_clustering.amlg
@@ -12,6 +12,14 @@
 		result (null)
 	))
 
+	(assign (assoc
+		training_data
+			(sort
+				(lambda (> (last (current_value)) (last (current_value 1))))
+				training_data
+			)
+	))
+
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes (associate (last features) (assoc "type" "nominal" "data_type" "number"))
 	))
@@ -43,9 +51,9 @@
 		num_unclustered (size (filter (lambda (= -1 (current_value))) cluster_ids))
 	))
 
-	(print "Iris has 3 clusters and some unclustered: ")
+	(print "Iris has 3 (or 4) clusters and some unclustered: ")
 	(call assert_true (assoc
-		obs (= 4 (size (values cluster_ids (true))))
+		obs (contains_value [4 5] (size (values cluster_ids (true))))
 	))
 	(print "Very few unclustered: ")
 	(call assert_true (assoc
@@ -56,7 +64,68 @@
 			)
 	))
 
-	(call exit_if_failures (assoc msg "Clustering Iris into three clusters."))
+	(call exit_if_failures (assoc msg "Clustering Iris into 3-4 clusters."))
+
+
+	(assign (assoc
+		result
+			(call_entity "howso" "react" (assoc
+				context_features features
+				context_values [[4 3 1 0.1 0]]
+				action_features [".cluster_id"]
+			))
+	))
+	(call keep_result_payload)
+
+	(print "Predicts cluster 1: ")
+	(call assert_same (assoc
+		exp [1]
+		obs (get result ["action_values" 0])
+	))
+
+	(print "Outputs non clustered DC and SC in details:")
+	(call assert_not_null (assoc
+		obs (get result ["non_clustered_distance_contribution" 0])
+	))
+	(call assert_not_null (assoc
+		obs (get result ["non_clustered_similarity_conviction" 0])
+	))
+
+
+	(assign (assoc
+		result
+			(call_entity "howso" "react" (assoc
+				context_features features
+				context_values [[6 2 4 1 1]]
+				action_features [".cluster_id"]
+			))
+	))
+	(call keep_result_payload)
+
+	(print "Predicts unclustered -1: ")
+	(call assert_same (assoc
+		exp [-1]
+		obs (get result ["action_values" 0])
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "react" (assoc
+				preserve_feature_values features
+				case_indices [["my_session" 149]]
+				action_features [".cluster_id"]
+			))
+	))
+	(call keep_result_payload)
+
+	(print "Gets cluster 3 from existing case: ")
+	(call assert_same (assoc
+		exp [3]
+		obs (get result ["action_values" 0])
+	))
+
+	(call exit_if_failures (assoc msg "Predicts case clusters."))
+
 
 	(destroy_entities "howso")
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_clustering.amlg" skip_init (true)) )

--- a/unit_tests/ut_h_clustering.amlg
+++ b/unit_tests/ut_h_clustering.amlg
@@ -36,6 +36,7 @@
 
 	(call_entity "howso" "react_into_features" (assoc
 		clustering (true)
+		clustering_expansion_threshold 0.6
 	))
 
 	(assign (assoc
@@ -55,12 +56,12 @@
 	(call assert_true (assoc
 		obs (contains_value [4 5] (size (values cluster_ids (true))))
 	))
-	(print "Very few unclustered: ")
+	(print "A few unclustered: ")
 	(call assert_true (assoc
 		obs
 			(and
 				(> num_unclustered 0)
-				(< num_unclustered 5)
+				(< num_unclustered 10)
 			)
 	))
 
@@ -118,10 +119,9 @@
 	))
 	(call keep_result_payload)
 
-	(print "Gets cluster 3 from existing case: ")
-	(call assert_same (assoc
-		exp [3]
-		obs (get result ["action_values" 0])
+	(print "Gets last cluster (3 or 4) from existing case: ")
+	(call assert_true (assoc
+		obs (contains_value [3 4] (get result ["action_values" 0 0]))
 	))
 
 	(call exit_if_failures (assoc msg "Predicts case clusters."))


### PR DESCRIPTION
When predicting cluster id,  computes DC and SC of the case to use in the contexts for the prediction