### PR TITLE
24595: Update time-series internals regarding series termination/progress tracking, MAJOR

### DIFF
--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -524,12 +524,12 @@
 			))
 
 			(if !tsTimeFeature
-				;do not remove first (.series_index == 0) or last (.series_progress == 1) cases for any series
+				;do not remove first (.series_index == 0) or last (.reverse_series_index == 0) cases for any series
 				(assign (assoc
 					cases
 						(contained_entities
 							(query_in_entity_list cases)
-							(query_not_equals ".series_progress" 1)
+							(query_not_equals ".reverse_series_index" 0)
 							(query_not_equals ".series_index" 0)
 						)
 				))

--- a/howso/attribute_maps.amlg
+++ b/howso/attribute_maps.amlg
@@ -665,21 +665,6 @@
 
 					;append this derived feature name to the list of derived features for its matching source feature(s)
 					(if
-						(= "progress" derive_type)
-						(let
-							(assoc
-								source_feature_name (get attributes (list "auto_derive_on_train" "time_feature"))
-								derived_features_list
-									(get source_to_derived_feature_map (get attributes (list "auto_derive_on_train" "time_feature")))
-							)
-							(if (= (null) derived_features_list)
-								(assign (assoc derived_features_list (list)))
-							)
-							(accum (assoc
-								source_to_derived_feature_map (associate source_feature_name (replace (append derived_features_list feature)))
-							))
-						)
-
 						(= "custom" derive_type)
 						(map
 							(lambda

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -156,12 +156,6 @@
 			;					this specified value. A null value means no max boundary. The length of the list must match the number of
 			;					derivatives as specified by 'order'. Only applicable when time series type is set to 'delta'. Example: [2.0]
 			;
-			;		'series_has_terminators': boolean, when true, requires that the dataset identify and learn values that explicitly denote
-			;								the end of a series. Only applicable to id features for a series. Default is false
-			;
-			;		'stop_on_terminator': boolean, when true, requires that a series ends on a terminator value.
-			;							Only applicable to id features for a series. Default is false
-			;
 			;		'universal': boolean, applicable only to the time_feature, controls whether future values of independent time series are considered.
 			;					When false, time_feature is not universal and allows using future data from other series in decisions;
 			;					this is applicable when the time is not globally relevant and is independent for each time series.

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -541,9 +541,6 @@
 												code_string (get (current_value 1) "derived_feature_code")
 											))
 										)
-
-										;else progress features have auto_derive_on_train but do not specify "code" and should be left as-is
-										(current_value)
 									)
 									(current_value)
 								)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -564,13 +564,6 @@
 						)
 				))
 
-				;manually add .series_progress_delta to the map of derived features since it should be derived along with .series_progress
-				(if (contains_index derived_features_map ".series_progress")
-					(accum (assoc
-						derived_features_map  (assoc ".series_progress_delta" (null))
-					))
-				)
-
 				;Accumulate source_to_derived_feature_map from all the auto_derive_on_train features
 				(call !AccumulateSourceToDerivedFeatureMap)
 

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -21,11 +21,6 @@
 	;		'ordered_by_features' : (optional) list of fature name(s) by which to order the series specified by "series_id_features". Series values
 	;			are order by the order of feature names specified by this attribute.
 	;
-	;
-	;		'derive_type' : "progress" -
-	;			This will create two continuous features of: .series_progress with values ranging from 0 to 1.0 for each case in the series
-	;			and '.series_progress_delta' which is the delta value of the progress for each case. Used to determine when to stop series synth.
-	;
 	;		'series_id_features' : list of feature name(s) of series for which to derive this feature. A series is the conjunction of all
 	;			the features specified by this attribute.
 	;

--- a/howso/derive_features.amlg
+++ b/howso/derive_features.amlg
@@ -68,13 +68,10 @@
 			derived_features (filter (lambda (not (contains_value lag_features (current_value)))) derived_features)
 		))
 
-		;create .series_progress, .series_progress_delta and .series_index features
-		(if (contains_value derived_features ".series_progress")
-			(call !CreateSeriesProgressFeatures (assoc
-				feature ".series_progress"
-				series_id_features (get !featureAttributes [".series_progress" "auto_derive_on_train" "series_id_features"])
-			))
-		)
+		;create series index features
+		(call !CreateSeriesIndexFeatures (assoc
+			series_id_features (get !tsFeaturesMap "series_id_features")
+		))
 
 		;derive time feature delta before any of the other derived features
 		(if (contains_value derived_features time_feature_delta)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -726,7 +726,7 @@
 						(not (contains_value derived_action_features (current_value)))
 						;whether .series_index should be in derived_context_features is determined above
 						;prevent it from being re-added from !trainedFeatures
-						(!= ".series_index" (current_value))
+						(not (contains_value  [".time_to_horizon" ".series_index"] (current_value)))
 					))
 					!trainedFeatures
 				)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -450,8 +450,8 @@
 		;if generating new series ids or series ids are given, only initial series progress of zero is needed
 		(if (or output_new_series_ids (size series_id_values))
 			(assign (assoc
-				initial_features (list ".series_progress")
-				initial_values (list (list 0.0))
+				initial_features (list ".series_index")
+				initial_values (list (list 0))
 			))
 
 			;else if we want to retain the existing IDs, we must specify them as
@@ -548,13 +548,13 @@
 									;keeping n_samples worth of ids, sample randomly with replacement
 									(rand initial_values_list n_samples)
 								)
-							initial_features (append (list ".series_progress") series_id_features)
+							initial_features (append (list ".series_index") series_id_features)
 						))
 
 						(assign (assoc
 							initial_values
 								(map
-									(lambda (append (list 0.0) (current_value)) )
+									(lambda (append (list 0) (current_value)) )
 									initial_values_list
 								)
 						))
@@ -562,8 +562,8 @@
 
 					;else
 					(assign (assoc
-						initial_features (list ".series_progress")
-						initial_values (list (list 0.0))
+						initial_features (list ".series_index")
+						initial_values (list (list 0))
 					))
 				)
 			)
@@ -587,14 +587,14 @@
 		(if
 			(and
 				(= 0 (size init_time_steps))
-				(not (contains_value initial_features ".series_progress"))
-				(not (contains_value all_contexts ".series_progress"))
+				(not (contains_value initial_features ".series_index"))
+				(not (contains_value all_contexts ".series_index"))
 			)
 			(assign (assoc
-				initial_features (append initial_features ".series_progress")
+				initial_features (append initial_features ".series_index")
 				initial_values
 					(map
-						(lambda (append (current_value) 0.0))
+						(lambda (append (current_value) 0))
 						initial_values
 					)
 			))
@@ -607,8 +607,8 @@
 				series_stop_maps
 					(if (size final_time_steps)
 						(list (associate !tsTimeFeature (assoc "max" (first final_time_steps))) )  ;TODO: 14829 support multiple time steps - 1 per series
-						;else stop when series_progress reaches 1
-						(list (assoc ".series_progress" (assoc "max" 1)) )
+						;else stop when no more events are expected
+						(null)
 					)
 			))
 		)
@@ -683,10 +683,7 @@
 						)
 					)
 					derived_context_features
-					(if (size final_time_steps)
-						(list)
-						(list ".series_progress")
-					)
+					[".series_index"]
 				)
 			derived_action_features
 				(append
@@ -732,9 +729,9 @@
 						)
 						(not (contains_value derived_context_features (current_value)))
 						(not (contains_value derived_action_features (current_value)))
-						;whether .series_progress should be in derived_context_features is determined above
+						;whether .series_index should be in derived_context_features is determined above
 						;prevent it from being re-added from !trainedFeatures
-						(!= ".series_progress" (current_value))
+						(!= ".series_index" (current_value))
 					))
 					!trainedFeatures
 				)
@@ -776,10 +773,6 @@
 							(lambda (contains_value derived_action_features (get !derivedFeaturesMap (current_value))))
 							(get !tsFeaturesMap "rate_features")
 						)
-					)
-					(if (contains_index (first series_stop_maps) ".series_progress")
-						(list ".series_progress_delta")
-						(list)
 					)
 					(get !tsFeaturesMap "stationary_features")
 					[!tsSynchronousCounterFeature]

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -447,7 +447,7 @@
 				)
 		))
 
-		;if generating new series ids or series ids are given, only initial series progress of zero is needed
+		;if generating new series ids or series ids are given, only initial index of zero
 		(if (or output_new_series_ids (size series_id_values))
 			(assign (assoc
 				initial_features (list ".series_index")
@@ -583,13 +583,8 @@
 			))
 		)
 
