### PR TITLE
24708: Refactors reduce_data method and streamlines ablation

### DIFF
--- a/howso.amlg
+++ b/howso.amlg
@@ -40,6 +40,7 @@
 	#!internalLabelImputed ".imputed"
 	#!internalLabelCaseEditHistory ".case_edit_history"
 	#!internalLabelInfluenceWeightEntropy ".influence_weight_entropy"
+	#!internalLabelTooFarForRemoval ".too_far_for_removal"
 	#!internalLabelProbabilityMass ".probability_mass"
 
 	;the name of the entity that contains subtrainees

--- a/howso.amlg
+++ b/howso.amlg
@@ -40,7 +40,6 @@
 	#!internalLabelImputed ".imputed"
 	#!internalLabelCaseEditHistory ".case_edit_history"
 	#!internalLabelInfluenceWeightEntropy ".influence_weight_entropy"
-	#!internalLabelTooFarForRemoval ".too_far_for_removal"
 	#!internalLabelProbabilityMass ".probability_mass"
 
 	;the name of the entity that contains subtrainees

--- a/howso.amlg
+++ b/howso.amlg
@@ -132,6 +132,7 @@
 	#!autoAblationConvictionUpperThreshold (null)
 	#!autoAblationWeightFeature (null)
 	#!autoAblationMaxInfluenceWeightEntropy (null)
+	#!autoAblationNinetyPercentQuantileInfluence (null)
 	#!autoAblationAbsThresholdMap (null)
 	#!autoAblationDeltaThresholdMap (null)
 	#!autoAblationRelThresholdMap (null)
@@ -708,6 +709,9 @@
 
 			;cached value of the max influence weight entropy to keep cases cases during ablation
 			!autoAblationMaxInfluenceWeightEntropy (null)
+
+			;cached value of the 90% quantile of influences of most similar cases
+			!autoAblationNinetyPercentQuantileInfluence (null)
 
 			;absolute threshold map for auto-ablation, if these are satisfied then auto-ablation will cease.
 			!autoAblationAbsThresholdMap (assoc)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -162,29 +162,34 @@
 			label_name (or label_name !internalLabelInfluenceWeightEntropy)
 		))
 
-		(declare (assoc quantile_value (call !RecomputeAndCacheMaxInfluenceWeightEntropy) ))
+		(declare (assoc
+			perfect_match_influence (if (= "surprisal_to_prob" dt_parameter) 1 .infinity)
+		))
+		;compute the 90%th quantile for closest case influence, so that only cases that are in the 10% closest are considered
+		(declare (assoc
+			ninety_percent_quantile_closest_influence
+				(quantile
+					(values (filter
+						(lambda (!= perfect_match_influence (current_value)))
+						(map (lambda (get (current_value) 2)) influence_weight_entropy_map)
+					))
+					0.9
+				)
+		))
 
-		(assign_to_entities (assoc !autoAblationMaxInfluenceWeightEntropy quantile_value ))
+		(assign_to_entities (assoc
+			!autoAblationMaxInfluenceWeightEntropy (call !RecomputeAndCacheMaxInfluenceWeightEntropy)
+			!autoAblationNinetyPercentQuantileInfluence ninety_percent_quantile_closest_influence
+		))
 
 		;if computing on the entire dataset, mark cases that are very close to exactly one other case and can be merged together
 		(if (and compute_all (= (null) specific_case_ids))
 			(declare (assoc
-				extreme_neighbors_map
+				near_duplicate_map
 					(let
-						(assoc perfect_match_influence (if (= "surprisal_to_prob" dt_parameter) 1 .infinity) )
-
-						;compute the 90%th quantile for closest case influence, so that only cases that are in the 10% closest are considered
-						(declare (assoc
-							ninety_percent_quantile_closest_influence
-								(quantile
-									(values (filter (lambda (!= perfect_match_influence (current_value))) (map (lambda (get (current_value) 2)) influence_weight_entropy_map)))
-									0.9
-								)
-						))
-
-						;from those 10% closest (ignoring duplicate cases), only keep those whose influence weight entropy is under 0.1,
-						;denoting that they are very close to just their one nearest neighbor
-						(declare (assoc
+						(assoc
+							;from the 10% closest (ignoring duplicate cases), only keep those whose influence weight entropy is under 0.1,
+							;denoting that they are very close to just their one nearest neighbor
 							extremely_close_to_one_neighbor_map
 								(filter
 									(lambda (and
@@ -197,7 +202,7 @@
 									))
 									influence_weight_entropy_map
 								)
-						))
+						)
 
 						;create an assoc of case -> neighbor_case to merge into
 						;filters out null if case is reciprocated, but this case has higher entropy and will absorb the one with the lower entropy
@@ -245,7 +250,7 @@
 						)
 						"too_far_for_removal"
 
-						(contains_index extreme_neighbors_map (current_index))
+						(contains_index near_duplicate_map (current_index))
 						"near_duplicate"
 					)
 				)
@@ -884,14 +889,20 @@
 			(conclude .true)
 		)
 
-		(assign (assoc max_influence_weight_entropy_to_keep !autoAblationMaxInfluenceWeightEntropy  ))
+		(assign (assoc
+			max_influence_weight_entropy_to_keep !autoAblationMaxInfluenceWeightEntropy
+			ninety_percent_quantile_closest_influence !autoAblationNinetyPercentQuantileInfluence
+		))
 
 		;if there is no influence weight entropy cached yet, do the caching here
 		(if (= (null) max_influence_weight_entropy_to_keep)
 			(seq
 				(call !ComputeAndStoreInfluenceWeightEntropies (assoc features features))
 
-				(assign (assoc max_influence_weight_entropy_to_keep !autoAblationMaxInfluenceWeightEntropy ))
+				(assign (assoc
+					max_influence_weight_entropy_to_keep !autoAblationMaxInfluenceWeightEntropy
+					ninety_percent_quantile_closest_influence !autoAblationNinetyPercentQuantileInfluence
+				))
 			)
 		)
 
@@ -904,63 +915,72 @@
 				))
 		))
 
