### PR TITLE
24820: Adjusts value_* details to scale by probability mass and filter out insignificant value combinations by new `min_num_samples_for_values` param, MINOR

### DIFF
--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -127,6 +127,10 @@
 			;{type "number" exclusive_min 0}
 			;number of maximum buckets to bin continuous values into when using any of the "value_*" details, defaults to 30 when unspecified
 			value_robust_contributions_num_buckets 30
+			;{type "number" exclusive_min 0}
+			;The minimum number of samples necessary to report a metric value for a combination of feature values when computing any of the values
+			;details.
+			min_num_samples_for_values 15
 			;{ref "ReactAggregateDetails"}
 			;assoc, optional. an assoc of flags for which type of audit data to return, and corresponding values to return (if applicable) in the format of:
 			;	(assoc
@@ -1119,6 +1123,7 @@
 								action_feature value_robust_contributions_action_feature
 								value_robust_contributions_features value_robust_contributions_features
 								max_num_buckets value_robust_contributions_num_buckets
+								min_num_samples_for_values min_num_samples_for_values
 								valid_weight_feature valid_weight_feature
 								compute_ac (get details "value_robust_accuracy_contributions")
 								compute_pc (get details "value_robust_prediction_contributions")
@@ -1142,6 +1147,7 @@
 								action_feature value_robust_contributions_action_feature
 								value_robust_contributions_features value_robust_contributions_features
 								max_num_buckets value_robust_contributions_num_buckets
+								min_num_samples_for_values min_num_samples_for_values
 								valid_weight_feature valid_weight_feature
 							))
 					)

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -130,7 +130,7 @@
 			;{type "number" exclusive_min 0}
 			;The minimum number of samples necessary to report a metric value for a combination of feature values when computing any of the values
 			;details.
-			min_num_samples_for_values 15
+			value_robust_contributions_min_samples 15
 			;{ref "ReactAggregateDetails"}
 			;assoc, optional. an assoc of flags for which type of audit data to return, and corresponding values to return (if applicable) in the format of:
 			;	(assoc
@@ -1123,7 +1123,7 @@
 								action_feature value_robust_contributions_action_feature
 								value_robust_contributions_features value_robust_contributions_features
 								max_num_buckets value_robust_contributions_num_buckets
-								min_num_samples_for_values min_num_samples_for_values
+								value_robust_contributions_min_samples value_robust_contributions_min_samples
 								valid_weight_feature valid_weight_feature
 								compute_ac (get details "value_robust_accuracy_contributions")
 								compute_pc (get details "value_robust_prediction_contributions")
@@ -1147,7 +1147,7 @@
 								action_feature value_robust_contributions_action_feature
 								value_robust_contributions_features value_robust_contributions_features
 								max_num_buckets value_robust_contributions_num_buckets
-								min_num_samples_for_values min_num_samples_for_values
+								value_robust_contributions_min_samples value_robust_contributions_min_samples
 								valid_weight_feature valid_weight_feature
 							))
 					)