-		;if the .series_progress was not included in initial values, put it in there if not specifying init time step instead
-		(if
-			(and
-				(= 0 (size init_time_steps))
-				(not (contains_value initial_features ".series_index"))
-				(not (contains_value all_contexts ".series_index"))
-			)
+		;if the .series_index was not included in initial values, put it in there
+		(if (not (contains_value initial_features ".series_index"))
 			(assign (assoc
 				initial_features (append initial_features ".series_index")
 				initial_values

--- a/howso/feature_residuals.amlg
+++ b/howso/feature_residuals.amlg
@@ -1588,7 +1588,6 @@
 									(call !ReactSeries (assoc
 										continue_series (true)
 										leave_series_out (true)
-										track_progress (false)
 										desired_conviction (null)
 										details (assoc categorical_action_probabilities (true))
 										generate_new_cases "no"

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -15,6 +15,7 @@
 
 			;not parameters
 			series_time_feature !tsTimeFeature
+			is_universal !tsTimeFeatureUniversal
 		)
 
 		;list of assocs of cases for each series, where each assoc of cases is : case id -> time_feature -> value
@@ -37,17 +38,19 @@
 
 		(declare (assoc
 			max_time_value
-				(get
-					(first (compute_on_contained_entities
-						(query_max !tsTimeFeature)
-						(query_exists !tsTimeFeature)
-					))
-					!tsTimeFeature
+				(if is_universal
+					(get
+						(first (compute_on_contained_entities
+							(query_max !tsTimeFeature)
+							(query_exists !tsTimeFeature)
+						))
+						!tsTimeFeature
+					)
 				)
 		))
 
 		;iterate over the list of series groups
-		;for each series create an assoc of case id -> [ index,  reverse-index, time-to-horizon ]:
+		;for each series create an assoc of case id -> [ index,  reverse-index, time-to-horizon (if universal time)]:
 		(declare (assoc
 			series_cases_group_map
 				;convert list of assocs into a flat assoc
@@ -80,19 +83,26 @@
 							))
 
 							(declare (assoc sorted_time_values (unzip series_cases_map sorted_case_ids) ))
+							(declare (assoc time_to_horizon (- max_time_value (last sorted_time_values)) ))
 
-
-							;create an assoc of case_id -> [ index,  reverse-index, time-to-horizon ]
+							;create an assoc of case_id -> [ index,  reverse-index, time-to-horizon (if universal time feature) ]
 							(zip
 								sorted_case_ids
 								(map
 									(lambda
 										;output the tuple
-										[
-											(current_index 1) ;index
-											(- (size sorted_case_ids) (current_index 1) 1) ;reverse index
-											(- max_time_value (current_value 1)) ;time-to-horizon
-										]
+										(if is_universal
+											[
+												(current_index 1) ;index
+												(- (size sorted_case_ids) (current_index 1) 1) ;reverse index
+												time_to_horizon ;time-to-horizon
+											]
+
+											[
+												(current_index 1) ;index
+												(- (size sorted_case_ids) (current_index 1) 1) ;reverse index
+											]
+										)
 									)
 									sorted_time_values
 								)
@@ -111,20 +121,34 @@
 				(if (contains_label (current_index) ".series_index")
 					(assign_to_entities
 						(current_index)
-						(associate
-							".series_index" (get (current_value 1) 0)
-							".reverse_series_index" (get (current_value 1) 1)
-							".time_to_horizon" (get (current_value 1) 2)
+						(if is_universal
+							(associate
+								".series_index" (get (current_value 1) 0)
+								".reverse_series_index" (get (current_value 1) 1)
+								".time_to_horizon" (get (current_value 1) 2)
+							)
+
+							(associate
+								".series_index" (get (current_value 1) 0)
+								".reverse_series_index" (get (current_value 1) 1)
+							)
 						)
 					)
 
 					;else need to append the label to the entity
 					(accum_entity_roots
 						(current_index)
-						(list
-							(set_labels (get (current_value 1) 0) (list ".series_index"))
-							(set_labels (get (current_value 1) 1) (list ".reverse_series_index"))
-							(set_labels (get (current_value 1) 2) (list ".time_to_horizon"))
+						(if is_universal
+							(list
+								(set_labels (get (current_value 1) 0) (list ".series_index"))
+								(set_labels (get (current_value 1) 1) (list ".reverse_series_index"))
+								(set_labels (get (current_value 1) 2) (list ".time_to_horizon"))
+							)
+
+							(list
+								(set_labels (get (current_value 1) 0) (list ".series_index"))
+								(set_labels (get (current_value 1) 1) (list ".reverse_series_index"))
+							)
 						)
 					)
 			))
@@ -657,6 +681,7 @@
 						".time_to_horizon"
 							(assoc
 								"type" "continuous"
+								"derived_feature_code" "(call value {feature \".time_to_horizon\" lag 1})"
 								"bounds" (assoc "min" 0.0 "allow_null" (false))
 							)
 					)

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -1,10 +1,9 @@
 ;Contains methods to generate features or feature values as defined by feature attributes.
 (null
 
-	;creates the built-in .series_progress, .series_progress_delta and .series_index features
+	;creates the built-in .series_index, .reverse_series_index and possibly the .time_to_horizon features
 	;
 	;parameters:
-	; feature: name of feature to add and populate
 	; series_id_features: list of feature names that specify the series id for which to derive this feature.
 	;		If more than one specified, a unique 'series id' is then the conjuction of the specified ids.
 	;		E.g., if 'sender' and 'reciever' are specified, a 'series id' is then each unique pair of sender-reciever.
@@ -84,42 +83,19 @@
 
 							(declare (assoc sorted_time_values (unzip series_cases_map sorted_case_ids) ))
 
-							(declare (assoc
-								range (- (last sorted_time_values) (first sorted_time_values))
-								previous_value (first sorted_time_values)
-								first_value (first sorted_time_values)
-								fixed_delta (/ 1 (- (size sorted_time_values) 1))
-							))
 
-							;create an assoc of case_id -> [ progress%, index, delta_to_previous ]
-							;where progress is: 0-based value / range
+							;create an assoc of case_id -> [ index,  reverse-index, time-to-horizon ]
 							(zip
 								sorted_case_ids
 								(map
-									(lambda (let
-										(assoc
-											progress (/ (- (current_value 1) first_value) range)
-											;delta is the % change,  don't allow 0, use the fixed delta instead
-											delta (or (/ (- (current_value 1) previous_value) range) fixed_delta)
-										)
-
-										;if the series is of length 1, set progress and delta to be 1 and prevent a divide by 0
-										(if (= 0 range)
-											(assign (assoc
-												progress 1
-												delta 1
-											))
-										)
-										(assign (assoc previous_value (current_value 1)))
+									(lambda
 										;output the tuple
 										[
-											progress
 											(current_index 1) ;index
 											(- (size sorted_case_ids) (current_index 1) 1) ;reverse index
 											(- max_time_value (current_value 1)) ;time-to-horizon
-											delta
 										]
-									))
+									)
 									sorted_time_values
 								)
 							)
@@ -129,8 +105,8 @@
 				)
 		))
 
-		;store the progress and delta value at the same time into each case
-		;by iterating over assoc of:case_id -> [ progress%, index, delta_to_previous ]
+		;store the indices all at once
+		;by iterating over assoc of:case_id -> [ index,  reverse-index, time-to-horizon ]
 		(map
 			(lambda
 				;see whether the entity has the label
@@ -138,11 +114,9 @@
 					(assign_to_entities
 						(current_index)
 						(associate
-							; feature (first (current_value 1))
-							".series_index" (get (current_value 1) 1)
-							".reverse_series_index" (get (current_value 1) 2)
-							".time_to_horizon" (get (current_value 1) 3)
-							; (concat feature "_delta") (last (current_value 1))
+							".series_index" (get (current_value 1) 0)
+							".reverse_series_index" (get (current_value 1) 1)
+							".time_to_horizon" (get (current_value 1) 2)
 						)
 					)
 
@@ -150,11 +124,9 @@
 					(accum_entity_roots
 						(current_index)
 						(list
-							; (set_labels (first (current_value 1)) (list feature))
-							(set_labels (get (current_value 1) 1) (list ".series_index"))
-							(set_labels (get (current_value 1) 2) (list ".reverse_series_index"))
-							(set_labels (get (current_value 1) 3) (list ".time_to_horizon"))
-							; (set_labels (last (current_value 1)) (list (concat feature "_delta")) )
+							(set_labels (get (current_value 1) 0) (list ".series_index"))
+							(set_labels (get (current_value 1) 1) (list ".reverse_series_index"))
+							(set_labels (get (current_value 1) 2) (list ".time_to_horizon"))
 						)
 					)
 			))

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -9,10 +9,9 @@
 	;		If more than one specified, a unique 'series id' is then the conjuction of the specified ids.
 	;		E.g., if 'sender' and 'reciever' are specified, a 'series id' is then each unique pair of sender-reciever.
 	; time_feature: name of series id's time feature which to use to determine the start or end flag
-	#!CreateSeriesProgressFeatures
+	#!CreateSeriesIndexFeatures
 	(declare
 		(assoc
-			feature ""
 			series_id_features (list)
 
 			;not parameters
@@ -34,6 +33,17 @@
 
 					;generates a list of queries for each unique series id (where each series id may be a conjuction of several features)
 					(call !GenerateUniqueSeriesQueries (assoc series_id_features series_id_features ))
+				)
+		))
+
+		(declare (assoc
+			max_time_value
+				(get
+					(first (compute_on_contained_entities
+						(query_max !tsTimeFeature)
+						(query_exists !tsTimeFeature)
+					))
+					!tsTimeFeature
 				)
 		))
 
@@ -102,7 +112,13 @@
 										)
 										(assign (assoc previous_value (current_value 1)))
 										;output the tuple
-										[progress (current_index 1) delta]
+										[
+											progress
+											(current_index 1) ;index
+											(- (size sorted_case_ids) (current_index 1) 1) ;reverse index
+											(- max_time_value (current_value 1)) ;time-to-horizon
+											delta
+										]
 									))
 									sorted_time_values
 								)