-		(+
-			(or
-				;case should be kept because influentials are not evenly distributed (their entropy is low)
-				(if (> max_influence_weight_entropy_to_keep (first influentials_entropy_tuple))
-					.true
-
-					;always ablate perfect matches/identical cases
-					(= .infinity (first influentials_entropy_tuple))
+		(or
+			;case may be kept because influentials are not evenly distributed (their entropy is low)
+			(if (> max_influence_weight_entropy_to_keep (first influentials_entropy_tuple))
+				;check if case is a near duplicate, if it is, it can be ablated
+				(if (and
+						;entropy is < 0.1, meaning significantly closer to one case than any of the others
+						(< (first influentials_entropy_tuple) 0.1)
+						;closest case influence is in the top 10%
+						(> (last influentials_entropy_tuple) ninety_percent_quantile_closest_influence)
+					)
 					.false
 
-					;else ablate? check distance to closest vs its distance to its K'th closest
-					(let
-						(assoc
-							neighbor_cases_pairs
-								(compute_on_contained_entities
-									(query_not_in_entity_list [(get influentials_entropy_tuple 1)])
-									(query_nearest_generalized_distance
-										closest_k
-										features
-										(retrieve_from_entity (get influentials_entropy_tuple 1) features)
-										p_parameter
-										feature_weights
-										!queryDistanceTypeMap
-										query_feature_attributes_map
-										feature_deviations
-										(null)
-										dt_parameter
-										weight_feature
-										(rand)
-										(null) ;radius
-										!numericalPrecision
-										;output as ordered pair
-										.true
-									)
-								)
-						)
-
-						;in non-surprisal space, the values coming out of the query are inverse distance, inverting them back converts them back to distances to the cases
-						;in surprisal space, the values coming out of the query are probabilities, inverted probabilities are monotonic to surprisals (distances)
-						;thus the comparison below works as intended
-						(declare (assoc
-							dist_to_closest_neighbor (/ 1 (last influentials_entropy_tuple))
-							neighbor_dist_to_its_farthest_case (/ 1 (last (last neighbor_cases_pairs)) )
-						))
-
-						;keep this training case if the 'distance' to its closest existing case is relatively large
-						(>
-							dist_to_closest_neighbor
-							neighbor_dist_to_its_farthest_case
-						)
-					)
+					;keep case
+					.true
 				)
 
-				; This is probably unnecessary but in case we cannot compute the requested influence weight
-				; quantile return 1 as well.
-				(= max_influence_weight_entropy_to_keep (null))
+				;always ablate perfect matches/identical cases
+				(= .infinity (first influentials_entropy_tuple))
+				.false
+
+				;else ablate? check distance to closest vs its distance to its K'th closest
+				(let
+					(assoc
+						neighbor_cases_pairs
+							(compute_on_contained_entities
+								(query_not_in_entity_list [(get influentials_entropy_tuple 1)])
+								(query_nearest_generalized_distance
+									closest_k
+									features
+									(retrieve_from_entity (get influentials_entropy_tuple 1) features)
+									p_parameter
+									feature_weights
+									!queryDistanceTypeMap
+									query_feature_attributes_map
+									feature_deviations
+									(null)
+									dt_parameter
+									weight_feature
+									(rand)
+									(null) ;radius
+									!numericalPrecision
+									;output as ordered pair
+									.true
+								)
+							)
+					)
+
+					;in non-surprisal space, the values coming out of the query are inverse distance, inverting them back converts them back to distances to the cases
+					;in surprisal space, the values coming out of the query are probabilities, inverted probabilities are monotonic to surprisals (distances)
+					;thus the comparison below works as intended
+					(declare (assoc
+						dist_to_closest_neighbor (/ 1 (last influentials_entropy_tuple))
+						neighbor_dist_to_its_farthest_case (/ 1 (last (last neighbor_cases_pairs)) )
+					))
+
+					;keep this training case if the 'distance' to its closest existing case is relatively large
+					(>
+						dist_to_closest_neighbor
+						neighbor_dist_to_its_farthest_case
+					)
+				)
 			)
+
+			; This is probably unnecessary but in case we cannot compute the requested influence weight
+			; quantile return 1 as well.
+			(= max_influence_weight_entropy_to_keep (null))
 		)
 	)
 

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -166,9 +166,64 @@
 
 		(assign_to_entities (assoc !autoAblationMaxInfluenceWeightEntropy quantile_value ))
 
+		;if computing on the entire dataset, mark cases that are very close to exactly one other case and can be merged together
+		(if (and compute_all (= (null) specific_case_ids))
+			(declare (assoc
+				extreme_neighbors_map
+					(let
+						(assoc perfect_match_influence (if (= "surprisal_to_prob" dt_parameter) 1 .infinity) )
+
+						;compute the 90%th quantile for closest case influence, so that only cases that are in the 10% closest are considered
+						(declare (assoc
+							ninety_percent_quantile_closest_influence
+								(quantile
+									(values (filter (lambda (!= perfect_match_influence (current_value))) (map (lambda (get (current_value) 2)) influence_weight_entropy_map)))
+									0.9
+								)
+						))
+
+						;from those 10% closest (ignoring duplicate cases), only keep those whose influence weight entropy is under 0.1,
+						;denoting that they are very close to just their one nearest neighbor
+						(declare (assoc
+							extremely_close_to_one_neighbor_map
+								(filter
+									(lambda (and
+										;closest case influence is in the top 10%
+										(> (get (current_value) 2) ninety_percent_quantile_closest_influence)
+										;entropy is < 0.1, meaning significantly closer to one case than any of the others
+										(< (first (current_value)) 0.1)
+										;ignore duplicates since they'll be merged together separately
+										(!= perfect_match_influence (get (current_value) 2))
+									))
+									influence_weight_entropy_map
+								)
+						))
+
+						;create an assoc of case -> neighbor_case to merge into
+						;filters out null if case is reciprocated, but this case has higher entropy and will absorb the one with the lower entropy
+						(filter (map
+							(lambda (let
+								(assoc nearest_case (get (current_value 1) 1))
+								;this case is reciprocated as the closest by nearest_case
+								(if (= (current_index) (get extremely_close_to_one_neighbor_map [nearest_case 1]))
+									;if the entropy of this case is smaller, it should be merged into nearest_case, else it should not be merged
+									(if (<= (first (current_value)) (get extremely_close_to_one_neighbor_map [nearest_case 0]))
+										nearest_case
+									)
+
+									nearest_case
+								)
+							))
+							extremely_close_to_one_neighbor_map
+						))
+					)
+			))
+		)
+
 		(if compute_all
-			;output an assoc of case id -> "duplicate" or "too_far_for_removal", for any cases that match that criteria
-			;"too_far_for_removal" applies to any case that should not be removed because its closest case is relatively too far (farther that its farthest)
+			;output an assoc of case id -> "duplicate" or "too_far_for_removal" or "near_duplicate" (for extremely close single neighbors), depending if any cases match that criteria
+			; "too_far_for_removal" applies to any case that should not be removed because its closest case is relatively too far (farther that its farthest)
+			; "near_duplicate" applies to any cases that are extremely close to exactly one neighbor case
 			(filter (map
 				(lambda
 					;(current_value) is a tuple of [ entropy, closest_case_id, closest_influence, farthest_influence, is_duplicate ]
@@ -189,6 +244,9 @@
 							(/ 1 (get influence_weight_entropy_map [ (get (current_value 1) 1) 3 ]) )
 						)
 						"too_far_for_removal"
+
+						(contains_index extreme_neighbors_map (current_index))
+						"near_duplicate"
 					)
 				)
 				influence_weight_entropy_map
@@ -531,7 +589,7 @@
 
 		;Also ensure that we have all influence weight entropies and that they are up-to-date
 		(declare (assoc
-			;store a map of case id -> "duplicate"/"too_far_for_removal" for any duplicate cases or cases that should not be removed because they are too far
+			;store a map of case id -> "duplicate"/"too_far_for_removal"/"near_duplicate" for any duplicate cases or cases that should not be removed because they are too far
 			case_duplicate_or_far_map
 				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
 					features features
@@ -565,7 +623,15 @@
 
 		(declare (assoc
 			cases_too_far_for_removal (indices (filter (lambda (= "too_far_for_removal" (current_value))) case_duplicate_or_far_map))
+			near_duplicate_cases (indices (filter (lambda (= "near_duplicate" (current_value))) case_duplicate_or_far_map))
 		))
+		;remove and redistribute the near_duplicate cases' weights
+		(if (size near_duplicate_cases)
+			(call !RemoveCases (assoc
+				cases near_duplicate_cases
+				distribute_weight_feature distribute_weight_feature
+			))
+		)
 
 		;Begin looping on data removal. The ultimate end condition is if the dataset gets too small
 		; to continue removing cases. Removes cases with relatively high influence weight entropy, i.e., cases with equidistant neighbors.

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -585,7 +585,8 @@
 		(if (< (call !GetNumTrainingCases) (/ pre_reduce_num_cases 2.718281828459))
 			(call !AutoAnalyzeIfNeeded (assoc
 				skip_auto_analyze skip_auto_analyze
-				in_reduce_data .true
+				;no need to compute entropies for all cases anymore since reduction is complete
+				in_reduce_data .false
 			))
 		)
 

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -59,13 +59,6 @@
 				(and
 					(>= (first (last local_cases_pairs)) 1)
 					(= "surprisal_to_prob" dt_parameter)
-					(if use_case_weights
-						(=
-							(first (last local_cases_pairs))
-							(retrieve_from_entity (first (first local_cases_pairs)) weight_feature )
-						)
-						.true
-					)
 				)
 				(conclude [ .infinity (null) ])
 			)
@@ -927,11 +920,12 @@
 					)
 					.false
 
-					;keep case
+					;else keep case
 					.true
 				)
 
 				;always ablate perfect matches/identical cases
+				;entropy value will have been set to .infinity by !ComputeInfluenceWeightEntropy for duplicates
 				(= .infinity (first influentials_entropy_tuple))
 				.false
 

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -142,89 +142,58 @@
 				)
 		))
 
-		(if compute_all
-			(map
-				(lambda (let
-					(assoc
-						case_id (current_index 1)
-						influence_weight_entropy (first (current_value 1))
-						is_too_far (last (current_value 1))
-					)
-
-					(if (contains_label case_id !internalLabelInfluenceWeightEntropy)
-						(assign_to_entities case_id
-							(associate
-								!internalLabelInfluenceWeightEntropy influence_weight_entropy
-								!internalLabelTooFarForRemoval is_too_far
-							)
-						)
-
-						(accum_entity_roots case_id
-							(zip_labels
-								[ !internalLabelInfluenceWeightEntropy !internalLabelTooFarForRemoval ]
-								[ influence_weight_entropy is_too_far ]
-							)
+		(call !StoreCaseValues (assoc
+			case_values_map
+				(if (or
+						compute_all
+						(<
+							(call !GetNumTrainingCases)
+							(* 1.02 !autoAblationInfluenceWeightEntropySampleSize)
 						)
 					)
-				))
+					(map (lambda (first (current_value))) influence_weight_entropy_map)
 
-				;create an assoc of case id -> [ entropy, case is too far boolean]
-				;boolean is true if this case should not be removed because its closest case is relatively too far (farther that its farthest)
-				(map
-					(lambda
-						;(current_value) is a tuple of [ entropy, closest_case_id, closest_influence, farthest_influence ]
-
-						;in non-surprisal space, influences are inverse distance, inverting them back converts them back to distances to the cases
-						;in surprisal space, influences are probabilities, inverted probabilities are monotonic to surprisals (distances)
-						;thus the comparison below works as intended
-
-						;output a pair of [ entropy, 'is_too_far' boolean ]
-						[
-							(first (current_value 1))
-
-							;if has exact duplicates, just output "duplicate"
-							(if (last (current_value 1))
-								"duplicate"
-
-								;else output .true if this case is too far for removal
-								(>
-									;distance to closest case
-									(/ 1 (get (current_value 1) 2))
-									;distance to closest case's farthest influence
-									(/ 1 (get influence_weight_entropy_map [ (get (current_value 2) 1) 3 ]) )
-								)
-							)
-						]
-					)
-					influence_weight_entropy_map
-				)
-			)
-
-			;else only store the influence weight entropy
-			(call !StoreCaseValues (assoc
-				case_values_map
-					(if (or
-							compute_all
-							(<
-								(call !GetNumTrainingCases)
-								(* 1.02 !autoAblationInfluenceWeightEntropySampleSize)
-							)
-						)
+					;explicitly store null in all the other cases by appending the computed entropy map to a zipped assoc of all case ids
+					(append
+						(zip (call !AllCases))
 						(map (lambda (first (current_value))) influence_weight_entropy_map)
-
-						;explicitly store null in all the other cases by appending the computed entropy map to a zipped assoc of all case ids
-						(append
-							(zip (call !AllCases))
-							(map (lambda (first (current_value))) influence_weight_entropy_map)
-						)
 					)
-				label_name (or label_name !internalLabelInfluenceWeightEntropy)
-			))
-		)
+				)
+			label_name (or label_name !internalLabelInfluenceWeightEntropy)
+		))
 
 		(declare (assoc quantile_value (call !RecomputeAndCacheMaxInfluenceWeightEntropy) ))
 
 		(assign_to_entities (assoc !autoAblationMaxInfluenceWeightEntropy quantile_value ))
+
+		(if compute_all
+			;output an assoc of case id -> "duplicate" or "too_far_for_removal", for any cases that match that criteria
+			;"too_far_for_removal" applies to any case that should not be removed because its closest case is relatively too far (farther that its farthest)
+			(filter (map
+				(lambda
+					;(current_value) is a tuple of [ entropy, closest_case_id, closest_influence, farthest_influence, is_duplicate ]
+
+					;in non-surprisal space, influences are inverse distance, inverting them back converts them back to distances to the cases
+					;in surprisal space, influences are probabilities, inverted probabilities are monotonic to surprisals (distances)
+					;thus the comparison below works as intended
+
+					;output "duplicate" if case is duplate otherwise output "too_far_for_removal" if case is too far to be removed
+					(if (last (current_value))
+						"duplicate"
+
+						;else if this case is too far for removal
+						(>
+							;distance to closest case
+							(/ 1 (get (current_value) 2))
+							;distance to closest case's farthest influence
+							(/ 1 (get influence_weight_entropy_map [ (get (current_value 1) 1) 3 ]) )
+						)
+						"too_far_for_removal"
+					)
+				)
+				influence_weight_entropy_map
+			))
+		)
 	)
 
 	;initialize parameters and internal features related to auto ablation
@@ -561,11 +530,15 @@
 		))
 
 		;Also ensure that we have all influence weight entropies and that they are up-to-date
