### PR TITLE
24752: Adds missing return type declarations, fixes incorrect descriptions, MINOR

### DIFF
--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -67,7 +67,7 @@
 						"derivation_parameters"
 							{
 								type "list"
-								description "A list of maps of the parameters used in the React call and their values."
+								description "A list of maps of the parameters used in the React call to their values."
 								values {ref "DerivationParameters"}
 							}
 						"distance_ratio"

--- a/howso/return_types.amlg
+++ b/howso/return_types.amlg
@@ -64,6 +64,12 @@
 								description "A list of lists of boundary cases for each given case."
 								values {ref "Cases"}
 							}
+						"derivation_parameters"
+							{
+								type "list"
+								description "A list of maps of the parameters used in the React call and their values."
+								values {ref "DerivationParameters"}
+							}
 						"distance_ratio"
 							{
 								type "list"
@@ -174,13 +180,19 @@
 								description "A list of maps defining the local feature robust directional contributions of the action feature for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
+						"feature_robust_directional_prediction_contributions_for_case"
+							{
+								type "list"
+								description "A list of maps defining the local feature robust directional contributions of the action feature each given case."
+								values {ref "FeatureMetricIndex"}
+							}
 						"feature_full_directional_prediction_contributions"
 							{
 								type "list"
 								description "A list of maps defining the local feature robust directional contributions of the action feature for each feature in the query."
 								values {ref "FeatureMetricIndex"}
 							}
-						"case_robust_prediction_contributions"
+						"case_robust_accuracy_contributions"
 							{
 								type "list"
 								description "A list of lists of maps containing the case index and robust MDA for each influential case of each given case."
@@ -190,7 +202,7 @@
 										values {ref "CaseAccuracyContributions"}
 									}
 							}
-						"case_full_prediction_contributions"
+						"case_full_accuracy_contributions"
 							{
 								type "list"
 								description "A list of lists of maps containing the case index and full MDA for each influential case of each given case."
@@ -223,14 +235,13 @@
 						"feature_full_prediction_contributions_for_case"
 							{
 								type "list"
-								description "A list of lists of maps containing the case index and full contribution to the action feature each given case."
+								description "A list of maps containing the case index and full contribution to the action feature each given case."
 								values {ref "FeatureMetricIndex"}
-
 							}
 						"feature_robust_prediction_contributions_for_case"
 							{
 								type "list"
-								description "A list of lists of maps containing the case index and robust contribution to the action feature each given case."
+								description "A list of maps containing the case index and robust contribution to the action feature each given case."
 								values {ref "FeatureMetricIndex"}
 							}
 						"case_directional_feature_contributions_full"


### PR DESCRIPTION
* `derivation_parameters` and `feature_robust_directional_prediction_contributions_for_case` were missing
* `case_full_prediction_contributions` and `case_robust_prediction_contributions` were duplicated (and the "accuracy" variants missing)
* A few descriptions incorrect