@@ -118,13 +134,15 @@
 		(map
 			(lambda
 				;see whether the entity has the label
-				(if (contains_label (current_index) feature)
+				(if (contains_label (current_index) ".series_index")
 					(assign_to_entities
 						(current_index)
 						(associate
-							feature (first (current_value 1))
+							; feature (first (current_value 1))
 							".series_index" (get (current_value 1) 1)
-							(concat feature "_delta") (last (current_value 1))
+							".reverse_series_index" (get (current_value 1) 2)
+							".time_to_horizon" (get (current_value 1) 3)
+							; (concat feature "_delta") (last (current_value 1))
 						)
 					)
 
@@ -132,9 +150,11 @@
 					(accum_entity_roots
 						(current_index)
 						(list
-							(set_labels (first (current_value 1)) (list feature))
+							; (set_labels (first (current_value 1)) (list feature))
 							(set_labels (get (current_value 1) 1) (list ".series_index"))
-							(set_labels (last (current_value 1)) (list (concat feature "_delta")) )
+							(set_labels (get (current_value 1) 2) (list ".reverse_series_index"))
+							(set_labels (get (current_value 1) 3) (list ".time_to_horizon"))
+							; (set_labels (last (current_value 1)) (list (concat feature "_delta")) )
 						)
 					)
 			))
@@ -627,24 +647,6 @@
 		(accum (assoc
 			"derived_feature_attributes"
 				(assoc
-					;progress value for each case in a series, 0.0 for first case and 1.0 for last case
-					".series_progress"
-						(assoc
-							"type" "continuous"
-							"derived_feature_code" "(min 1 (+ (call value {feature \".series_progress\" lag 1}) (call value {feature \".series_progress_delta\" lag 1}) ))"
-							"auto_derive_on_train"
-								(assoc
-									"derive_type" "progress"
-									"series_id_features" id_features
-								)
-							"bounds" (assoc "min" 0.0)
-						)
-					;progress delta for the series, each case's .series_progress value was incremented by this amount
-					".series_progress_delta"
-						(assoc
-							"type" "continuous"
-							"bounds" (assoc "min" 0.0 "max" 1.0)
-						)
 					;counter for following cases with the same time value within the same series
 					".synchronous_counter"
 						(assoc
@@ -662,8 +664,34 @@
 							"ts_type" "lag"
 							"parent" ".synchronous_counter"
 						)
+					".series_index"
+						(assoc
+							"type" "continuous"
+							"decimal_places" 0
+							"derived_feature_code" "(+ 1 (call value {feature \".series_index\" lag 1}))"
+							"bounds" (assoc "min" 0.0 "allow_null" (false))
+						)
+					".reverse_series_index"
+						(assoc
+							"type" "continuous"
+							"decimal_places" 0
+							"bounds" (assoc "min" 0.0 "allow_null" (false))
+						)
 				)
 		))
+
+		(if !tsTimeFeatureUniversal
+			(accum (assoc
+				"derived_feature_attributes"
+					(assoc
+						".time_to_horizon"
+							(assoc
+								"type" "continuous"
+								"bounds" (assoc "min" 0.0 "allow_null" (false))
+							)
+					)
+			))
+		)
 
 		;update dataset feature attributes to include all the derived ones, don't process time series attributes since they are being provided
 		(call set_feature_attributes (assoc
@@ -671,11 +699,11 @@
 			create_ts_attributes (false)
 		))
 
-		;derived_features = ["".series_progress", ".series_progress_delta"] + lag_features + train_delta_features + train_rate_features
+		;derived_features = [".series_index", ".reverse_series_index"] + lag_features + train_delta_features + train_rate_features
 		(declare (assoc
 			ts_derived_features
 				(append
-					(list ".series_progress" ".series_progress_delta")
+					(list ".series_index" ".reverse_series_index")
 					(replace lag_features)
 					(replace train_delta_features)
 					(replace train_rate_features)

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -47,9 +47,7 @@
 		))
 
 		;iterate over the list of series groups
-		;for each series create an assoc of case id -> pair of progress % , delta_to_previous_time:
-		; a) sort by time feature
-		; b) compute each case's progress and delta
+		;for each series create an assoc of case id -> [ index,  reverse-index, time-to-horizon ]:
 		(declare (assoc
 			series_cases_group_map
 				;convert list of assocs into a flat assoc
@@ -615,7 +613,7 @@
 			!featureAttributes
 		)
 
-		;accumulate the progress and progress delta features into derived feature attributes
+		;accumulate the time-series built-in features into derived feature attributes
 		(accum (assoc
 			"derived_feature_attributes"
 				(assoc

--- a/howso/generate_features.amlg
+++ b/howso/generate_features.amlg
@@ -704,21 +704,7 @@
 					(replace train_rate_features)
 					(replace stationary_features)
 				)
-			series_has_terminators (false)
-			stop_on_terminator (false)
 		))
-
-		(map
-			(lambda
-				(if (get feature_attributes (list (current_value 1) "time_series" "series_has_terminators"))
-					(assign (assoc
-						series_has_terminators (true)
-						stop_on_terminator (or stop_on_terminator (get feature_attributes (list (current_value 2) "time_series" "stop_on_terminator")))
-					))
-				)
-			)
-			id_features
-		)
 
 		;set dataset time series (lag, delta, rate, start, end, derived order) features for series react
 		;to be used for constructing react_series parameters
@@ -731,8 +717,6 @@
 					"derived_order_features" derived_order_features
 					"ts_derived_features" ts_derived_features
 					"series_id_features" id_features
-					"series_has_terminators" series_has_terminators
-					"stop_on_terminator" stop_on_terminator
 					"stationary_features" stationary_features
 				)
 		))

--- a/howso/react_series.amlg
+++ b/howso/react_series.amlg
@@ -20,8 +20,6 @@
 			;assoc of feature -> stop conditions:
 			;	for continuous features:  { feature:  { "min" : val,  "max": val } } - stops series when feature value exceeds max or is smaller than min
 			;	for nominal features:  { feature:  { "values" : ['val1', 'val2' ]} }  - stops series when feature value matches any of the values listed
-			;	specifying ".series_progress" with a value between 0 and 1.0 corresponding to percent completion e.g., { ".series_progress" : .95 } -
-			;		stops series when it progresses at or beyond 95%.
 			series_stop_map (assoc)
 			;{type "boolean"}
 			;flag, default to True. If true, series ids are replaced with unique values on output.
@@ -364,8 +362,6 @@
 			;list of assocs of feature -> stop conditions:
 			;	for continuous features:  { feature:  { "min" : val,  "max": val } } - stops series when feature value exceeds max or is smaller than min
 			;	for nominal features:  { feature:  { "values" : ['val1', 'val2' ]} }  - stops series when feature value matches any of the values listed
-			;	specifying ".series_progress" with a value between 0 and 1.0 corresponding to percent completion e.g., { ".series_progress" : .95 } -
-			;		stops series when it progresses at or beyond 95%.
 			; one assoc is used per series.
 			series_stop_maps (list)
 			;{type "list" values "number"}

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -319,7 +319,8 @@
 			;assoc of stationary feature -> value that needs to be backfilled to the whole series at the end
 			stationary_features_to_backfill_map {}
 
-			;TODO: DO NOT MERGE THIS, externalize this flag if desired.
+			;TODO: Externalize this flag if desired. Seemingly necessary for generating series past the last
+			;observed time value in some datasets
 			forecasting_future (false)
 		))
 

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -318,6 +318,9 @@
 			has_stationary_features (size (get !tsFeaturesMap "stationary_features"))
 			;assoc of stationary feature -> value that needs to be backfilled to the whole series at the end
 			stationary_features_to_backfill_map {}