-		(call !ComputeAndStoreInfluenceWeightEntropies (assoc
-			features features
-			weight_feature distribute_weight_feature
-			use_case_weights .true
-			compute_all .true
+		(declare (assoc
+			;store a map of case id -> "duplicate"/"too_far_for_removal" for any duplicate cases or cases that should not be removed because they are too far
+			case_duplicate_or_far_map
+				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+					features features
+					weight_feature distribute_weight_feature
+					use_case_weights .true
+					compute_all .true
+				))
 		))
 
 		(if thresholds_enabled
@@ -584,78 +557,15 @@
 
 		;if this dataset has duplicates merge them all here first and recompute weight entropies for their remaining representative non-duplicates
 		(declare (assoc
-			all_duplicate_cases_map (zip (contained_entities (query_equals !internalLabelTooFarForRemoval "duplicate")))
+			all_duplicate_cases_map (filter (lambda (= "duplicate" (current_value))) case_duplicate_or_far_map)
 		))
 		(if (size all_duplicate_cases_map)
-			(let
-				(assoc
-					;assoc of case id -> duplicate neighbors (not including the case id)
-					duplicate_neighbors_map {}
-					duplicates []
-				)
-				(while (size all_duplicate_cases_map)
-					;find all duplicates for a given case in this list
-					(assign (assoc
-						duplicates
-							(contained_entities (values
-								(map
-									(lambda (query_equals (current_index) (current_value)) )
-									;assoc of feature -> value for all the values in a duplicate case
-									(zip features (retrieve_from_entity (first (indices all_duplicate_cases_map)) features))
-								)
-							))
-					))
-
-					;quick check for a failure case that should never occur, but if query engine somehow fails the above query to find anything,
-					;ensure that the list all_duplicate_cases_map keeps shrinking to prevent being stuck in an infinite loop
-					(if (= 0 (size duplicates))
-						(assign (assoc
-							all_duplicate_cases_map (remove all_duplicate_cases_map (first (indices all_duplicate_cases_map)) )
-						))
-
-						(seq
-							(assign (assoc
-								all_duplicate_cases_map (remove all_duplicate_cases_map duplicates)
-							))
-							(accum (assoc
-								duplicate_neighbors_map (associate (first duplicates) (tail duplicates))
-							))
-						)
-					)
-				)
-
-				;merge duplicates by iterating over the assoc of case id -> duplicate ids
-				(map
-					(lambda (seq
-						;distribute the total weight from all the dupes to the case
-						(accum_to_entities (current_index) (associate
-							distribute_weight_feature
-								(apply "+" (map
-									(lambda (first (current_value)))
-									(values (compute_on_contained_entities
-										;pull the weight feature value for all the duplicates
-										(query_in_entity_list (current_value 1))
-										(query_exists distribute_weight_feature)
-									))
-								))
-						))
-
-						;remove all the duplicates
-						(apply "destroy_entities" (current_value))
-					))
-					duplicate_neighbors_map
-				)
-
-				;recompute influence weight entropy for the remaining no-longer duplicates
-				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
-					features features
-					weight_feature distribute_weight_feature
-					use_case_weights .true
-					compute_all .true
-					specific_case_ids (indices duplicate_neighbors_map)
-				))
-			)
+			(call !ReduceMergeDuplicateCases)
 		)
+
+		(declare (assoc
+			cases_too_far_for_removal (indices (filter (lambda (= "too_far_for_removal" (current_value))) case_duplicate_or_far_map))
+		))
 
 		;Begin looping on data removal. The ultimate end condition is if the dataset gets too small
 		; to continue removing cases. Removes cases with relatively high influence weight entropy, i.e., cases with equidistant neighbors.