--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -12,7 +12,7 @@
 
 		(declare (assoc
 			context_features (filter (lambda (not (contains_value (append action_feature value_robust_contributions_features) (current_value)))) features)
-			case_features (values (append features (if !tsTimeFeature [".series_index"] [])) .true)
+			case_features (values (append features action_feature value_robust_contributions_features (if !tsTimeFeature [".series_index"] [])) .true)
 		))
 
 		(declare (assoc

--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -512,7 +512,7 @@
 
 						;matching_ac_pc_tuples will be empty if this feature_values did not appear in the dataset (or no reacts were registered using them),
 						;of so, output null so it can be filtered out later
-						(if (>= (size matching_ac_pc_tuples) min_num_samples_for_values)
+						(if (>= (size matching_ac_pc_tuples) value_robust_contributions_min_samples)
 							[
 								;output AC for this combination of feature_values
 								(if compute_ac
@@ -1360,7 +1360,7 @@
 								)
 						))
 
-						(if (>= (size matching_value_asymmetry_pairs) min_num_samples_for_values)
+						(if (>= (size matching_value_asymmetry_pairs) value_robust_contributions_min_samples)
 							(*
 								(generalized_mean (map
 									(lambda (first (current_value)))

--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -512,19 +512,28 @@
 
 						;matching_ac_pc_tuples will be empty if this feature_values did not appear in the dataset (or no reacts were registered using them),
 						;of so, output null so it can be filtered out later
-						(if (size matching_ac_pc_tuples)
+						(if (>= (size matching_ac_pc_tuples) min_num_samples_for_values)
 							[
 								;output AC for this combination of feature_values
 								(if compute_ac
-									(generalized_mean (map (lambda (first (current_value))) matching_ac_pc_tuples))
+									(*
+										(generalized_mean (map (lambda (first (current_value))) matching_ac_pc_tuples))
+										(/ (size matching_ac_pc_tuples) (size case_ac_pc_tuples))
+									)
 								)
 								;output PC for this combination of feature_values
 								(if compute_pc
-									(generalized_mean (map (lambda (get (current_value) 1)) matching_ac_pc_tuples))
+									(*
+										(generalized_mean (map (lambda (get (current_value) 1)) matching_ac_pc_tuples))
+										(/ (size matching_ac_pc_tuples) (size case_ac_pc_tuples))
+									)
 								)
 								;output directional PC for this combination of feature_values
 								(if compute_pc
-									(generalized_mean (map (lambda (get (current_value) 2)) matching_ac_pc_tuples))
+									(*
+										(generalized_mean (map (lambda (get (current_value) 2)) matching_ac_pc_tuples))
+										(/ (size matching_ac_pc_tuples) (size case_ac_pc_tuples))
+									)
 								)
 							]
 						)
@@ -1290,67 +1299,79 @@
 					(lambda (let
 						(assoc feature_values (current_value 1))
 
-						;output AC for the feature_values
-						(generalized_mean (map
-							(lambda (first (current_value)))
-							;filter case acs by the unique feature values
-							(if has_multiple_features
-								(filter
-									(lambda
-										(apply "and" (map
-											(lambda (let
-												(assoc ac_feature (get value_robust_contributions_features (current_index 1)) )
-												;nominal must match exactly
-												(if (contains_index !nominalsMap ac_feature)
-													(= (first (current_value)) (last (current_value)))
+						(declare (assoc
+							matching_value_asymmetry_pairs
+								;filter case acs by the unique feature values
+								(if has_multiple_features
+									(filter
+										(lambda
+											(apply "and" (map
+												(lambda (let
+													(assoc ac_feature (get value_robust_contributions_features (current_index 1)) )
+													;nominal must match exactly
+													(if (contains_index !nominalsMap ac_feature)
+														(= (first (current_value)) (last (current_value)))
 
-													;else continuous values will be a pair of [min max] for a value to fall between
-													(and
-														(<=
-															(get continuous_feature_buckets_map [ac_feature (first (current_value 1)) 0])
-															(last (current_value))
-														)
-														(>=
-															(get continuous_feature_buckets_map [ac_feature (first (current_value 1)) 1])
-															(last (current_value))
+														;else continuous values will be a pair of [min max] for a value to fall between
+														(and
+															(<=
+																(get continuous_feature_buckets_map [ac_feature (first (current_value 1)) 0])
+																(last (current_value))
+															)
+															(>=
+																(get continuous_feature_buckets_map [ac_feature (first (current_value 1)) 1])
+																(last (current_value))
+															)
 														)
 													)
-												)
+												))
+												;grab the values to filter by
+												feature_values
+												;grab the values for this case's ac
+												(last (current_value))
 											))
-											;grab the values to filter by
-											feature_values
-											;grab the values for this case's ac
-											(last (current_value))
-										))
-									)
-									case_surprisal_asymmetries
-								)
-
-								;same code but optimized for the one current feature
-								(let
-									(assoc value (first feature_values))
-									(if ac_feature_is_continuous
-										(filter
-											(lambda (and
-												;continuous values will be a pair of [min max] for a value to fall between
-												(<= (get ac_feature_bucket_map [value 0]) (get (current_value) [1 0]) )
-												(>= (get ac_feature_bucket_map [value 1]) (get (current_value) [1 0]) )
-											))
-											case_surprisal_asymmetries
 										)
+										case_surprisal_asymmetries
+									)
 
-										;else if current feature is nominal
-										(filter
-											(lambda
-												;must match current nominal value exactly
-												(= value (get (current_value) [1 0]) )
+									;same code but optimized for the one current feature
+									(let
+										(assoc value (first feature_values))
+										(if ac_feature_is_continuous
+											(filter
+												(lambda (and
+													;continuous values will be a pair of [min max] for a value to fall between
+													(<= (get ac_feature_bucket_map [value 0]) (get (current_value) [1 0]) )
+													(>= (get ac_feature_bucket_map [value 1]) (get (current_value) [1 0]) )
+												))
+												case_surprisal_asymmetries
 											)
-											case_surprisal_asymmetries
+
+											;else if current feature is nominal
+											(filter
+												(lambda
+													;must match current nominal value exactly
+													(= value (get (current_value) [1 0]) )
+												)
+												case_surprisal_asymmetries
+											)
 										)
 									)
 								)
-							)
 						))
+
+						(if (>= (size matching_value_asymmetry_pairs) min_num_samples_for_values)
+							(*
+								(generalized_mean (map
+									(lambda (first (current_value)))
+									matching_value_asymmetry_pairs
+								))
+								(/ (size matching_value_asymmetry_pairs) (size case_surprisal_asymmetries))
+							)
+
+							;else return null if not enough samples
+							(null)
+						)
 					))
 					all_unique_value_combinations
 				)

--- a/unit_tests/ut_h_value_contributions.amlg
+++ b/unit_tests/ut_h_value_contributions.amlg
@@ -83,7 +83,7 @@
 	(call assert_approximate (assoc
 		obs (apply "+" (get result ["value_robust_contributions" "ac_values"]))
 		exp (get ac_map ["feature_robust_accuracy_contributions" "score" "subject"])
-		thresh 0.2
+		thresh 0.1
 	))
 
 	(print "'subject' PC matches the sum of the decomposed robust PCs:")
@@ -268,7 +268,7 @@
 	(call assert_approximate (assoc
 		obs (apply "+" (get result ["value_robust_contributions" "ac_values"]))
 		exp (get ac_map  ["feature_robust_accuracy_contributions" "score" "study_time"])
-		percent 0.25
+		thresh 0.2
 	))
 
 	(print "\nValue Robust Information Asymmetry\n")

--- a/unit_tests/ut_h_value_contributions.amlg
+++ b/unit_tests/ut_h_value_contributions.amlg
@@ -71,31 +71,31 @@
 	(call keep_result_payload)
 	(print
 		"ANALYSIS:\n"
+		"	everyone does consistently well in 'math' which also has many examinations, even the poor performers\n\n"
 		"	everyone gets similar very high grades in 'art'\n"
-		"	everyone does consistently well in 'math', even the poor performers\n\n"
 	)
 	(call assert_same (assoc
-		exp [ ["art"] ["math"] ["science"] ]
+		exp [ ["math"] ["art"] ["science"] ]
 		obs (trunc (get result ["value_robust_contributions" "feature_values"]) 3)
 	))
 
-	(print "Average 'subject' AC matches its avg decomposed robust AC:")
+	(print "'subject' AC matches the sum of the decomposed robust ACs:")
 	(call assert_approximate (assoc
-		obs (generalized_mean (get result ["value_robust_contributions" "ac_values"]))
+		obs (apply "+" (get result ["value_robust_contributions" "ac_values"]))
 		exp (get ac_map ["feature_robust_accuracy_contributions" "score" "subject"])
 		thresh 0.2
 	))
 
-	(print "Average 'subject' PC matches its avg decomposed robust PC:")
+	(print "'subject' PC matches the sum of the decomposed robust PCs:")
 	(call assert_approximate (assoc
-		obs (generalized_mean (get result ["value_robust_contributions" "pc_values"]))
+		obs (apply "+" (get result ["value_robust_contributions" "pc_values"]))
 		exp (get ac_map ["feature_robust_prediction_contributions" "subject"])
 		thresh 0.3
 	))
 
-	(print "Average 'subject' PC matches its avg decomposed robust directional PC:")
+	(print "'subject' PC matches the sum of the decomposed robust directional PCs:")
 	(call assert_approximate (assoc
-		obs (generalized_mean (get result ["value_robust_contributions" "pc_directional_values"]))
+		obs (apply "+" (get result ["value_robust_contributions" "pc_directional_values"]))
 		exp (get ac_map ["feature_robust_directional_prediction_contributions" "subject"])
 		thresh 0.2
 	))
@@ -130,39 +130,39 @@
 		exp ["cora"]
 		obs (last (get result ["value_robust_contributions" "feature_values"]))
 	))
-	(print "Average 'name' AC matches its avg decomposed robust AC:")
+	(print "'name' AC matches the sum of decomposed robust ACs:")
 	(call assert_approximate (assoc
-		obs (generalized_mean (get result ["value_robust_contributions" "ac_values"]))
+		obs (apply "+" (get result ["value_robust_contributions" "ac_values"]))
 		exp (get ac_map ["feature_robust_accuracy_contributions" "score" "name"])
 		percent 0.1
 	))
-	(print "Average 'name' PC matches its avg decomposed robust PC:")
+	(print "'name' PC matches the sum of decomposed robust PCs:")
 	(call assert_approximate (assoc
-		obs (generalized_mean (get result ["value_robust_contributions" "pc_values"]))
+		obs (apply "+" (get result ["value_robust_contributions" "pc_values"]))
 		exp (get ac_map ["feature_robust_prediction_contributions" "name"])
 		thresh 0.5
 	))
-	(print "both computed and avg decomposed PC are > 2.5: ")
+	(print "both computed and sum of  decomposed PC are > 2.5: ")
 	(call assert_true (assoc
 		obs
 			(and
 				(> (get ac_map ["feature_robust_prediction_contributions" "name"])  2.5)
-				(> (generalized_mean (get result ["value_robust_contributions" "pc_values"])) 2.5)
+				(> (apply "+" (get result ["value_robust_contributions" "pc_values"])) 2.5)
 			)
 	))
 
-	(print "Average 'name' PC matches its avg decomposed robust directional PC: ")
+	(print "'name' directional PC matches the sum of decomposed robust directional PCs: ")
 	(call assert_approximate (assoc
-		obs (generalized_mean (get result ["value_robust_contributions" "pc_directional_values"]))
+		obs (apply "+" (get result ["value_robust_contributions" "pc_directional_values"]))
 		exp (get ac_map ["feature_robust_directional_prediction_contributions" "name"])
 		thresh 0.4
 	))
-	(print "both computed and avg decomposed directional PC are < -0.2: ")
+	(print "both computed and sum of decomposed directional PC are < -0.2: ")
 	(call assert_true (assoc
 		obs
 			(and
 				(< (get ac_map ["feature_robust_directional_prediction_contributions" "name"]) -0.2)
-				(< (generalized_mean (get result ["value_robust_contributions" "pc_directional_values"])) -0.2)
+				(< (apply "+" (get result ["value_robust_contributions" "pc_directional_values"])) -0.2)
 			)
 	))
 
@@ -208,7 +208,7 @@
 					["anne" "math"]
 					["anne" "history"]
 					["bill" "math"]
-					["ed" "literature"]
+					["fiona" "math"]
 					["fiona" "science"]
 				]
 			)
@@ -219,8 +219,8 @@
 	(print "'Anne + math' and 'Fiona + science' both have high P.C. because they are so extreme: ")
 	(call assert_approximate (assoc
 		obs (trunc (get result ["value_robust_contributions" "pc_values"]) 2)
-		exp [5 3.5]
-		thresh 0.7
+		exp [0.25 0.13125]
+		thresh 0.05
 	))
 	(print
 		"'Anne + math' has very high directional P.C. because she always does so well, while\n"
@@ -228,8 +228,8 @@
 	)
 	(call assert_approximate (assoc
 		obs (trunc (get result ["value_robust_contributions" "pc_directional_values"]) 2)
-		exp [5 -2.5]
-		thresh 0.7
+		exp [0.25 -0.1]
+		thresh 0.05
 	))
 	(call exit_if_failures (assoc msg "A.C. and P.C. for two features."))
 
@@ -249,24 +249,24 @@
 		"	low study time (e.g.. for 'fiona') is consistently low scores, etc.\n\n"
 	)
 	(call assert_same (assoc
-		obs (trunc (get result ["value_robust_contributions" "feature_values"]) 3)
+		obs (zip (trunc (get result ["value_robust_contributions" "feature_values"]) 3))
 		exp
-			[
-				[
-					[150.7 153.7]
-				]
+			(zip [
 				[
 					[73.3 79]
 				]
 				[
-					[109 109.7]
+					[150.7 153.7]
 				]
-			]
+				[
+					[134.2 148.5]
+				]
+			])
 	))
 
-	(print "Average 'study_time' AC approximately matches its robust AC:")
+	(print "'study_time' AC approximately matches the sum of decomposed robust ACs:")
 	(call assert_approximate (assoc
-		obs (generalized_mean (get result ["value_robust_contributions" "ac_values"]))
+		obs (apply "+" (get result ["value_robust_contributions" "ac_values"]))
 		exp (get ac_map  ["feature_robust_accuracy_contributions" "score" "study_time"])
 		percent 0.25
 	))

--- a/unit_tests/ut_h_value_contributions.amlg
+++ b/unit_tests/ut_h_value_contributions.amlg
@@ -83,7 +83,7 @@
 	(call assert_approximate (assoc
 		obs (apply "+" (get result ["value_robust_contributions" "ac_values"]))
 		exp (get ac_map ["feature_robust_accuracy_contributions" "score" "subject"])
-		thresh 0.1
+		thresh 0.15
 	))
 
 	(print "'subject' PC matches the sum of the decomposed robust PCs:")


### PR DESCRIPTION
This PR has 3 functional changes:
- Fixes a bug in value_robust_prediction_contributions and value_robust_accuracy_contributions where specifying a collection of context features that does not include the action feature/decomposition features will render the output useless.
- Adds logic to scale the computed values for each combination of values by its probability mass. So if some value combination describes 5% of sampled cases, then its AC/PC will be multiplied by 0.05.
- Adds logic to filter out value combinations that do not receive a statistically significant number of samples. This threshold is parametrizable via the new param: `min_num_samples_for_values` (name pending). It defaults to 15.

I also have to update the test of course, now that values are a fair bit different.