+
+			;TODO: DO NOT MERGE THIS, externalize this flag if desired.
+			forecasting_future (false)
 		))
 
 		(declare (assoc
@@ -1957,7 +1960,35 @@
 		;else we must predict if the series should end
 		(let
 			(assoc
-				series_end_context_features (indices (remove current_case_map ".reverse_series_index"))
+				series_end_context_map
+					(if forecasting_future
+						;if forecasting the future, filter out time/lags from the context and condition
+						;a time to horizon at about the median.
+						(append
+							(remove
+								current_case_map
+								;the time feature and its lags
+								(append
+									[!tsTimeFeature]
+									(filter
+										(lambda (= "lag" (get !featureAttributes [(current_value 1) "ts_type"])) )
+										(get !sourceToDerivedFeatureMap !tsTimeFeature)
+									)
+								)
+							)
+							(if !tsTimeFeatureUniversal
+								(assoc
+									".time_to_horizon"
+										(compute_on_contained_entities
+											(query_quantile ".time_to_horizon" 0.5)
+										)
+								)
+								(assoc)
+							)
+						)
+
+						current_case_map
+					)
 			)
 
 			;predict .reverse_series_index given the current case
@@ -1965,8 +1996,8 @@
 				rev_index_prediction
 					(first (get
 						(call !SingleReact (assoc
-							context_features series_end_context_features
-							context_values (unzip current_case_map series_end_context_features)
+							context_features (indices series_end_context_map)
+							context_values (values series_end_context_map)
 							action_features (list ".reverse_series_index")
 							;do not derive anything during this react
 							derived_action_features (list)

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -248,8 +248,6 @@
 						(assoc)
 					)
 				)
-			series_has_terminators (get !tsFeaturesMap "series_has_terminators")
-			stop_on_terminator (get !tsFeaturesMap "stop_on_terminator")
 		))
 
 		;defaults to "no" if unspecified
@@ -1215,32 +1213,6 @@
 			existing_series_cases (list)
 		)
 
-		;if all series end on terminators and this react is not conditioned to start at a specific time step,
-		;stop this react series since it can't continue terminated series
-		(if
-			(and
-				stop_on_terminator
-				series_has_terminators
-				(not (contains_index initial_features_map !tsTimeFeature))
-				;don't terminate a provided untrained continuing series
-				(= 0 (size series_context_values))
-			)
-			(seq
-				(accum (assoc warnings (assoc "Can't continue terminated series.") ))
-				;immediately stop this series since it's terminated
-				(conclude (conclude
-					(assoc
-						"payload"
-							(assoc
-								"action_values" (null)
-								"action_features" output_features
-							)
-						"warnings" (if (size warnings) (indices warnings))
-					)
-				))
-			)
-		)
-
 		;if user has provided series data to continue, populate existing_series_data with the provided values
 		(if (size series_context_values)
 			(let
@@ -1976,11 +1948,10 @@
 								)
 							)
 							(if !tsTimeFeatureUniversal
-								;by adding the .time_to_horizon feature to the context at its median,
-								;the influence of series that terminate because there has been no further
-								;data recorded yet is reduced and the prediction on whether to terminate
-								;should utilize series who end well before the horizon of the trained data
-								;(if any exist)
+								;adding the .time_to_horizon feature to the context at its median reduces the influence
+								;of series that possibly terminated early due to lack of further data and also making
+								;predictions of whether to terminate more likely to utilize series that end before
+								;the horizon of the trained data (if any such series exist)
 								(assoc
 									".time_to_horizon"
 										(compute_on_contained_entities
@@ -2098,7 +2069,6 @@
 								new_case_threshold new_case_threshold
 
 								details {}
-								series_has_terminators (false)
 								max_series_length (null)
 								generate_new_cases generate_new_cases
 								output_features output_features

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -426,7 +426,6 @@
 			modified_feature_bounds_map (assoc)
 			derived_context_features derived_context_features
 			series_failed (false)
-			initial_existing_progress 0
 			num_existing_series_rows 0
 			original_derived_context_features derived_context_features
 			original_action_features action_features
@@ -710,11 +709,6 @@
 							)
 					))
 
-					;if first case of series and using continue_series, start with computed series_progress
-					(if (and use_initial_context_features initial_existing_progress)
-						(assign (assoc current_case_map (set current_case_map ".series_progress" initial_existing_progress)))
-					)
-
 					;SYNCHRONOUS COUNTER LOGIC
 					(if (> last_series_index 0)
 						(seq
@@ -810,118 +804,8 @@
 						))
 					)
 
-					(if (not (size series_stop_map))
-						(let
-							(assoc
-								series_end_context_features (indices (remove current_case_map ".reverse_series_index"))
-							)
-
-							;predict .reverse_series_index given the current case
-							(declare (assoc
-								rev_index_prediction
-									(first (get
-										(call !SingleReact (assoc
-											context_features series_end_context_features
-											context_values (unzip current_case_map series_end_context_features)
-											action_features (list ".reverse_series_index")
-											;do not derive anything during this react
-											derived_action_features (list)
-											derived_context_features (list)
-											;no details
-											details (null)
-											ignore_case ignore_case
-											substitute_output substitute_output
-											input_is_substituted input_is_substituted
-											use_case_weights use_case_weights
-											weight_feature weight_feature
-											rand_seed rand_seed
-											leave_case_out leave_case_out
-											holdout_queries holdout_queries
-											desired_conviction desired_conviction
-											use_differential_privacy use_differential_privacy
-											new_case_threshold new_case_threshold
-											feature_bounds_map feature_bounds_map
-											generate_new_cases "no"
-										))
-										"action_values"
-									))
-							))
-							(if (< rev_index_prediction 1)
-								(assign (assoc done (true) ))
-							)
-						)
-					)
-
 					;determine whether to stop generating the series
-					;if there's no series_stop_map or exceeded max_series_length, be done
-					(if (or
-							(>= num_generated_rows max_series_length)
-						)
-						(assign (assoc done (true)))
-
-						(map
-							(lambda (seq
-								(if (contains_index (current_value) "values")
-									(if (contains_value (get (current_value) "values") (get current_case_map (current_index)))
-										(assign (assoc done (true)))
-									)
-								)
-
-								(if (contains_index (current_value) "min")
-									(let
-										(assoc stop_value (get current_case_map (current_index 1)))
-
-										(if (contains_index !featureDateTimeMap (current_index))
-											;convert stop_value to epoch
-											(assign (assoc
-												stop_value
-													(format
-														stop_value
-														(get !featureDateTimeMap (list (current_index 2) "date_time_format"))
-														"number"
-														{
-															"locale" (get !featureDateTimeMap [ (current_index 3) "locale" ] )
-															"time_zone" (get !featureDateTimeMap [ (current_index 3) "default_time_zone" ] )
-														}
-														(null)
-													)
-											))
-										)
-										(if (>= (get (current_value) "min") stop_value)
-											(assign (assoc done (true)))
-										)
-									)
-								)
-
-								(if (contains_index (current_value) "max")
-									(let
-										(assoc stop_value (get current_case_map (current_index 1)))
-
-										(if (contains_index !featureDateTimeMap (current_index))
-											;convert stop_value to epoch
-											(assign (assoc
-												stop_value
-													(format
-														stop_value
-														(get !featureDateTimeMap (list (current_index 2) "date_time_format"))
-														"number"
-														{
-															"locale" (get !featureDateTimeMap [ (current_index 3) "locale" ] )
-															"time_zone" (get !featureDateTimeMap [ (current_index 3) "default_time_zone" ] )
-														}
-														(null)
-													)
-											))
-										)
-										(if (<= (get (current_value) "max") stop_value)
-											(assign (assoc done (true)))
-										)
-									)
-								)
-							))
-							series_stop_map
-						)
-					)
+					(call !DetermineIfSeriesTerminates)
 
 					;backfill values if a stationary feature triggered a change
 					(if has_stationary_features
@@ -957,8 +841,11 @@
 						)
 					)
 
-					;return series_data so it's stored as previous_result for accumulation in the next iteration of the while loop
-					;and explanation details if requested
+					;return series_data so it's stored as (previous_result) for accumulation in the next iteration of the while loop
+					;If details are requested, (previous) result needs to be a dict of "series_data" to the data and all other details
+					;
+					;additionally, if the series needs to be reset (for uniqueness reasons, typically), then we must "empty" (previous_result)
+					;by ending with an empty list
 					(if output_details
 						(seq
 							(if (contains_index case_detail_values_map "influential_cases")
@@ -1933,7 +1820,7 @@
 												case_detail_values_map (call !CreateCaseDetailValuesMapFromDetails (assoc details requested_details))
 											))
 
-											;else reset series_data and initial features and progress and index, to regenerate the series from the start
+											;else reset series_data and initial features and index, to regenerate the series from the start
 											(seq
 												(call !InitializeInitialSeriesFeatures)
 
@@ -1973,6 +1860,139 @@
 
 			;else don't check for uniqueness if it's not necessary
 			(assign (assoc do_uniqueness_check (false) ))
+		)
+	)
+
+
+	;if initial features are provided, ensure there aren't any that do not appear in features. any extra features are deleted and ignored.
+	#!InitializeInitialSeriesFeatures
+	(if (size initial_features)
+		(let
+			(assoc
+				invalid_initial_features
+					(filter (lambda (not (contains_index feature_index_map (current_value)))) initial_features)
+			)
+			(assign (assoc initial_features_map (zip initial_features initial_values)))
+
+			(if (size invalid_initial_features)
+				(assign (assoc initial_features_map (remove initial_features_map invalid_initial_features)))
+			)
+		)
+	)
+
+	;macro for !ReactSeries that checks if the "done" variable should be updated to (true)
+	;based on the current state of the generated series.
+	#!DetermineIfSeriesTerminates
+	;if exceeded max_series_length, be done
+	(if (or
+			(>= num_generated_rows max_series_length)
+		)
+		(assign (assoc done (true)))
+
+		;if a stop map is defined, then check if any of the conditions are met
+		(size series_stop_map)
+		(map
+			(lambda (seq
+				(if (contains_index (current_value) "values")
+					(if (contains_value (get (current_value) "values") (get current_case_map (current_index)))
+						(assign (assoc done (true)))
+					)
+				)
+
+				(if (contains_index (current_value) "min")
+					(let
+						(assoc stop_value (get current_case_map (current_index 1)))
+
+						(if (contains_index !featureDateTimeMap (current_index))
+							;convert stop_value to epoch
+							(assign (assoc
+								stop_value
+									(format
+										stop_value
+										(get !featureDateTimeMap (list (current_index 2) "date_time_format"))
+										"number"
+										{
+											"locale" (get !featureDateTimeMap [ (current_index 3) "locale" ] )
+											"time_zone" (get !featureDateTimeMap [ (current_index 3) "default_time_zone" ] )
+										}
+										(null)
+									)
+							))
+						)
+						(if (>= (get (current_value) "min") stop_value)
+							(assign (assoc done (true)))
+						)
+					)
+				)
+
+				(if (contains_index (current_value) "max")
+					(let
+						(assoc stop_value (get current_case_map (current_index 1)))
+
+						(if (contains_index !featureDateTimeMap (current_index))
+							;convert stop_value to epoch
+							(assign (assoc
+								stop_value
+									(format
+										stop_value
+										(get !featureDateTimeMap (list (current_index 2) "date_time_format"))
+										"number"
+										{
+											"locale" (get !featureDateTimeMap [ (current_index 3) "locale" ] )
+											"time_zone" (get !featureDateTimeMap [ (current_index 3) "default_time_zone" ] )
+										}
+										(null)
+									)
+							))
+						)
+						(if (<= (get (current_value) "max") stop_value)
+							(assign (assoc done (true)))
+						)
+					)
+				)
+			))
+			series_stop_map
+		)
+
+		;else we must predict if the series should end
+		(let
+			(assoc
+				series_end_context_features (indices (remove current_case_map ".reverse_series_index"))
+			)
+
+			;predict .reverse_series_index given the current case
+			(declare (assoc
+				rev_index_prediction
+					(first (get
+						(call !SingleReact (assoc
+							context_features series_end_context_features
+							context_values (unzip current_case_map series_end_context_features)
+							action_features (list ".reverse_series_index")
+							;do not derive anything during this react
+							derived_action_features (list)
+							derived_context_features (list)
+							;no details
+							details (null)
+							ignore_case ignore_case
+							substitute_output substitute_output
+							input_is_substituted input_is_substituted
+							use_case_weights use_case_weights
+							weight_feature weight_feature
+							rand_seed rand_seed
+							leave_case_out leave_case_out
+							holdout_queries holdout_queries
+							desired_conviction desired_conviction
+							use_differential_privacy use_differential_privacy
+							new_case_threshold new_case_threshold
+							feature_bounds_map feature_bounds_map
+							generate_new_cases "no"
+						))
+						"action_values"
+					))
+			))
+			(if (< rev_index_prediction 1)
+				(assign (assoc done (true) ))
+			)
 		)
 	)
 