@@ -664,7 +574,7 @@
 				cases
 					(contained_entities
 						;ignore cases that have been determined to be too far for removal
-						(query_not_equals !internalLabelTooFarForRemoval .true)
+						(query_not_in_entity_list cases_too_far_for_removal)
 						(query_greater_or_equal_to !internalLabelInfluenceWeightEntropy
 							(call !RecomputeAndCacheMaxInfluenceWeightEntropy (assoc
 								influence_weight_entropy_threshold influence_weight_entropy_threshold
@@ -768,6 +678,86 @@
 		(accum_to_entities (assoc !revision 1))
 		(call !Return (assoc payload output))
 	)
+
+
+	;helper method that merges duplicate cases during the reduce_data flow
+	#!ReduceMergeDuplicateCases
+	(let
+		(assoc
+			;assoc of case id -> duplicate neighbors (not including the case id)
+			duplicate_neighbors_map {}
+			duplicates []
+		)
+		(while (size all_duplicate_cases_map)
+			;find all duplicates for a given case in this list
+			(assign (assoc
+				duplicates
+					(contained_entities (values
+						(map
+							(lambda (query_equals (current_index) (current_value)) )
+							;assoc of feature -> value for all the values in a duplicate case
+							(zip features (retrieve_from_entity (first (indices all_duplicate_cases_map)) features))
+						)
+					))
+			))
+
+			;quick check for a failure case that should never occur, but if query engine somehow fails the above query to find anything,
+			;ensure that the list all_duplicate_cases_map keeps shrinking to prevent being stuck in an infinite loop
+			(if (= 0 (size duplicates))
+				(assign (assoc
+					all_duplicate_cases_map (remove all_duplicate_cases_map (first (indices all_duplicate_cases_map)) )
+				))
+
+				(seq
+					(assign (assoc
+						all_duplicate_cases_map (remove all_duplicate_cases_map duplicates)
+					))
+					(accum (assoc
+						duplicate_neighbors_map (associate (first duplicates) (tail duplicates))
+					))
+				)
+			)
+		)
+
+		;merge duplicates by iterating over the assoc of case id -> duplicate ids
+		(map
+			(lambda (seq
+				;distribute the total weight from all the dupes to the case
+				(accum_to_entities (current_index) (associate
+					distribute_weight_feature
+						(apply "+" (map
+							(lambda (first (current_value)))
+							(values (compute_on_contained_entities
+								;pull the weight feature value for all the duplicates
+								(query_in_entity_list (current_value 1))
+								(query_exists distribute_weight_feature)
+							))
+						))
+				))
+
+				;remove all the duplicates
+				(apply "destroy_entities" (current_value))
+			))
+			duplicate_neighbors_map
+		)
+
+		;recompute influence weight entropy for the remaining no-longer duplicates
+		(declare (assoc
+			cases_too_far_map
+				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+					features features
+					weight_feature distribute_weight_feature
+					use_case_weights .true
+					compute_all .true
+					specific_case_ids (indices duplicate_neighbors_map)
+				))
+		))
+
+		(if (size cases_too_far_map)
+			(accum (assoc case_duplicate_or_far_map cases_too_far_map))
+		)
+	)
+
 
 	;helper method which queries and returns the specified quantile of influence weight entropies
 	; for use in data reduction and auto-ablation.

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -238,7 +238,7 @@
 						"duplicate"
 
 						;else if this case is too far for removal, if its probability (inverse distance) is too small
-						(<=
+						(<
 							;closest case probability (inverse distance)
 							(get (current_value) 2)
 							;closest case's farthest neighbor influence probability (inverse distance)
@@ -937,7 +937,7 @@
 
 					;keep this training case if the 'distance' to its closest existing case is relatively large
 					;i.e., if its probability (inverse distance) is too small
-					(<=
+					(<
 						;closest case probability (inverse distance)
 						(last influentials_entropy_tuple)
 						;closest case's farthest neighbor influence probability (inverse distance)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -155,13 +155,13 @@
 						(assign_to_entities case_id
 							(associate
 								!internalLabelInfluenceWeightEntropy influence_weight_entropy
-								".too_far_for_removal" is_too_far
+								!internalLabelTooFarForRemoval is_too_far
 							)
 						)
 
 						(accum_entity_roots case_id
 							(zip_labels
-								[ !internalLabelInfluenceWeightEntropy ".too_far_for_removal" ]
+								[ !internalLabelInfluenceWeightEntropy !internalLabelTooFarForRemoval ]
 								[ influence_weight_entropy is_too_far ]
 							)
 						)
@@ -584,7 +584,7 @@
 
 		;if this dataset has duplicates merge them all here first and recompute weight entropies for their remaining representative non-duplicates
 		(declare (assoc
-			all_duplicate_cases_map (zip (contained_entities (query_equals ".too_far_for_removal" "duplicate")))
+			all_duplicate_cases_map (zip (contained_entities (query_equals !internalLabelTooFarForRemoval "duplicate")))
 		))
 		(if (size all_duplicate_cases_map)
 			(let
@@ -664,7 +664,7 @@
 				cases
 					(contained_entities
 						;ignore cases that have been determined to be too far for removal
-						(query_not_equals ".too_far_for_removal" .true)
+						(query_not_equals !internalLabelTooFarForRemoval .true)
 						(query_greater_or_equal_to !internalLabelInfluenceWeightEntropy
 							(call !RecomputeAndCacheMaxInfluenceWeightEntropy (assoc
 								influence_weight_entropy_threshold influence_weight_entropy_threshold

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -477,6 +477,7 @@
 			feature_weights (get hyperparam_map "featureWeights")
 			feature_deviations (get hyperparam_map "featureDeviations")
 			query_feature_attributes_map (get hyperparam_map "featureDomainAttributes")
+			pre_reduce_num_cases (call !GetNumTrainingCases)
 		))
 
 		;Also ensure that we have all influence weight entropies and that they are up-to-date
@@ -543,11 +544,6 @@
 				distribute_weight_feature distribute_weight_feature
 			))
 
-			(call !AutoAnalyzeIfNeeded (assoc
-				skip_auto_analyze skip_auto_analyze
-				in_reduce_data .true
-			))
-
 			(if thresholds_enabled
 				(let
 					(assoc
@@ -583,6 +579,14 @@
 					)
 				)
 			)
+		)
+
+		;if the number of cases has been reduced by 'e' or more, auto analyze if needed
+		(if (< (call !GetNumTrainingCases) (/ pre_reduce_num_cases 2.718281828459))
+			(call !AutoAnalyzeIfNeeded (assoc
+				skip_auto_analyze skip_auto_analyze
+				in_reduce_data .true
+			))
 		)
 
 		(declare (assoc

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -233,20 +233,16 @@
 				(lambda
 					;(current_value) is a tuple of [ entropy, closest_case_id, closest_influence, farthest_influence, is_duplicate ]
 
-					;in non-surprisal space, influences are inverse distance, inverting them back converts them back to distances to the cases
-					;in surprisal space, influences are probabilities, inverted probabilities are monotonic to surprisals (distances)
-					;thus the comparison below works as intended
-
 					;output "duplicate" if case is duplate otherwise output "too_far_for_removal" if case is too far to be removed
 					(if (last (current_value))
 						"duplicate"
 
-						;else if this case is too far for removal
-						(>
-							;distance to closest case
-							(/ 1 (get (current_value) 2))
-							;distance to closest case's farthest influence
-							(/ 1 (get influence_weight_entropy_map [ (get (current_value 1) 1) 3 ]) )
+						;else if this case is too far for removal, if its probability (inverse distance) is too small
+						(<=
+							;closest case probability (inverse distance)
+							(get (current_value) 2)
+							;closest case's farthest neighbor influence probability (inverse distance)
+							(get influence_weight_entropy_map [ (get (current_value 1) 1) 3 ])
 						)
 						"too_far_for_removal"
 
@@ -939,18 +935,13 @@
 							)
 					)
 
-					;in non-surprisal space, the values coming out of the query are inverse distance, inverting them back converts them back to distances to the cases
-					;in surprisal space, the values coming out of the query are probabilities, inverted probabilities are monotonic to surprisals (distances)
-					;thus the comparison below works as intended
-					(declare (assoc
-						dist_to_closest_neighbor (/ 1 (last influentials_entropy_tuple))
-						neighbor_dist_to_its_farthest_case (/ 1 (last (last neighbor_cases_pairs)) )
-					))
-
 					;keep this training case if the 'distance' to its closest existing case is relatively large
-					(>
-						dist_to_closest_neighbor
-						neighbor_dist_to_its_farthest_case
+					;i.e., if its probability (inverse distance) is too small
+					(<=
+						;closest case probability (inverse distance)
+						(last influentials_entropy_tuple)
+						;closest case's farthest neighbor influence probability (inverse distance)
+						(last (last neighbor_cases_pairs))
 					)
 				)
 			)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -1,14 +1,15 @@
 ;Contains methods for ablation flows.
 (null
 
-	;compute the entropy of the influence weights of the context's influential cases
+	;compute the entropy of the influence weights of the context's influential cases. equidistant neighbors = high entropy
 	; features: list of features to react to
 	; feature_values: optional list of feature values to react to
 	; case_id: optional case id in the dataset to react to
 	; use_case_weights: optional flag default true. if false, case weights will not be used during the react
 	; weight_feature: optional, default '.case_weight'. name of feature whose values to use as case weights
-	; output_most_influential: optional, boolean, default false. when false outputs influential cases' entropy,
-	;	when true will output a tuple of [ entropy, most influential case id, distance to most influential case ]
+	; output_most_influential_only: optional, boolean, default false. outputs influential cases' entropy and neighbor info
+	;	when true, outputs a tuple of [ entropy, most influential case id, influence of most influential ]
+	;	when false, outputs a tuple of [ entropy, most influential case id, influence of most influential, influence of least influential, is_duplicate]
 	#!ComputeInfluenceWeightEntropy
 	(declare
 		(assoc
@@ -17,7 +18,7 @@
 			case_id (null)
 			use_case_weights .true
 			weight_feature !autoAblationWeightFeature
-			output_most_influential .false
+			output_most_influential_only .false
 		)
 
 		(if (not use_case_weights)
@@ -70,13 +71,30 @@
 			)
 		)
 
-		(declare (assoc influence_weight_entropy (entropy (normalize (last local_cases_pairs))) ))
+		(declare (assoc
+			influence_weight_entropy (entropy (normalize (last local_cases_pairs)))
+			closest_influence (first (last local_cases_pairs))
+		))
 
 		;outputs the case id of the most influential and distance to it, else output just the entropy value
-		(if output_most_influential
-			[ influence_weight_entropy (first (first local_cases_pairs)) (first (last local_cases_pairs)) ]
-			influence_weight_entropy
+		(if output_most_influential_only
+			(conclude [ influence_weight_entropy (first (first local_cases_pairs)) closest_influence ] )
 		)
+
+		;true if this case has exact duplicates
+		(declare (assoc
+			is_duplicate
+				(or
+					(= .infinity closest_influence)
+					(and
+						(= "surprisal_to_prob" dt_parameter)
+						(>= closest_influence 1)
+					)
+				)
+		))
+
+		;output tuple of: [ entropy, most influential case id, influence of most influential, influence of least influential, is_duplicate]
+		[ influence_weight_entropy (first (first local_cases_pairs)) closest_influence (last (last local_cases_pairs)) is_duplicate ]
 	)
 
 	;used to compute and store the influence weight entropies (IWE) for all cases contained in the Trainee in #Analyze
@@ -84,9 +102,15 @@
 	; label_name: optional name of the feature to store influence weight entropies in.
 	; compute_all: optional, boolean. if set to true will compute IWE for all cases.
 	;	default is false, which samples up to !autoAblationInfluenceWeightEntropySampleSize (default of 2000) cases
+	; specific_case_ids: optional, list of specific case_ids for which to compute. only applicable if compute_all is also true
 	#!ComputeAndStoreInfluenceWeightEntropies
-	(let
+	(declare
 		(assoc
+			label_name (null)
+			compute_all .false
+			specific_case_ids (null)
+		)
+		(declare (assoc
 			influence_weight_entropy_map
 				||(map
 					(lambda
@@ -106,7 +130,7 @@
 									(* 1.02 !autoAblationInfluenceWeightEntropySampleSize)
 								)
 							)
-							(call !AllCases)
+							(or specific_case_ids (call !AllCases))
 
 							;else compute on a random sample of !autoAblationInfluenceWeightEntropySampleSize cases
 							(call !AllCases (assoc
@@ -116,35 +140,91 @@
 						)
 					)
 				)
-		)
+		))
 
-		(call !StoreCaseValues (assoc
-			case_values_map
-				(if (or
-						compute_all
-						(<
-							(call !GetNumTrainingCases)
-							(* 1.02 !autoAblationInfluenceWeightEntropySampleSize)
+		(if compute_all
+			(map
+				(lambda (let
+					(assoc
+						case_id (current_index 1)
+						influence_weight_entropy (first (current_value 1))
+						is_too_far (last (current_value 1))
+					)
+
+					(if (contains_label case_id !internalLabelInfluenceWeightEntropy)
+						(assign_to_entities case_id
+							(associate
+								!internalLabelInfluenceWeightEntropy influence_weight_entropy
+								".too_far_for_removal" is_too_far
+							)
+						)
+
+						(accum_entity_roots case_id
+							(zip_labels
+								[ !internalLabelInfluenceWeightEntropy ".too_far_for_removal" ]
+								[ influence_weight_entropy is_too_far ]
+							)
 						)
 					)
-					influence_weight_entropy_map
+				))
 
-					;explicitly store null in all the other cases by appending the computed entropy map to a zipped assoc of all case ids
-					(append
-						(zip (call !AllCases))
-						influence_weight_entropy_map
+				;create an assoc of case id -> [ entropy, case is too far boolean]
+				;boolean is true if this case should not be removed because its closest case is relatively too far (farther that its farthest)
+				(map
+					(lambda
+						;(current_value) is a tuple of [ entropy, closest_case_id, closest_influence, farthest_influence ]
+
+						;in non-surprisal space, influences are inverse distance, inverting them back converts them back to distances to the cases
+						;in surprisal space, influences are probabilities, inverted probabilities are monotonic to surprisals (distances)
+						;thus the comparison below works as intended
+
+						;output a pair of [ entropy, 'is_too_far' boolean ]
+						[
+							(first (current_value 1))
+
+							;if has exact duplicates, just output "duplicate"
+							(if (last (current_value 1))
+								"duplicate"
+
+								;else output .true if this case is too far for removal
+								(>
+									;distance to closest case
+									(/ 1 (get (current_value 1) 2))
+									;distance to closest case's farthest influence
+									(/ 1 (get influence_weight_entropy_map [ (get (current_value 2) 1) 3 ]) )
+								)
+							)
+						]
 					)
+					influence_weight_entropy_map
 				)
-			label_name (or label_name !internalLabelInfluenceWeightEntropy)
-		))
+			)
 
-		(declare (assoc
-			quantile_value (call !RecomputeAndCacheMaxInfluenceWeightEntropy)
-		))
+			;else only store the influence weight entropy
+			(call !StoreCaseValues (assoc
+				case_values_map
+					(if (or
+							compute_all
+							(<
+								(call !GetNumTrainingCases)
+								(* 1.02 !autoAblationInfluenceWeightEntropySampleSize)
+							)
+						)
+						(map (lambda (first (current_value))) influence_weight_entropy_map)
 
-		(assign_to_entities (assoc
-			!autoAblationMaxInfluenceWeightEntropy quantile_value
-		))
+						;explicitly store null in all the other cases by appending the computed entropy map to a zipped assoc of all case ids
+						(append
+							(zip (call !AllCases))
+							(map (lambda (first (current_value))) influence_weight_entropy_map)
+						)
+					)
+				label_name (or label_name !internalLabelInfluenceWeightEntropy)
+			))
+		)
+
+		(declare (assoc quantile_value (call !RecomputeAndCacheMaxInfluenceWeightEntropy) ))
+
+		(assign_to_entities (assoc !autoAblationMaxInfluenceWeightEntropy quantile_value ))
 	)
 
 	;initialize parameters and internal features related to auto ablation
@@ -502,26 +582,101 @@
 			))
 		)
 
+		;if this dataset has duplicates merge them all here first and recompute weight entropies for their remaining representative non-duplicates
+		(declare (assoc
+			all_duplicate_cases_map (zip (contained_entities (query_equals ".too_far_for_removal" "duplicate")))
+		))
+		(if (size all_duplicate_cases_map)
+			(let
+				(assoc
+					;assoc of case id -> duplicate neighbors (not including the case id)
+					duplicate_neighbors_map {}
+					duplicates []
+				)
+				(while (size all_duplicate_cases_map)
+					;find all duplicates for a given case in this list
+					(assign (assoc
+						duplicates
+							(contained_entities (values
+								(map
+									(lambda (query_equals (current_index) (current_value)) )
+									;assoc of feature -> value for all the values in a duplicate case
+									(zip features (retrieve_from_entity (first (indices all_duplicate_cases_map)) features))
+								)
+							))
+					))
+
+					;quick check for a failure case that should never occur, but if query engine somehow fails the above query to find anything,
+					;ensure that the list all_duplicate_cases_map keeps shrinking to prevent being stuck in an infinite loop
+					(if (= 0 (size duplicates))
+						(assign (assoc
+							all_duplicate_cases_map (remove all_duplicate_cases_map (first (indices all_duplicate_cases_map)) )
+						))
+
+						(seq
+							(assign (assoc
+								all_duplicate_cases_map (remove all_duplicate_cases_map duplicates)
+							))
+							(accum (assoc
+								duplicate_neighbors_map (associate (first duplicates) (tail duplicates))
+							))
+						)
+					)
+				)
+
+				;merge duplicates by iterating over the assoc of case id -> duplicate ids
+				(map
+					(lambda (seq
+						;distribute the total weight from all the dupes to the case
+						(accum_to_entities (current_index) (associate
+							distribute_weight_feature
+								(apply "+" (map
+									(lambda (first (current_value)))
+									(values (compute_on_contained_entities
+										;pull the weight feature value for all the duplicates
+										(query_in_entity_list (current_value 1))
+										(query_exists distribute_weight_feature)
+									))
+								))
+						))
+
+						;remove all the duplicates
+						(apply "destroy_entities" (current_value))
+					))
+					duplicate_neighbors_map
+				)
+
+				;recompute influence weight entropy for the remaining no-longer duplicates
+				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+					features features
+					weight_feature distribute_weight_feature
+					use_case_weights .true
+					compute_all .true
+					specific_case_ids (indices duplicate_neighbors_map)
+				))
+			)
+		)
+
 		;Begin looping on data removal. The ultimate end condition is if the dataset gets too small
-		; to continue removing cases.
+		; to continue removing cases. Removes cases with relatively high influence weight entropy, i.e., cases with equidistant neighbors.
 		(while (< !autoAblationMinNumCases (call !GetNumTrainingCases))
 			(assign (assoc
 				cases
-					(call !GetCasesByCondition (assoc
-						condition
-							(associate
-								!internalLabelInfluenceWeightEntropy
-									(list
-										(call !RecomputeAndCacheMaxInfluenceWeightEntropy (assoc
-											influence_weight_entropy_threshold influence_weight_entropy_threshold
-											weight_feature distribute_weight_feature
-										))
-										.infinity
-									)
-							)
-						num_cases
+					(contained_entities
+						;ignore cases that have been determined to be too far for removal
+						(query_not_equals ".too_far_for_removal" .true)
+						(query_greater_or_equal_to !internalLabelInfluenceWeightEntropy
+							(call !RecomputeAndCacheMaxInfluenceWeightEntropy (assoc
+								influence_weight_entropy_threshold influence_weight_entropy_threshold
+								weight_feature distribute_weight_feature
+							))
+						)
+						;grab the largest entropy values of specified batch_size number of cases
+						(query_max !internalLabelInfluenceWeightEntropy
 							(min batch_size (- (call !GetNumTrainingCases) !autoAblationMinNumCases))
-					))
+							.true
+						)
+					)
 			))
 
 			(if !tsTimeFeature
@@ -543,6 +698,17 @@
 				cases cases
 				distribute_weight_feature distribute_weight_feature
 			))
+
+			;TODO: verify if this is needed?
+			;recompute all the entropy weights as mass is updated
+			; (if (and (not skip_auto_analyze) (>= !dataMassChangeSinceLastAnalyze !autoAnalyzeThreshold))
+			; 	(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+			; 		features features
+			; 		weight_feature distribute_weight_feature
+			; 		use_case_weights .true
+			; 		compute_all .true
+			; 	))
+			; )
 
 			(if thresholds_enabled
 				(let
@@ -678,7 +844,7 @@
 				(call !ComputeInfluenceWeightEntropy (assoc
 					features features
 					feature_values feature_values
-					output_most_influential .true
+					output_most_influential_only .true
 				))
 		))
 

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -170,10 +170,17 @@
 				)
 		))
 
+		;recompute this value for the entire dataset
 		(assign_to_entities (assoc
 			!autoAblationMaxInfluenceWeightEntropy (call !RecomputeAndCacheMaxInfluenceWeightEntropy)
-			!autoAblationNinetyPercentQuantileInfluence ninety_percent_quantile_closest_influence
 		))
+
+		;do not compute the 90% quantile for just the specific cases
+		(if (= (null) specific_case_ids)
+			(assign_to_entities (assoc
+				!autoAblationNinetyPercentQuantileInfluence ninety_percent_quantile_closest_influence
+			))
+		)
 
 		;if computing on the entire dataset, mark cases that are very close to exactly one other case and can be merged together
 		(if (and compute_all (= (null) specific_case_ids))

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -10,7 +10,7 @@
 	; output_most_influential_only: optional, boolean, default false. outputs influential cases' entropy and neighbor info
 	;	when true, outputs a tuple of [ entropy, most influential case id, influence of most influential ]
 	;	when false, outputs a tuple of [ entropy, most influential case id, influence of most influential, influence of least influential, is_duplicate]
-	#!ComputeInfluenceWeightEntropy
+	#!ComputeInfluenceWeightEntropyTuple
 	(declare
 		(assoc
 			features (list)
@@ -107,7 +107,7 @@
 			influence_weight_entropy_map
 				||(map
 					(lambda
-						(call !ComputeInfluenceWeightEntropy (assoc
+						(call !ComputeInfluenceWeightEntropyTuple (assoc
 							case_id (current_index 1)
 							features features
 							use_case_weights use_case_weights
@@ -812,7 +812,8 @@
 				;remove all the duplicates
 				(call !RemoveCases (assoc
 					cases (current_value 1)
-					distribute_weight_feature distribute_weight_feature
+					;weight has already been distributed, don't do it again
+					distribute_weight_feature (null)
 				))
 			))
 			duplicate_neighbors_map
@@ -878,7 +879,7 @@
 		(assoc
 			; tuple of [ entropy, most influential case id, influence of most influential ]
 			influentials_entropy_tuple
-				(call !ComputeInfluenceWeightEntropy (assoc
+				(call !ComputeInfluenceWeightEntropyTuple (assoc
 					features features
 					feature_values feature_values
 					output_most_influential_only .true
@@ -907,7 +908,7 @@
 				)
 
 				;always ablate perfect matches/identical cases
-				;entropy value will have been set to .infinity by !ComputeInfluenceWeightEntropy for duplicates
+				;entropy value will have been set to .infinity by !ComputeInfluenceWeightEntropyTuple for duplicates
 				(= .infinity (first influentials_entropy_tuple))
 				.false
 

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -483,8 +483,11 @@
 		)
 	)
 
-	;reduce the trained data by removing cases which have an influence weight entropy that falls above
-	; a threshold.
+	;reduce the trained data by removing cases that match the following criteria:
+	;a) it's an exact duplicate
+	;b) a near-duplicate (very similar to exactly one other case)
+	;c) it's not "too far" away (keep outliers and dissimilar cases)
+	;d) its influence weight entropy is relatively high (above a threshold, case can be evenly distributed among its neighbors)
 	;{long_running .true}
 	#reduce_data
 	(declare
@@ -853,64 +856,40 @@
 		)
 	)
 
-	;determine whether a new case (one that is not in the Trainee) should be ablated (trained as weights) or kept.
-	; a return value of true indicates that a case should be kept and a return value of false indicates that the case should be ablated.
+	;determine whether a new case (one that is not in the dataset) should be ablated (trained as weights only) or kept
+	;returns .true if case should be kept and trained
+	;returns .false when case should be ablated
+	;
+	;parameters:
 	; features: list of features to react to
 	; feature_values: list of feature values to react to
-	; num_cases: number of current cases in the dataset
-	#!ShouldNewCaseBeAblated
-	(declare
+	#!ShouldNewCaseNotBeAblated
+	(let
 		(assoc
-			features (list)
-			feature_values (list)
-		)
-
-		;If we do not have influence weight entropies stored, ablation cannot happen.
-		; So, always return true when that is the case.  The same is true for when there
-		; are not enough cases in the dataset.
-		(if (or
-				(< num_cases !autoAblationMinNumCases )
-				(not (and !autoAblationEnabled (call !HasInfluenceWeightEntropies) ))
-			)
-			;return true, keep case / do not ablate
-			(conclude .true)
-		)
-
-		(declare (assoc
-			max_influence_weight_entropy_to_keep !autoAblationMaxInfluenceWeightEntropy
-			ninety_percent_quantile_closest_influence !autoAblationNinetyPercentQuantileInfluence
-		))
-
-		;if there is no influence weight entropy cached yet, do the caching here
-		(if (= (null) max_influence_weight_entropy_to_keep)
-			(seq
-				(call !ComputeAndStoreInfluenceWeightEntropies (assoc features features))
-
-				(assign (assoc
-					max_influence_weight_entropy_to_keep !autoAblationMaxInfluenceWeightEntropy
-					ninety_percent_quantile_closest_influence !autoAblationNinetyPercentQuantileInfluence
-				))
-			)
-		)
-
-		(declare (assoc
+			; tuple of [ entropy, most influential case id, influence of most influential ]
 			influentials_entropy_tuple
 				(call !ComputeInfluenceWeightEntropy (assoc
 					features features
 					feature_values feature_values
 					output_most_influential_only .true
 				))
-		))
+		)
 
+
+		;case can be ablated if:
+		;a) it's an exact duplicate
+		;b) a near-duplicate (very similar to exactly one other case)
+		;c) it's not "too far" away (keep outliers and dissimilar cases)
+		;d) its influence weight entropy is relatively high (above a threshold, case can be evenly distributed among its neighbors)
 		(or
 			;case may be kept because influentials are not evenly distributed (their entropy is low)
-			(if (> max_influence_weight_entropy_to_keep (first influentials_entropy_tuple))
+			(if (<= (first influentials_entropy_tuple) !autoAblationMaxInfluenceWeightEntropy)
 				;check if case is a near duplicate, if it is, it can be ablated
 				(if (and
 						;entropy is < 0.1, meaning significantly closer to one case than any of the others
 						(< (first influentials_entropy_tuple) 0.1)
 						;closest case influence is in the top 10%, meaning it's very close to its one neighbor
-						(> (last influentials_entropy_tuple) ninety_percent_quantile_closest_influence)
+						(> (last influentials_entropy_tuple) !autoAblationNinetyPercentQuantileInfluence)
 					)
 					.false
 
@@ -968,7 +947,7 @@
 
 			; This is probably unnecessary but in case we cannot compute the requested influence weight
 			; quantile return .true as well (keep the case)
-			(= max_influence_weight_entropy_to_keep (null))
+			(= (null) !autoAblationMaxInfluenceWeightEntropy)
 		)
 	)
 

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -863,26 +863,20 @@
 		(assoc
 			features (list)
 			feature_values (list)
-
-			;internal
-			max_influence_weight_entropy_to_keep .infinity
 		)
 
 		;If we do not have influence weight entropies stored, ablation cannot happen.
 		; So, always return true when that is the case.  The same is true for when there
 		; are not enough cases in the dataset.
-		(if
-			(or
-				(not (and
-					(call !HasInfluenceWeightEntropies) !autoAblationEnabled
-				))
+		(if (or
 				(< num_cases !autoAblationMinNumCases )
+				(not (and !autoAblationEnabled (call !HasInfluenceWeightEntropies) ))
 			)
 			;return true, keep case / do not ablate
 			(conclude .true)
 		)
 
-		(assign (assoc
+		(declare (assoc
 			max_influence_weight_entropy_to_keep !autoAblationMaxInfluenceWeightEntropy
 			ninety_percent_quantile_closest_influence !autoAblationNinetyPercentQuantileInfluence
 		))
@@ -915,7 +909,7 @@
 				(if (and
 						;entropy is < 0.1, meaning significantly closer to one case than any of the others
 						(< (first influentials_entropy_tuple) 0.1)
-						;closest case influence is in the top 10%
+						;closest case influence is in the top 10%, meaning it's very close to its one neighbor
 						(> (last influentials_entropy_tuple) ninety_percent_quantile_closest_influence)
 					)
 					.false
@@ -973,7 +967,7 @@
 			)
 
 			; This is probably unnecessary but in case we cannot compute the requested influence weight
-			; quantile return 1 as well.
+			; quantile return .true as well (keep the case)
 			(= max_influence_weight_entropy_to_keep (null))
 		)
 	)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -679,16 +679,7 @@
 				distribute_weight_feature distribute_weight_feature
 			))
 
-			;TODO: verify if this is needed?
-			;recompute all the entropy weights as mass is updated
-			; (if (and (not skip_auto_analyze) (>= !dataMassChangeSinceLastAnalyze !autoAnalyzeThreshold))
-			; 	(call !ComputeAndStoreInfluenceWeightEntropies (assoc
-			; 		features features
-			; 		weight_feature distribute_weight_feature
-			; 		use_case_weights .true
-			; 		compute_all .true
-			; 	))
-			; )
+
 
 			(if thresholds_enabled
 				(let

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -641,16 +641,18 @@
 		; to continue removing cases. Removes cases with relatively high influence weight entropy, i.e., cases with equidistant neighbors.
 		(while (< !autoAblationMinNumCases (call !GetNumTrainingCases))
 			(assign (assoc
+				max_influence_weight_entropy_to_keep
+					(call !RecomputeAndCacheMaxInfluenceWeightEntropy (assoc
+						influence_weight_entropy_threshold influence_weight_entropy_threshold
+						weight_feature distribute_weight_feature
+					))
+			))
+			(assign (assoc
 				cases
 					(contained_entities
 						;ignore cases that have been determined to be too far for removal
 						(query_not_in_entity_list cases_too_far_for_removal)
-						(query_greater_or_equal_to !internalLabelInfluenceWeightEntropy
-							(call !RecomputeAndCacheMaxInfluenceWeightEntropy (assoc
-								influence_weight_entropy_threshold influence_weight_entropy_threshold
-								weight_feature distribute_weight_feature
-							))
-						)
+						(query_greater_or_equal_to !internalLabelInfluenceWeightEntropy max_influence_weight_entropy_to_keep)
 						;grab the largest entropy values of specified batch_size number of cases
 						(query_max !internalLabelInfluenceWeightEntropy
 							(min batch_size (- (call !GetNumTrainingCases) !autoAblationMinNumCases))
@@ -671,48 +673,101 @@
 				))
 			)
 
-			;if there are no cases which satisfy the criteria, then break.
-			(if (not (size cases)) (conclude))
-
-			(call !RemoveCases (assoc
-				cases cases
-				distribute_weight_feature distribute_weight_feature
-			))
-
-
-
-			(if thresholds_enabled
-				(let
-					(assoc
-						batch_threshold_info (null)
-						new_prediction_stats_map
-							(get
-								(call !CalculateFeatureResiduals (assoc
-									weight_feature distribute_weight_feature
-									use_case_weights .true
-									compute_all_statistics .true
-								))
-								"prediction_stats"
-							)
-					)
-					(assign (assoc
-						batch_threshold_info
-							(call !CheckThresholds (assoc
-								abs_threshold_map abs_threshold_map
-								delta_threshold_map delta_threshold_map
-								rel_threshold_map rel_threshold_map
-								prev_prediction_stats_map prev_prediction_stats_map
-								new_prediction_stats_map new_prediction_stats_map
-							))
+			(if (size cases)
+				(seq
+					(call !RemoveCases (assoc
+						cases cases
+						distribute_weight_feature distribute_weight_feature
 					))
-					(if (apply "or" (values batch_threshold_info))
-						(seq
-							(accum "output" ["threshold_info"] batch_threshold_info)
-							(conclude)
+
+					(if thresholds_enabled
+						(let
+							(assoc
+								batch_threshold_info (null)
+								new_prediction_stats_map
+									(get
+										(call !CalculateFeatureResiduals (assoc
+											weight_feature distribute_weight_feature
+											use_case_weights .true
+											compute_all_statistics .true
+										))
+										"prediction_stats"
+									)
+							)
+							(assign (assoc
+								batch_threshold_info
+									(call !CheckThresholds (assoc
+										abs_threshold_map abs_threshold_map
+										delta_threshold_map delta_threshold_map
+										rel_threshold_map rel_threshold_map
+										prev_prediction_stats_map prev_prediction_stats_map
+										new_prediction_stats_map new_prediction_stats_map
+									))
+							))
+							(if (apply "or" (values batch_threshold_info))
+								(seq
+									(accum "output" ["threshold_info"] batch_threshold_info)
+									(conclude)
+								)
+								(assign (assoc
+									prev_prediction_stats_map new_prediction_stats_map
+								))
+							)
+						)
+					)
+				)
+
+				;else no cases left to remove even though the desired datasat size has not been reached yet
+				;stop removing cases if there are no unremovable cases left
+				(if (<= (call !GetNumTrainingCases) (size cases_too_far_for_removal))
+					(conclude)
+
+					;else recompute all the influence entropies since dataset has been updated
+					(let
+						(assoc
+							;number of cases that were supposed to be removed during this iteration
+							num_cases_to_remove (min batch_size (- (call !GetNumTrainingCases) !autoAblationMinNumCases))
 						)
 						(assign (assoc
-							prev_prediction_stats_map new_prediction_stats_map
+							case_duplicate_or_far_map
+								(call !ComputeAndStoreInfluenceWeightEntropies (assoc
+									features features
+									weight_feature distribute_weight_feature
+									use_case_weights .true
+									compute_all .true
+								))
 						))
+						(assign (assoc
+							cases_too_far_for_removal (indices (filter (lambda (= "too_far_for_removal" (current_value))) case_duplicate_or_far_map))
+							near_duplicate_cases (indices (filter (lambda (= "near_duplicate" (current_value))) case_duplicate_or_far_map))
+						))
+
+						;remove the new near duplicates here
+						(if (size near_duplicate_cases)
+							;if there were fewer cases that needed to be removed than there are near duplicates, select some near duplicates to remove
+							(if (> (size near_duplicate_cases) num_cases_to_remove)
+								(call !RemoveCases (assoc
+									cases (rand near_duplicate_cases num_cases_to_remove .true)
+									distribute_weight_feature distribute_weight_feature
+								))
+
+								;else remove all near duplicates
+								(call !RemoveCases (assoc
+									cases near_duplicate_cases
+									distribute_weight_feature distribute_weight_feature
+								))
+							)
+
+							;else if the entropy value to keep hasn't changed since the recomputation, nothing has changed, can stop iteration
+							(=
+								max_influence_weight_entropy_to_keep
+								(call !RecomputeAndCacheMaxInfluenceWeightEntropy (assoc
+									influence_weight_entropy_threshold influence_weight_entropy_threshold
+									weight_feature distribute_weight_feature
+								))
+							)
+							(conclude)
+						)
 					)
 				)
 			)

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -810,7 +810,10 @@
 				))
 
 				;remove all the duplicates
-				(apply "destroy_entities" (current_value))
+				(call !RemoveCases (assoc
+					cases (current_value 1)
+					distribute_weight_feature distribute_weight_feature
+				))
 			))
 			duplicate_neighbors_map
 		)
@@ -870,7 +873,7 @@
 	;parameters:
 	; features: list of features to react to
 	; feature_values: list of feature values to react to
-	#!ShouldNewCaseNotBeAblated
+	#!ShouldNewCaseBeTrained
 	(let
 		(assoc
 			; tuple of [ entropy, most influential case id, influence of most influential ]
@@ -881,7 +884,6 @@
 					output_most_influential_only .true
 				))
 		)
-
 
 		;case can be ablated if:
 		;a) it's an exact duplicate

--- a/howso/remove_cases.amlg
+++ b/howso/remove_cases.amlg
@@ -326,9 +326,9 @@
 					session (current_index 1)
 					replay_steps (retrieve_from_entity (current_index 1) ".replay_steps")
 					removed_cases_map
-						;if there's only one case for this session, its size will be 0, wrap it in a list prior to zipping
-						(if (= 0 (size (current_value 1)))
-							(zip (list (current_value 2)))
+						;if there's only one case for this session, it'll be a string, wrap it in a list prior to zipping
+						(if (~ "" (current_value 1))
+							(zip [ (current_value 2) ] )
 							(zip (current_value 1))
 						)
 				)

--- a/howso/scale.amlg
+++ b/howso/scale.amlg
@@ -534,7 +534,7 @@
 				;the default !reduceDataInfluenceWeightEntropyThreshold of 0.6 will ensure that approximately 1/e of the data is removed
 				(if
 					(and
-						(>= (+ !dataMassChangeSinceLastDataReduction (size cases)) !autoAblationMaxNumCases)
+						(>= (+ num_cases (size cases)) !autoAblationMaxNumCases)
 						(not skip_reduce_data)
 						(size !hyperparameterMetadataMap)
 					)
@@ -551,7 +551,7 @@
 					(seq
 						;ensure we only set the reduce_data status output if a reduction is actually necessary.
 						(if (and
-								(>= (+ !dataMassChangeSinceLastDataReduction (size cases)) !autoAblationMaxNumCases)
+								(>= (+ num_cases (size cases)) !autoAblationMaxNumCases)
 								skip_reduce_data
 							)
 							(assign (assoc status_output "reduce_data"))

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -1091,7 +1091,7 @@
 							(and
 								(call !CaseOutsideThresholds)
 								;do ablation entropy check, else keep case / do not ablate
-								(if do_influence_weight_entropy_check (call !ShouldNewCaseNotBeAblated) .true)
+								(if do_influence_weight_entropy_check (call !ShouldNewCaseBeTrained) .true)
 							)
 						))
 						(indices cases)

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -1030,6 +1030,21 @@
 	#!AblateCases
 	(let
 		(assoc
+			do_influence_weight_entropy_check
+				;only do I.W.E. ablation if there are enough cases in dataset and influence weight entropies are stored
+				(and
+					!autoAblationEnabled
+					(>= num_cases !autoAblationMinNumCases)
+					(call !HasInfluenceWeightEntropies)
+				)
+		)
+
+		(if (and do_influence_weight_entropy_check (= (null) !autoAblationMaxInfluenceWeightEntropy))
+			;if there is no influence weight entropy cached yet, do the caching here
+			(call !ComputeAndStoreInfluenceWeightEntropies (assoc features features))
+		)
+
+		(declare (assoc
 			indices_to_train
 				;If one or more thresholds has been satisfied, or the Trainee has not yet been analyzed,
 				; just train all of the cases in this batch.
@@ -1075,19 +1090,14 @@
 							;if one of the ablation methods returns false, then the case should be ablated.
 							(and
 								(call !CaseOutsideThresholds)
-								(call !ShouldNewCaseBeAblated (assoc
-									features features
-									feature_values feature_values
-									;always use the most current trained count to determine whether cases should be ablated
-									num_cases (+ ablation_trained_instance_count case_index)
-								))
+								;do ablation entropy check, else keep case / do not ablate
+								(if do_influence_weight_entropy_check (call !ShouldNewCaseNotBeAblated) .true)
 							)
 						))
 						(indices cases)
 					)
 				)
-
-		)
+		))
 
 		;ensure ablated indices are based off actual training index and not restarted at 0 every time this method is called
 		(accum (assoc

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -971,8 +971,8 @@
 			;the default !reduceDataInfluenceWeightEntropyThreshold of 0.6 will ensure that approximately 1/e of the data is removed
 			(if
 				(and
-					(>= (+ !dataMassChangeSinceLastDataReduction batch_size) !autoAblationMaxNumCases)
 					(not skip_reduce_data)
+					(>= (call !GetNumTrainingCases) !autoAblationMaxNumCases)
 					(size !hyperparameterMetadataMap)
 				)
 				(call reduce_data (assoc
@@ -988,15 +988,13 @@
 				(seq
 					;ensure we only set the reduce_data status output if a reduction is actually necessary.
 					(if (and
-							(>= (+ !dataMassChangeSinceLastDataReduction batch_size) !autoAblationMaxNumCases)
 							skip_reduce_data
+							(>= (call !GetNumTrainingCases) !autoAblationMaxNumCases)
 						)
 						(assign (assoc status_output "reduce_data"))
 					)
 					(if (not read_only_mode)
-						(accum_to_entities (assoc
-							!dataMassChangeSinceLastDataReduction batch_size
-						))
+						(accum_to_entities (assoc !dataMassChangeSinceLastDataReduction batch_size ))
 					)
 				)
 			)

--- a/howso/train.amlg
+++ b/howso/train.amlg
@@ -976,6 +976,7 @@
 					(size !hyperparameterMetadataMap)
 				)
 				(call reduce_data (assoc
+					features features
 					abs_threshold_map !autoAblationAbsThresholdMap
 					delta_threshold_map !autoAblationDeltaThresholdMap
 					rel_threshold_map !autoAblationRelThresholdMap

--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -864,7 +864,8 @@
 					;map of case_id -> weight
 					closest_cases_map
 						(compute_on_contained_entities
-							(query_not_in_entity_list (list case))
+							;don't consider cases whose weights should be distributed, since they are all about to be removed
+							(query_not_in_entity_list case_ids)
 							(query_nearest_generalized_distance
 								(replace (get hyperparam_map "k"))
 								(replace features)

--- a/unit_tests/unit_test_howso.amlg
+++ b/unit_tests/unit_test_howso.amlg
@@ -115,11 +115,15 @@
 				)
 				(call_entity "howso" "injectReturnValidation")
 			)
+
+			;set permissions with access to load and write files and to print output for debugging and system so it can exit on failure
+			(set_entity_permissions "howso" {load .true store .true std_out_and_std_err .true system .true})
 		)
+
+		;set permissions on howso engine so it has access to load and write files and to print output for debugging
+		(set_entity_permissions "howso" {load .true store .true std_out_and_std_err .true})
 	)
 
-	;set permissions on howso engine so it has access to load and write files and to print output for debugging and system so it can exit on failure
-	(set_entity_permissions "howso" {load .true store .true std_out_and_std_err .true system .true})
 
 	;set the number of allowed_retries only if it's specified and hasn't been set already
 	(if (and retries (= 0 allowed_retries))

--- a/unit_tests/unit_test_howso.amlg
+++ b/unit_tests/unit_test_howso.amlg
@@ -82,13 +82,17 @@
 													)
 												)
 												(seq
-													(print "FAILED: Return value for " label_name ":\n" payload "\nDoes not match schema:\n" type_schema "\n")
+													(print
+														"FAILED: Return value for " label_name ":\n" payload "\n"
+														"Does not match schema:\n" type_schema "\n"
+													)
 													(print
 														(call !SingleTypeCheck (assoc
 															exp_type (get type_schema "type")
 															specification type_schema
 															given_value payload
 														))
+														"\nERROR: Test terminated due to malformed return output from method: " label_name "\n"
 													)
 													(system "exit")
 												)
@@ -114,8 +118,8 @@
 		)
 	)
 
-	;set permissions on howso engine so it has access to load and write files and to print output for debugging
-	(set_entity_permissions "howso" {load .true store .true std_out_and_std_err .true})
+	;set permissions on howso engine so it has access to load and write files and to print output for debugging and system so it can exit on failure
+	(set_entity_permissions "howso" {load .true store .true std_out_and_std_err .true system .true})
 
 	;set the number of allowed_retries only if it's specified and hasn't been set already
 	(if (and retries (= 0 allowed_retries))

--- a/unit_tests/ut_h_reduce_data.amlg
+++ b/unit_tests/ut_h_reduce_data.amlg
@@ -5,10 +5,15 @@
     (declare (assoc
         training_data
 			(list
-				(list 6.4 2.8 5.6 2.2 "virginica")
-				(list 5.0 2.3 3.3 1.0 "versicolor")
-				(list 4.9 2.5 4.5 1.7 "virginica")
+				;relocated the duplicates to the top
 				(list 4.9 3.1 1.5 0.1 "setosa")
+				(list 4.9 3.1 1.5 0.1 "setosa")
+				(list 4.9 3.1 1.5 0.1 "setosa")
+				(list 5.8 2.7 5.1 1.9 "virginica")
+				(list 5.8 2.7 5.1 1.9 "virginica")
+				(list 5.0 2.3 3.3 1.0 "versicolor")
+				(list 6.4 2.8 5.6 2.2 "virginica")
+				(list 4.9 2.5 4.5 1.7 "virginica")
 				(list 5.7 3.8 1.7 0.3 "setosa")
 				(list 4.4 3.2 1.3 0.2 "setosa")
 				(list 5.4 3.4 1.5 0.4 "setosa")
@@ -46,7 +51,6 @@
 				(list 5.1 3.8 1.5 0.3 "setosa")
 				(list 4.8 3.0 1.4 0.3 "setosa")
 				(list 7.9 3.8 6.4 2.0 "virginica")
-				(list 5.8 2.7 5.1 1.9 "virginica")
 				(list 6.7 3.0 5.2 2.3 "virginica")
 				(list 5.1 3.8 1.9 0.4 "setosa")
 				(list 4.7 3.2 1.6 0.2 "setosa")
@@ -62,7 +66,6 @@
 				(list 7.0 3.2 4.7 1.4 "versicolor")
 				(list 6.0 3.0 4.8 1.8 "virginica")
 				(list 7.4 2.8 6.1 1.9 "virginica")
-				(list 5.8 2.7 5.1 1.9 "virginica")
 				(list 6.2 3.4 5.4 2.3 "virginica")
 				(list 5.0 2.0 3.5 1.0 "versicolor")
 				(list 5.6 2.5 3.9 1.1 "versicolor")
@@ -80,7 +83,6 @@
 				(list 5.5 3.5 1.3 0.2 "setosa")
 				(list 7.7 3.0 6.1 2.3 "virginica")
 				(list 6.1 3.0 4.9 1.8 "virginica")
-				(list 4.9 3.1 1.5 0.1 "setosa")
 				(list 5.5 2.4 3.8 1.1 "versicolor")
 				(list 5.7 2.9 4.2 1.3 "versicolor")
 				(list 6.0 2.9 4.5 1.5 "versicolor")
@@ -90,7 +92,6 @@
 				(list 6.5 2.8 4.6 1.5 "versicolor")
 				(list 5.6 2.7 4.2 1.3 "versicolor")
 				(list 6.3 3.4 5.6 2.4 "virginica")
-				(list 4.9 3.1 1.5 0.1 "setosa")
 				(list 6.8 2.8 4.8 1.4 "versicolor")
 				(list 5.7 2.8 4.5 1.3 "versicolor")
 				(list 6.0 2.7 5.1 1.6 "versicolor")
@@ -214,6 +215,8 @@
             (-
                 (size training_data)
                 (call_entity "howso""debug_label" (assoc label "!ablationBatchSize"))
+				;account for removed duplicates and near duplicates
+				4
             )
         obs
             (get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))

--- a/unit_tests/ut_h_reduce_data.amlg
+++ b/unit_tests/ut_h_reduce_data.amlg
@@ -1,9 +1,9 @@
 (seq
-    #unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
-    (call (load "unit_test_howso.amlg") (assoc name "ut_h_reduce_data.amlg" do_return_validation .false))
+	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_reduce_data.amlg" do_return_validation .false))
 
-    (declare (assoc
-        training_data
+	(declare (assoc
+		training_data
 			(list
 				;relocated the duplicates to the top
 				(list 4.9 3.1 1.5 0.1 "setosa")
@@ -127,114 +127,114 @@
 				(list 4.8 3.0 1.4 0.1 "setosa")
 				(list 5.5 2.4 3.7 1.0 "versicolor")
 			)
-        context_labels (list "sepal_length" "sepal_width" "petal_length" "petal_width")
-        action_labels (list "species")
-    ))
+		context_labels (list "sepal_length" "sepal_width" "petal_length" "petal_width")
+		action_labels (list "species")
+	))
 
-    #!EmptyAndTrain
+	#!EmptyAndTrain
 	(declare
 		(assoc
 			enable_auto_ablation .false
 			max_num_cases (null)
 		)
-        (call (load "unit_test_howso.amlg")
-            (assoc name "ut_h_reduce_data.amlg" skip_init .true do_return_validation .false)
-        )
-        (call_entity "howso" "set_feature_attributes" (assoc
-            feature_attributes (assoc species (assoc type "nominal"))
-        ))
+		(call (load "unit_test_howso.amlg")
+			(assoc name "ut_h_reduce_data.amlg" skip_init .true do_return_validation .false)
+		)
+		(call_entity "howso" "set_feature_attributes" (assoc
+			feature_attributes (assoc species (assoc type "nominal"))
+		))
 
-        (call_entity "howso" "set_auto_analyze_params" (assoc
-            auto_analyze_enabled .true
-            use_case_weights .true
-        ))
+		(call_entity "howso" "set_auto_analyze_params" (assoc
+			auto_analyze_enabled .true
+			use_case_weights .true
+		))
 
-        (call_entity "howso" "set_auto_ablation_params" (assoc
-            auto_ablation_enabled enable_auto_ablation
-            min_num_cases 20
+		(call_entity "howso" "set_auto_ablation_params" (assoc
+			auto_ablation_enabled enable_auto_ablation
+			min_num_cases 20
 			max_num_cases max_num_cases
-            batch_size 10
-        ))
-        (call_entity "howso" "train" (assoc
-            features (append context_labels action_labels)
-            cases training_data
-            session "iris_session"
-            skip_auto_analyze .false
-        ))
-        (call_entity "howso" "analyze" (assoc
-            use_case_weights .true
-        ))
-    )
+			batch_size 10
+		))
+		(call_entity "howso" "train" (assoc
+			features (append context_labels action_labels)
+			cases training_data
+			session "iris_session"
+			skip_auto_analyze .false
+		))
+		(call_entity "howso" "analyze" (assoc
+			use_case_weights .true
+		))
+	)
 
-    (print "Initial train of training data successful: ")
-    (call assert_same (assoc
-        exp (size training_data)
-        obs (get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
-    ))
+	(print "Initial train of training data successful: ")
+	(call assert_same (assoc
+		exp (size training_data)
+		obs (get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
+	))
 
-    (print "reduce_data with no thresholds reduces down to minimum model size: ")
-    (call_entity "howso" "reduce_data")
-    (call assert_same (assoc
-        exp
-            (get
-                (call_entity "howso" "get_auto_ablation_params")
-                (list 1 "payload" "min_num_cases")
-            )
-        obs
-            (get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
-    ))
-    (call exit_if_failures (assoc msg "reduce_data with no thresholds reduced as expected"))
-    (call !EmptyAndTrain)
+	(print "reduce_data with no thresholds reduces down to minimum model size: ")
+	(call_entity "howso" "reduce_data")
+	(call assert_same (assoc
+		exp
+			(get
+				(call_entity "howso" "get_auto_ablation_params")
+				(list 1 "payload" "min_num_cases")
+			)
+		obs
+			(get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
+	))
+	(call exit_if_failures (assoc msg "reduce_data with no thresholds reduced as expected"))
+	(call !EmptyAndTrain)
 
-    (print "reduce_data with very liberal thresholds reduces down to minimum model size: ")
-    (call_entity "howso" "reduce_data" (assoc
-        abs_threshold_map (assoc accuracy (assoc species 0.1))
-        delta_threshold_map (assoc accuracy (assoc species 0.5))
-        rel_threshold_map (assoc accuracy (assoc species 0.5))
-    ))
-    (call assert_same (assoc
-        exp
-            (get
-                (call_entity "howso" "get_auto_ablation_params")
-                (list 1 "payload" "min_num_cases")
-            )
-        obs
-            (get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
-    ))
-    (call exit_if_failures (assoc msg "reduce_data with liberal thresholds reduced as expected"))
-    (call !EmptyAndTrain)
+	(print "reduce_data with very liberal thresholds reduces down to minimum model size: ")
+	(call_entity "howso" "reduce_data" (assoc
+		abs_threshold_map (assoc accuracy (assoc species 0.1))
+		delta_threshold_map (assoc accuracy (assoc species 0.5))
+		rel_threshold_map (assoc accuracy (assoc species 0.5))
+	))
+	(call assert_same (assoc
+		exp
+			(get
+				(call_entity "howso" "get_auto_ablation_params")
+				(list 1 "payload" "min_num_cases")
+			)
+		obs
+			(get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
+	))
+	(call exit_if_failures (assoc msg "reduce_data with liberal thresholds reduced as expected"))
+	(call !EmptyAndTrain)
 
-    (print "reduce_data with conservative thresholds reduces to above minimum model size: ")
-    (call_entity "howso" "reduce_data" (assoc
-        abs_threshold_map (assoc accuracy (assoc species 1))
-        delta_threshold_map (assoc accuracy (assoc species 0.001))
-        rel_threshold_map (assoc accuracy (assoc species 0.001))
-    ))
-    (call assert_same (assoc
-        exp
-            (-
-                (size training_data)
-                (call_entity "howso""debug_label" (assoc label "!ablationBatchSize"))
+	(print "reduce_data with conservative thresholds reduces to above minimum model size: ")
+	(call_entity "howso" "reduce_data" (assoc
+		abs_threshold_map (assoc accuracy (assoc species 1))
+		delta_threshold_map (assoc accuracy (assoc species 0.001))
+		rel_threshold_map (assoc accuracy (assoc species 0.001))
+	))
+	(call assert_same (assoc
+		exp
+			(-
+				(size training_data)
+				(call_entity "howso""debug_label" (assoc label "!ablationBatchSize"))
 				;account for removed duplicates and near duplicates
 				4
-            )
-        obs
-            (get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
-    ))
-    (call exit_if_failures (assoc msg "reduce_data with conservative thresholds reduced as expected"))
+			)
+		obs
+			(get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
+	))
+	(call exit_if_failures (assoc msg "reduce_data with conservative thresholds reduced as expected"))
 
 	(print "a basic train automatically calls reduce_data when the threshold is low enough, resulting in min. model size w/ no threshold maps: ")
-    (call !EmptyAndTrain (assoc enable_auto_ablation .true max_num_cases 120))
-    (call assert_same (assoc
-        exp
-            (get
-                (call_entity "howso" "get_auto_ablation_params")
-                (list 1 "payload" "min_num_cases")
-            )
-        obs
-            (get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
-    ))
-    (call exit_if_failures (assoc msg "train with auto-ablation calls reduce_data automatically when the threshold is reached"))
+	(call !EmptyAndTrain (assoc enable_auto_ablation .true max_num_cases 120))
+	(call assert_same (assoc
+		exp
+			(get
+				(call_entity "howso" "get_auto_ablation_params")
+				(list 1 "payload" "min_num_cases")
+			)
+		obs
+			(get (call_entity "howso" "get_num_training_cases") (list 1 "payload" "count"))
+	))
+	(call exit_if_failures (assoc msg "train with auto-ablation calls reduce_data automatically when the threshold is reached"))
 
-    (call exit_if_failures (assoc msg unit_test_name) )
+	(call exit_if_failures (assoc msg unit_test_name) )
 )

--- a/unit_tests/ut_h_scale_ablation.amlg
+++ b/unit_tests/ut_h_scale_ablation.amlg
@@ -77,7 +77,7 @@
 
     (print "train\n")
     (call_entity "howso" "train" (assoc
-        cases (call !CreateSquareCases (assoc xs (range 0 99)))
+        cases (call !CreateSquareCases (assoc xs (range 0 98)))
         features (list "x" "y")
         session "unit_test"
     ))


### PR DESCRIPTION
a) reduction is determined by number of cases not data mass
b) duplicates are automatically merged
c) cases that are 'too far' using the same metric as ablation are not removed regardless of their influence weight entropy
d) cases that are 'near duplicates' are removed (those very close to exactly one other case)