### PR TITLE
24823: FIxes distribution query used in training with weights to use correct weight feature

### DIFF
--- a/howso/update_cases.amlg
+++ b/howso/update_cases.amlg
@@ -794,7 +794,7 @@
 							(replace (get hyperparam_map "featureDeviations"))
 							(null)
 							(replace (get hyperparam_map "dt"))
-							(if (!= weight_feature ".none") (replace weight_feature) (null))
+							(if (!= accumulate_weight_feature ".none") accumulate_weight_feature)
 							;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 							"fixed rand seed"
 							(null) ;radius


### PR DESCRIPTION
train() call uses `accumulate_weight_feature` as the parameter