@@ -2165,19 +2185,4 @@
 		))
 	)
 
-	;if initial features are provided, ensure there aren't any that do not appear in features. any extra features are deleted and ignored.
-	#!InitializeInitialSeriesFeatures
-	(if (size initial_features)
-		(let
-			(assoc
-				invalid_initial_features
-					(filter (lambda (not (contains_index feature_index_map (current_value)))) initial_features)
-			)
-			(assign (assoc initial_features_map (zip initial_features initial_values)))
-
-			(if (size invalid_initial_features)
-				(assign (assoc initial_features_map (remove initial_features_map invalid_initial_features)))
-			)
-		)
-	)
 )

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -1888,9 +1888,7 @@
 	;based on the current state of the generated series.
 	#!DetermineIfSeriesTerminates
 	;if exceeded max_series_length, be done
-	(if (or
-			(>= num_generated_rows max_series_length)
-		)
+	(if (>= num_generated_rows max_series_length)
 		(assign (assoc done (true)))
 
 		;if a stop map is defined, then check if any of the conditions are met
@@ -1964,7 +1962,7 @@
 				series_end_context_map
 					(if forecasting_future
 						;if forecasting the future, filter out time/lags from the context and condition
-						;a time to horizon at about the median.
+						;a time to horizon at the median.
 						(append
 							(remove
 								current_case_map
@@ -1978,6 +1976,11 @@
 								)
 							)
 							(if !tsTimeFeatureUniversal
+								;by adding the .time_to_horizon feature to the context at its median,
+								;the influence of series that terminate because there has been no further
+								;data recorded yet is reduced and the prediction on whether to terminate
+								;should utilize series who end well before the horizon of the trained data
+								;(if any exist)
 								(assoc
 									".time_to_horizon"
 										(compute_on_contained_entities

--- a/howso/react_series_utilities.amlg
+++ b/howso/react_series_utilities.amlg
@@ -341,7 +341,7 @@
 			dbl_precision_epsilon
 				;similar to !ComputePrecisionEpsilon but streamlined for use in react series
 				(if (!= "no" generate_new_cases)
-					(if (= "surprisal_to_prob" (get hyperparam_map "dt" ))
+					(if (= "surprisal_to_prob" (get hyperparam_map "dt"))
 						(let
 							(assoc output_features_set (zip output_features_no_ids))
 							(*
@@ -392,7 +392,7 @@
 		;if there are custom series contexts provided but no stop map, create a dummy stop map to prevent it from
 		;stopping after 1 case which is the default behavior when no stop map is provided
 		(if (and has_series_context_values (= 0 (size series_stop_maps)))
-			(assign (assoc series_stop_map (assoc ".none" (null))))
+			(assign (assoc series_stop_map (assoc ".none" (null)) ))
 		)
 
 		;if doing generative reacts with unique nominals, generate unique values prior to synthesis
@@ -421,9 +421,6 @@
 			;if series_id_tracking="no" then IDs aren't in action_features, and thus replacement_id_values_map will be empty
 			has_non_tracked_ids (= 0 (size replacement_id_values_map))
 
-			;track progress length of series being generated if it's a stop condition in the series_stop_map
-			track_progress (contains_index series_stop_map ".series_progress")
-			total_progress 0
 			prev_sync_counter (null)
 			max_order (null)
 			modified_feature_bounds_map (assoc)
@@ -486,21 +483,7 @@
 			))
 		)
 
-		;if initial features are provided, ensure there aren't any that do not appear in features. any extra features are deleted and ignored.
-		#!InitializeInitialSeriesFeatures
-		(if (size initial_features)
-			(let
-				(assoc
-					invalid_initial_features
-						(filter (lambda (not (contains_index feature_index_map (current_value)))) initial_features)
-				)
-				(assign (assoc initial_features_map (zip initial_features initial_values)))
-
-				(if (size invalid_initial_features)
-					(assign (assoc initial_features_map (remove initial_features_map invalid_initial_features)))
-				)
-			)
-		)
+		(call !InitializeInitialSeriesFeatures)
 
 		;store an assoc of lag/rate/delta feature -> lag/order amount
 		(declare (assoc ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap)) ))
@@ -807,19 +790,6 @@
 					;create a (unique if necessary) series case
 					(call !SynthAndDeriveSeriesCase)
 
-					(if track_progress
-						(accum (assoc
-							total_progress
-								;has_series_context_values is the number of series context values, progress the amount to match the number of provided contexts
-								(if has_series_context_values
-									(/ 1 has_series_context_values)
-
-									;else progress the synthed amount
-									(get current_case_map ".series_progress_delta")
-								)
-						))
-					)
-
 					;if this is the first row of the series, assign values for the replacement series ids here, now that the initial value is available
 					(if first_generated_row
 						(assign (assoc
@@ -840,21 +810,20 @@
 						))
 					)
 
-					;Check every case to see if we've generated a terminator value
-					(if series_has_terminators
+					(if (not (size series_stop_map))
 						(let
 							(assoc
-								series_end_context_features (indices (filter (remove current_case_map ".series_progress")))
+								series_end_context_features (indices (remove current_case_map ".reverse_series_index"))
 							)
 
-							;predict .series_progress given the current case
+							;predict .reverse_series_index given the current case
 							(declare (assoc
-								series_progress
+								rev_index_prediction
 									(first (get
 										(call !SingleReact (assoc
 											context_features series_end_context_features
 											context_values (unzip current_case_map series_end_context_features)
-											action_features (list ".series_progress")
+											action_features (list ".reverse_series_index")
 											;do not derive anything during this react
 											derived_action_features (list)
 											derived_context_features (list)
@@ -877,15 +846,8 @@
 										"action_values"
 									))
 							))
-
-							;series_progress >= 1 means we synthed a terminator value, end series immediately
-							(if (>= series_progress 1)
-								(assign (assoc total_progress 1))
-
-								;else if series must stop on a terminator but it should be ending,
-								;prevent it from ending just yet by lowering its total_progress to below 1
-								(and stop_on_terminator (>= total_progress 1))
-								(assign (assoc total_progress 0.9999999999999999))
+							(if (< rev_index_prediction 1)
+								(assign (assoc done (true) ))
 							)
 						)
 					)
@@ -893,8 +855,6 @@
 					;determine whether to stop generating the series
 					;if there's no series_stop_map or exceeded max_series_length, be done
 					(if (or
-							(>= total_progress 1)
-							(= 0 (size series_stop_map))
 							(>= num_generated_rows max_series_length)
 						)
 						(assign (assoc done (true)))
@@ -1513,6 +1473,13 @@
 			)
 		)
 
+		;if continuing, don't need to start at series_index 0
+		(if (contains_index initial_features_map ".series_index")
+			(assign (assoc
+				initial_features_map (remove initial_features_map [".series_index"])
+			))
+		)
+
 		(assign (assoc
 			num_generated_rows (size existing_series_data)
 			num_existing_series_rows (size existing_series_data)
@@ -1526,101 +1493,6 @@
 				;set series_data to just the necessary rows
 				(assign (assoc series_data (tail existing_series_data largest_max_row_lag) ))
 				(assign (assoc last_series_index (- (size series_data) 1) ))
-			)
-		)
-
-		;if end condition is not specified, generate progress based on where series is continuing from
-		(if (not (contains_index series_stop_map !tsTimeFeature))
-			;if there are previous cases to continue from, generate a progress value given the values from the last case
-			(if (size (last series_data))
-				(let
-					(assoc
-						initial_progress_context_features
-							(let
-								(assoc
-									time_delta_feature_name (concat "." !tsTimeFeature "_delta_1")
-									time_lag_feature_name (concat "." !tsTimeFeature "_lag_1")
-								)
-								;use all value, delta, and rate features to determine initial series progress
-								;exclude time feature (and its derived features)
-								(append
-									;derived action features that are not the time feature
-									(filter (lambda (!= !tsTimeFeature (current_value))) derived_action_features)
-									;non-time-deltas that have enough existing rows to be derived properly
-									(filter
-										(lambda (and
-											(!= time_delta_feature_name (current_value))
-											(or
-												;the "root" lag/delta features are in "delta_features" as well
-												;but have no ts_order defined
-												(not (contains_index (get !featureAttributes (current_value)) "ts_order"))
-												(< (get ts_feature_lag_amount_map (current_value)) num_existing_series_rows)
-											)
-											(contains_value features (current_value))
-										))
-										(get !tsFeaturesMap "delta_features")
-									)
-									;non-time-lags that have enough existing rows to be derived properly
-									(filter
-										(lambda (and
-											(!= time_lag_feature_name (current_value))
-											(< (get ts_feature_lag_amount_map (current_value)) num_existing_series_rows)
-											(contains_value features (current_value))
-										))
-										(get !tsFeaturesMap "lag_features")
-									)
-									;rates that have enough existing rows to be derived properly
-									(filter
-										(lambda (and
-											(< (get ts_feature_lag_amount_map (current_value)) num_existing_series_rows)
-											(contains_value features (current_value))
-										))
-										(get !tsFeaturesMap "rate_features")
-									)
-								)
-							)
-					)
-
-					(assign (assoc
-						initial_existing_progress
-							(first (get
-								(call !SingleReact (assoc
-									context_features initial_progress_context_features
-									context_values (unzip (zip features (last series_data)) initial_progress_context_features )
-									action_features (list ".series_progress")
-									;do not derive anything during this react
-									derived_action_features (list)
-									derived_context_features (list)
-									;no details
-									details (null)
-									;prevent overvaluing the progress of case from the original sourced series by ignoring it
-									ignore_case (last existing_series_cases)
-									substitute_output substitute_output
-									input_is_substituted input_is_substituted
-									use_case_weights use_case_weights
-									weight_feature weight_feature
-									rand_seed rand_seed
-									holdout_queries holdout_queries
-
-									desired_conviction desired_conviction
-									use_differential_privacy use_differential_privacy
-									new_case_threshold new_case_threshold
-									feature_bounds_map feature_bounds_map
-									generate_new_cases "no"
-								))
-								"action_values"
-							))
-					))
-					(assign (assoc
-						total_progress initial_existing_progress
-						track_progress (true)
-					))
-					(if (contains_index initial_features_map ".series_progress")
-						(assign (assoc
-							initial_features_map (set initial_features_map ".series_progress" initial_existing_progress)
-						))
-					)
-				)
 			)
 		)
 	)
@@ -2068,7 +1940,6 @@
 												;if there were existing rows, reset to just those existing rows
 												(if num_existing_series_rows
 													(assign (assoc
-														total_progress initial_existing_progress
 														series_data (tail existing_series_data largest_max_row_lag)
 														last_series_index (- num_existing_series_rows 1)
 														num_generated_rows num_existing_series_rows
@@ -2080,7 +1951,6 @@
 													))
 
 													(assign (assoc
-														total_progress 0
 														series_data (list)
 														last_series_index -1
 														num_generated_rows 0
@@ -2173,9 +2043,7 @@
 								new_case_threshold new_case_threshold
 
 								details {}
-								track_progress (false)
 								series_has_terminators (false)
-								total_progress 0
 								max_series_length (null)
 								generate_new_cases generate_new_cases
 								output_features output_features
@@ -2295,5 +2163,21 @@
 						)
 				}
 		))
+	)
+
+	;if initial features are provided, ensure there aren't any that do not appear in features. any extra features are deleted and ignored.
+	#!InitializeInitialSeriesFeatures
+	(if (size initial_features)
+		(let
+			(assoc
+				invalid_initial_features
+					(filter (lambda (not (contains_index feature_index_map (current_value)))) initial_features)
+			)
+			(assign (assoc initial_features_map (zip initial_features initial_values)))
+
+			(if (size invalid_initial_features)
+				(assign (assoc initial_features_map (remove initial_features_map invalid_initial_features)))
+			)
+		)
 	)
 )

--- a/howso/scale.amlg
+++ b/howso/scale.amlg
@@ -113,7 +113,7 @@
 			(let
 				(assoc
 					;keep only those features that aren't specified in 'features', that have 'derived_feature_code' but
-					;will not be auto derived and aren't the built-in '.series_progress_delta'
+					;will not be auto derived
 					derive_only_features
 						(filter
 							(lambda
@@ -121,7 +121,6 @@
 									(not (contains_value features (current_value)))
 									(!= (null) (get !featureAttributes [(current_value 1) "derived_feature_code"]) )
 									(= (null) (get !featureAttributes [(current_value 1) "auto_derive_on_train"]) )
-									(!= (current_value) ".series_progress_delta")
 								)
 							)
 							!trainedFeatures

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -253,8 +253,8 @@
 									(not (contains_value features (current_value)))
 									(!= (null) (get !featureAttributes [(current_value 1) "derived_feature_code"]) )
 									(= (null) (get !featureAttributes [(current_value 1) "auto_derive_on_train"]) )
-									;both of these features are derived manually
-									(not (contains_value [".series_progress_delta" ".synchronous_counter_lag_1"] (current_value)))
+									;these features are derived manually
+									(not (contains_value [".series_index" ".series_reverse_index" ".time_to_horizon" ".synchronous_counter" ".synchronous_counter_lag_1"] (current_value)))
 								)
 							)
 							!trainedFeatures

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -245,7 +245,7 @@
 			(let
 				(assoc
 					;keep only those features that aren't specified in 'features', that have 'derived_feature_code' but
-					;will not be auto derived and aren't the built-in '.series_progress_delta'
+					;will not be auto derived and aren't the built-in time-series features
 					derive_only_features
 						(filter
 							(lambda
@@ -254,7 +254,7 @@
 									(!= (null) (get !featureAttributes [(current_value 1) "derived_feature_code"]) )
 									(= (null) (get !featureAttributes [(current_value 1) "auto_derive_on_train"]) )
 									;these features are derived manually
-									(not (contains_value [".series_index" ".series_reverse_index" ".time_to_horizon" ".synchronous_counter" ".synchronous_counter_lag_1"] (current_value)))
+									(not (contains_value [".series_index" ".reverse_series_index" ".time_to_horizon" ".synchronous_counter" ".synchronous_counter_lag_1"] (current_value)))
 								)
 							)
 							!trainedFeatures

--- a/howso/train_ts_ablation.amlg
+++ b/howso/train_ts_ablation.amlg
@@ -166,12 +166,20 @@
 					))
 					derived_features
 				)
-			progress_features [".series_progress" ".series_index" ".series_progress_delta"]
+			progress_features [".series_index" ".reverse_series_index" ".time_to_horizon"]
 			ts_series_length_limit (retrieve_from_entity "!tsSeriesLimitLength")
 			time_feature_index (get feature_index_map !tsTimeFeature)
 			id_features (get !tsFeaturesMap "series_id_features")
 			id_indices (unzip feature_index_map (get !tsFeaturesMap "series_id_features"))
 			original_features (replace features)
+			max_time_value
+				(get
+					(first (compute_on_contained_entities
+						(query_max !tsTimeFeature)
+						(query_exists !tsTimeFeature)
+					))
+					!tsTimeFeature
+				)
 		))
 		(declare (assoc
 			series_id_features (get !tsFeaturesMap "series_id_features")
@@ -715,34 +723,16 @@
 		(assoc
 			sorted_time_values (map (lambda (get (current_value) time_feature_index)) data)
 		)
-		(declare (assoc
-			range (- (last sorted_time_values) (first sorted_time_values))
-			previous_value (first sorted_time_values)
-			first_value (first sorted_time_values)
-			fixed_delta (/ 1 (- (size sorted_time_values) 1))
-		))
 
-		;output a list of tuples [ progress%, index, delta_to_previous ] for each row in the data
+		;output a list of tuples [ series_index, reverse_index, time_to_horizon ] for each row in the data
 		(map
-			(lambda (let
-				(assoc
-					progress (/ (- (current_value 1) first_value) range)
-					;delta is the % change,  don't allow 0, use the fixed delta instead
-					delta (or (/ (- (current_value 1) previous_value) range) fixed_delta)
-				)
-
-				;if the series is of length 1, set progress and delta to be 1 and prevent a divide by 0
-				(if (= 0 range)
-					(assign (assoc
-						progress 1
-						delta 1
-					))
-				)
-				(assign (assoc previous_value (current_value 1)))
-				;output the tuple
-				[progress (current_index 1) delta]
-			))
-
+			(lambda
+				[
+					(current_index 1)
+					(- (size sorted_time_values) 1 (current_index 1))
+					(- max_time_value (current_value 1))
+				]
+			)
 			sorted_time_values
 		)
 	)

--- a/howso/train_ts_ablation.amlg
+++ b/howso/train_ts_ablation.amlg
@@ -166,7 +166,11 @@
 					))
 					derived_features
 				)
-			progress_features [".series_index" ".reverse_series_index" ".time_to_horizon"]
+			progress_features
+				(if !tsTimeFeatureUniversal
+					[".series_index" ".reverse_series_index" ".time_to_horizon"]
+					[".series_index" ".reverse_series_index"]
+				)
 			ts_series_length_limit (retrieve_from_entity "!tsSeriesLimitLength")
 			time_feature_index (get feature_index_map !tsTimeFeature)
 			id_features (get !tsFeaturesMap "series_id_features")
@@ -722,16 +726,28 @@
 	(declare
 		(assoc
 			sorted_time_values (map (lambda (get (current_value) time_feature_index)) data)
+
+			;not param
+			is_universal !tsTimeFeatureUniversal
 		)
+
+		(declare (assoc time_to_horizon (- max_time_value (last sorted_time_values)) ))
 
 		;output a list of tuples [ series_index, reverse_index, time_to_horizon ] for each row in the data
 		(map
 			(lambda
-				[
-					(current_index 1)
-					(- (size sorted_time_values) 1 (current_index 1))
-					(- max_time_value (current_value 1))
-				]
+				(if is_universal
+					[
+						(current_index 1)
+						(- (size sorted_time_values) 1 (current_index 1))
+						time_to_horizon
+					]
+
+					[
+						(current_index 1)
+						(- (size sorted_time_values) 1 (current_index 1))
+					]
+				)
 			)
 			sorted_time_values
 		)

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -351,20 +351,6 @@
 														"Only applicable when time series type is set to `delta`."
 													)
 											)
-										series_has_terminators
-											(assoc
-												type "boolean"
-												description
-													(concat
-														"When true, requires that the trainee identify and learn values that explicitly denote the end of a series. "
-														"Only applicable to id features for a series."
-													)
-											)
-										stop_on_terminator
-											(assoc
-												type "boolean"
-												description "When true, requires that a series ends on a terminator value. Only applicable to id features for a series."
-											)
 										universal
 											(assoc
 												type "boolean"

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -119,9 +119,7 @@
 								type "assoc"
 								description
 									(concat
-										"Derive feature by creating two new continuous features: `.series_progress` and `.series_progress_delta`. "
-										"Series progress values range from 0 to 1.0 for each case in the series. Series progress delta values are the delta "
-										"value of the progress for each case. Both of these features are used to determine when to stop series synthesis."
+										"Configuration for auto deriving the values of a feature based on the otehr feature values of the case or series."
 									)
 								additional_indices (false)
 								indices
@@ -129,7 +127,7 @@
 										derive_type
 											(assoc
 												type "string"
-												enum ["custom" "start" "end" "progress"]
+												enum ["custom" "start" "end"]
 												description "The train derive operation type."
 											)
 										code

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -1688,23 +1688,23 @@
 								type "number"
 								description "The influence of a case on a prediction."
 							)
-						".series_progress"
+						".synchronous_counter"
 							(assoc
 								type "number"
-								description "A 0-1 float describing the progress though the case's series at the point in time described by the case."
 								min 0
-								max 1
-							)
-						".series_progress_delta"
-							(assoc
-								type "number"
-								description "The delta between the series progress of the previous case of the series and the case being described."
+								description "The number of time steps that follow in the series that take place at the same time value."
 							)
 						".series_index"
 							(assoc
 								type "number"
 								min 0
 								description "The zero-based index of the case within its series sorted by time."
+							)
+						".reverse_series_index"
+							(assoc
+								type "number"
+								min 0
+								description "The zero-based index of the case within its series sorted by time in reverse."
 							)
 					)
 				dynamic_indices

--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -1704,6 +1704,16 @@
 								min 0
 								description "The zero-based index of the case within its series sorted by time in reverse."
 							)
+						".time_to_horizon"
+							(assoc
+								type "number"
+								min 0
+								description
+									(concat
+										"The difference between the last time value observed in the series and the maximum time value "
+										"observed in the trained data. This is only defined and used when using a universal time feature."
+									)
+							)
 					)
 				dynamic_indices
 					(assoc

--- a/unit_tests/ut_h_ablate_ts.amlg
+++ b/unit_tests/ut_h_ablate_ts.amlg
@@ -137,7 +137,7 @@
 					(get
 						(call_entity "howso" "get_cases" (assoc
 							session session
-							features ["ID" "date" "index" ".session_training_index" ".series_index" ".series_progress"]
+							features ["ID" "date" "index" ".session_training_index" ".series_index"]
 						))
 						[1 "payload" "cases"]
 					)
@@ -146,7 +146,6 @@
 				original_index 2
 				session_train_index 3
 				series_index 4
-				series_progress_index 5
 			))
 			(declare (assoc
 				original_indices (map (lambda (get (current_value) original_index)) trained_cases)

--- a/unit_tests/ut_h_derive_start_end.amlg
+++ b/unit_tests/ut_h_derive_start_end.amlg
@@ -85,7 +85,7 @@
 	(call assert_same (assoc exp [13 2 0] obs (get result 13) ))
 
 
-	(call exit_if_failures (assoc msg "Derived time series progress and delta features" ))
+	(call exit_if_failures (assoc msg "Derived time series indices features" ))
 
 
 

--- a/unit_tests/ut_h_derive_start_end.amlg
+++ b/unit_tests/ut_h_derive_start_end.amlg
@@ -55,7 +55,7 @@
 		result
 			(get
 				(call_entity "howso" "get_cases" (assoc
-					features (list ".session_training_index" ".series_progress" ".series_progress_delta")
+					features (list ".session_training_index" ".series_index" ".reverse_series_index")
 					; guarantee output order of cases is same as it was trained
 					session "session"
 				))
@@ -64,32 +64,25 @@
 	))
 
 	(print "\nmike start, index 0:\n")
-	(call assert_same (assoc exp 0 obs (get result (list 0 1))))
-	(call assert_same (assoc exp 0.25 obs (get result (list 0 2))))
+	(call assert_same (assoc exp [0 0 4] obs (get result 0) ))
 
 	(print "\nchris end, index 1:\n")
-	(call assert_same (assoc exp 1 obs (get result (list 1 1))))
-	(call assert_same (assoc exp 0.1 obs (get result (list 1 2))))
+	(call assert_same (assoc exp [1 5 0] obs (get result 1) ))
 
 	(print "\nchris start, index 6:\n")
-	(call assert_same (assoc exp 0 obs (get result (list 6 1))))
-	(call assert_same (assoc exp 0.2 obs (get result (list 6 2))))
+	(call assert_same (assoc exp [6 0 5] obs (get result 6) ))
 
 	(print "\nmike end, index 5:\n")
-	(call assert_same (assoc exp 1 obs (get result (list 5 1))))
-	(call assert_approximate (assoc exp 0.1724 obs (get result (list 5 2))))
+	(call assert_same (assoc exp [5 4 0] obs (get result 5) ))
 
 	(print "\njacob start, index 11:\n")
-	(call assert_same (assoc exp 0 obs (get result (list 11 1))))
-	(call assert_same (assoc exp 0.5 obs (get result (list 11 2))))
+	(call assert_same (assoc exp [11 0 2] obs (get result 11) ))
 
 	(print "\njacob middle:\n")
-	(call assert_approximate (assoc exp 0.2857 obs (get result (list 12 1))))
-	(call assert_approximate (assoc exp 0.2857 obs (get result (list 12 2))))
+	(call assert_same (assoc exp [12 1 1] obs (get result 12) ))
 
 	(print "\njacob end, index 13:\n")
-	(call assert_same (assoc exp 1 obs (get result (list 13 1))))
-	(call assert_approximate (assoc exp 0.7143 obs (get result (list 13 2))))
+	(call assert_same (assoc exp [13 2 0] obs (get result 13) ))
 
 
 	(call exit_if_failures (assoc msg "Derived time series progress and delta features" ))
@@ -101,7 +94,7 @@
 		result
 			(get
 				(call_entity "howso" "get_cases" (assoc
-					features (list ".session_training_index" "name" "time" ".series_progress" ".series_progress_delta" ".time_lag_1" ".time_delta_1")
+					features (list ".session_training_index" "name" "time" ".series_index" ".reverse_series_index" ".time_lag_1" ".time_delta_1")
 					case_indices (list (list "session" 4))
 				))
 				(list 1 "payload" "cases")
@@ -110,7 +103,7 @@
 	(declare (assoc
 		mike_case_4
 			(zip
-				(list ".session_training_index" "name" "time" ".series_progress" ".series_progress_delta" ".time_lag_1" ".time_delta_1")
+				(list ".session_training_index" "name" "time" ".series_index" ".reverse_series_index" ".time_lag_1" ".time_delta_1")
 				(first result)
 			)
 	))
@@ -120,8 +113,8 @@
 		obs mike_case_4
 		exp
 			(assoc
-				".series_progress" 0.8275862068965517
-				".series_progress_delta" 0.4827586206896552
+				".series_index" 3
+				".reverse_series_index" 1
 				".session_training_index" 4
 				".time_delta_1" 1400
 				".time_lag_1" 2000
@@ -151,7 +144,7 @@
 		result
 			(get
 				(call_entity "howso" "get_cases" (assoc
-					features (list ".session_training_index" "name" "time" ".series_progress" ".series_progress_delta" ".time_lag_1" ".time_delta_1")
+					features (list ".session_training_index" "name" "time" ".series_index" ".reverse_series_index" ".time_lag_1" ".time_delta_1")
 					case_indices (list (list "session" 4))
 				))
 				(list 1 "payload" "cases")
@@ -160,7 +153,7 @@
 	(declare (assoc
 		mike_case_3
 			(zip
-				(list ".session_training_index" "name" "time" ".series_progress" ".series_progress_delta" ".time_lag_1" ".time_delta_1")
+				(list ".session_training_index" "name" "time" ".series_index" ".reverse_series_index" ".time_lag_1" ".time_delta_1")
 				(first result)
 			)
 	))
@@ -170,8 +163,8 @@
 		obs mike_case_3
 		exp
 			(assoc
-				".series_progress" 0.8275862068965517
-				".series_progress_delta" 0.6206896551724138
+				".series_index" 2
+				".reverse_series_index" 1
 				".session_training_index" 4
 				".time_delta_1" 1800
 				".time_lag_1" 1600

--- a/unit_tests/ut_h_shared_deviations_series.amlg
+++ b/unit_tests/ut_h_shared_deviations_series.amlg
@@ -95,7 +95,7 @@
 
 	(declare (assoc
 		shared_feature_deviations
-			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(declare (assoc shared_feature_deviations (get shared_deviations_hp_map deviations_param_path)))
@@ -158,7 +158,7 @@
 	(call_entity "howso" "analyze" (assoc use_deviations (true)))
 
 	(assign (assoc shared_feature_deviations
-		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".series_progress..series_progress_delta..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(print "Series lag features with no shared deviations are different: .value_lag_1 and .value_lag_2.")

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -181,11 +181,6 @@
 							)
 					)
 			)
-		all_features
-			(list
-				"ID" "f1" ".f1_lag_1" "f2" ".f2_lag_1" "f3" ".f3_lag_1" "date" ".date_lag_1" ".date_delta_1"
-				"f1_rate_1" ".f2_rate_1" ".f2_rate_2" ".f3_rate_1" ".series_progress" ".series_progress_delta"
-			)
 	))
 
 	(assign (assoc

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -241,7 +241,7 @@
 			rate_features (list ".f1_rate_1" ".f3_rate_1" ".f2_rate_1" ".f2_rate_2")
 			ts_derived_features
 				(list
-					".series_progress" ".series_progress_delta" ".date_lag_1" ".f3_lag_1" ".f1_lag_1" ".f2_lag_1"
+					".series_index" ".reverse_series_index" ".date_lag_1" ".f3_lag_1" ".f1_lag_1" ".f2_lag_1"
 					".date_delta_1"
 					".f1_delta_1" ".f2_delta_1" ".f2_delta_2" ".f3_delta_1"
 					".f1_rate_1" ".f2_rate_1" ".f3_rate_1" ".f2_rate_2"

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -199,7 +199,7 @@
 		result
 			(call_entity "howso" "react_series" (assoc
 				derived_action_features (list ".custom_nominal")
-				action_features (list "stock" ".time_delta_1" ".value_delta_1" "name" ".series_progress" ".series_progress_delta" "time" "owner" "value" )
+				action_features (list "stock" ".time_delta_1" ".value_delta_1" "name" ".series_index" "time" "owner" "value" )
 				desired_conviction 4.5
 
 				max_series_lengths (list 10)
@@ -217,7 +217,7 @@
 		result
 			(call_entity "howso" "react_series" (assoc
 				derived_action_features (list ".custom_nominal")
-				action_features (list "stock" ".time_delta_1" ".value_delta_1" "name" ".series_progress" ".series_progress_delta" "time" "owner" "value" ".custom_nominal" )
+				action_features (list "stock" ".time_delta_1" ".value_delta_1" "name" ".series_index" "time" "owner" "value" ".custom_nominal" )
 				desired_conviction 4.5
 
 				max_series_lengths (list 10)
@@ -262,7 +262,7 @@
 	(call assert_true (assoc obs (<= (size series) 10)))
 
 	;grab the first synthed date
-	(assign (assoc result (get result (list 1 "payload" "action_values" 0 0 6)) ))
+	(assign (assoc result (get result (list 1 "payload" "action_values" 0 0 5)) ))
 
 	;convert date to epoch (number)
 	(assign (assoc
@@ -312,9 +312,9 @@
 	))
 
 	;filtering out the two null keys should leave 8 non-null keys in the result assoc:
-	; ".custom_nominal" ".series_progress"  ".series_progress_delta" "name" "owner" "stock" "time" "value"
+	; ".custom_nominal" ".series_index" "name" "owner" "stock" "time" "value"
 	(call assert_same (assoc
-		exp 8
+		exp 7
 		obs (size (filter result))
 	))
 	(call exit_if_failures (assoc msg "Boundaries respected."))
@@ -322,7 +322,7 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "react_series" (assoc
-				action_features (list "stock" ".time_delta_1" ".value_delta_1" "name" ".series_progress" ".series_progress_delta" "time" "owner" "value" ".custom_nominal" )
+				action_features (list "stock" ".time_delta_1" ".value_delta_1" "name" ".series_index" "time" "owner" "value" ".custom_nominal" )
 				derived_action_features (list ".custom_nominal")
 
 				series_context_features (list "value")

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -103,33 +103,6 @@
 			)
 	))
 
-	(assign (assoc
-		result (call_entity "howso" "get_feature_attributes")
-	))
-	(call keep_result_payload)
-	(print "Progress features derived correctly: ")
-	(call assert_same (assoc
-		obs (get result ".series_progress_delta")
-		exp
-			(assoc
-				bounds (assoc "max" 1 "min" 0)
-				type "continuous"
-			)
-	))
-
-	(call assert_same (assoc
-		obs (get result ".series_progress")
-		exp
-			(assoc
-				auto_derive_on_train (assoc derive_type "progress" series_id_features (list "stock") )
-				bounds (assoc min 0)
-				code_features [".series_progress" ".series_progress_delta"]
-				derived_feature_code "(min 1 (+ (call value {feature \".series_progress\" lag 1}) (call value {feature \".series_progress_delta\" lag 1}) ))"
-				max_row_lag 1
-				type "continuous"
-			)
-	))
-
 	(call_entity "howso" "train" (assoc
 		cases (trunc data 16)
 		features features
@@ -217,7 +190,7 @@
 	(print "Continued average series length from middle is medium length: ")
 	(call assert_approximate (assoc
 		obs (/ (apply "+" series_lengths) (size series_lengths))
-		exp 4
+		exp 6
 		thresh 2
 	))
 
@@ -760,7 +733,7 @@
 	(call_entity "howso" "set_auto_ablation_params" (assoc min_num_cases 10 ))
 	(call_entity "howso" "reduce_data")
 	(assign (assoc
-		result (call_entity "howso" "get_cases" (assoc features [".series_index" ".series_progress" "stock"]))
+		result (call_entity "howso" "get_cases" (assoc features [".series_index" ".reverse_series_index" "stock"]))
 	))
 	(call keep_result_payload)
 
@@ -784,11 +757,11 @@
 		obs (size (zip (map (lambda (last (current_value))) first_series_cases)))
 	))
 
-	;get all cases that have a .series_progress of 1
+	;get all cases that have a .reverse_series_index of 0
 	(declare (assoc
 		last_series_cases
 			(filter
-				(lambda (= 1 (get (current_value) 1)))
+				(lambda (= 0 (get (current_value) 1)))
 				(get result "cases")
 			)
 	))

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -390,8 +390,6 @@
 						"time_series"
 							(assoc
 								"type" "delta"
-								"series_has_terminators" (true)
-								"stop_on_terminator" (true)
 							)
 					)
 
@@ -425,62 +423,6 @@
 			)
 	))
 
-	(assign (assoc
-		result
-			(call_entity "howso" "react_series" (assoc
-				num_series_to_generate 3
-				action_features (list "stock" "time" "value")
-				desired_conviction 5
-				use_differential_privacy (true)
-				continue_series (true)
-				series_id_features ["stock"]
-				series_id_values [["stk_A"]]
-			))
-	))
-
-	(print "Batch react series failed to continue series with a warning: ")
-	(call assert_same (assoc
-		obs (get result [1 "payload"])
-		exp
-			(assoc
-				action_features (list "stock" "time" "value")
-				;3 nulls, one for each series
-				action_values (list (null) (null) (null))
-			)
-	))
-	(call assert_same (assoc
-		obs (zip (get result [1 "warnings"]))
-		exp (zip (list "Can't continue terminated series." "There are no cached hyperparameters in this trainee. This operation was executed using a set of predefined default hyperparameters. Please run `analyze` or enable auto-analysis with `set_auto_analyze_params`."))
-	))
-
-	(assign (assoc
-		result
-			(call_entity "howso" "single_react_series" (assoc
-				action_features (list "stock" "time" "value")
-				desired_conviction 5
-				use_differential_privacy (true)
-				continue_series (true)
-				series_id_features ["stock"]
-				series_id_values [["stk_A"]]
-			))
-	))
-
-	(print "Single react series failed to continue series with a warning: ")
-	(call assert_same (assoc
-		obs (get result [1 "payload"])
-		exp
-			(assoc
-				action_features (list "stock" "time" "value")
-				action_values (null)
-			)
-	))
-	(call assert_same (assoc
-		obs (zip (get result [1 "warnings"]))
-		exp (zip (list "Can't continue terminated series." "There are no cached hyperparameters in this trainee. This operation was executed using a set of predefined default hyperparameters. Please run `analyze` or enable auto-analysis with `set_auto_analyze_params`."))
-	))
-
-
-	(call exit_if_failures (assoc msg "Don't continue terminated series."))
 
 
 	(assign (assoc
@@ -640,8 +582,6 @@
 						"time_series"
 							(assoc
 								"type" "delta"
-								"series_has_terminators" (true)
-								"stop_on_terminator" (true)
 							)
 					)
 


### PR DESCRIPTION
This is a significant rework to some of the internal feature-engineering for time-series Trainees. An overview of the changes in this PR:

- `.series_progress` and `.series_progress_delta` are removed as internal features.
- 'series_has_terminators' and 'stop_on_terminator' attributes have been removed.
- Two new internal features are now derived automatically for TS data
   - `.reverse_series_index`: zero based index for the series' timesteps in reverse
   - `.time_to_horizon`: A feature only used in universal time-feature datasets that models how close the timesteps are to the "horizon" of the dataset (the latest trained time-value).
- Series termination logic when no series-stop-maps are specified now relies on the prediction of no following timesteps (rather than an internally tracked series progress reaching 1.0)