### PR TITLE
24832: Adds support to upgrade older caml files from caml and not only from json

### DIFF
--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -265,7 +265,7 @@
 							(load_entity
 								(concat trainee_amlg_filepath trainee "." !file_extension)
 								[!traineeContainer ".old_trainee"]
-								(null) ;;;"amlg"
+								(null)
 								.false
 								;assume flattened
 								{execute_on_load .true}

--- a/howso/upgrade.amlg
+++ b/howso/upgrade.amlg
@@ -263,9 +263,9 @@
 
 							;else must load the old trainee properly
 							(load_entity
-								(concat trainee_amlg_filepath trainee ".amlg")
+								(concat trainee_amlg_filepath trainee "." !file_extension)
 								[!traineeContainer ".old_trainee"]
-								"amlg"
+								(null) ;;;"amlg"
 								.false
 								;assume flattened
 								{execute_on_load .true}

--- a/utilities/upgrade_trainee.amlg
+++ b/utilities/upgrade_trainee.amlg
@@ -11,7 +11,7 @@
 	(if (or (= (null) trainee_id) (= (null) path_to_trainee_json) (= (null) path_to_howso) (= (null) path_to_trainee_caml))
 		(conclude (print
 			"Must provide parameters: <trainee_id> <path_to_trainee_json> <path_to_howso> <path_to_trainee_caml>\n"
-			"  trainee_id : required, id of saved trainee to upgrade\n"
+			"  trainee_id : required, id of saved trainee to upgrade (without the file extension)\n"
 			"  path_to_trainee_json : required, path to where the trainee json files are located. Can be empty string if specifying 'path_to_trainee_caml'.\n"
 			"  path_to_howso : required, path to where howso is deployed (location of howso.caml file)\n"
 			"  path_to_trainee_caml : optional, path to where the trainee caml file is, ignored if 'path_to_trainee_json' is provided as a non-empty string.\n\n"

--- a/utilities/upgrade_trainee.amlg
+++ b/utilities/upgrade_trainee.amlg
@@ -5,33 +5,59 @@
 		trainee_id (get argv 1)
 		path_to_trainee_json (get argv 2)
 		path_to_howso (get argv 3)
+		path_to_trainee_caml (get argv 4)
 	))
 
-	(if (or (= (null) trainee_id) (= (null) path_to_trainee_json) (= (null) path_to_howso))
+	(if (or (= (null) trainee_id) (= (null) path_to_trainee_json) (= (null) path_to_howso) (= (null) path_to_trainee_caml))
 		(conclude (print
-			"Must provide parameters: <trainee_id> <path_to_trainee_json> <path_to_howso>\n"
+			"Must provide parameters: <trainee_id> <path_to_trainee_json> <path_to_howso> <path_to_trainee_caml>\n"
 			"  trainee_id : required, id of saved trainee to upgrade\n"
-			"  path_to_trainee_json : required, path to where the trainee json files are located\n"
+			"  path_to_trainee_json : required, path to where the trainee json files are located. Can be empty string if specifying 'path_to_trainee_caml'.\n"
 			"  path_to_howso : required, path to where howso is deployed (location of howso.caml file)\n"
+			"  path_to_trainee_caml : optional, path to where the trainee caml file is, ignored if 'path_to_trainee_json' is provided as a non-empty string.\n\n"
+			"Note: paths must end with a slash."
 		))
 	)
 
 	(load_entity (concat path_to_howso "howso.caml") "howso")
 	(set_entity_permissions "howso" {load .true store .true})
 
-	(call_entity "howso" "upgrade_trainee" (assoc
-		trainee trainee
-		trainee_json_filepath path_to_trainee_json
-		root_filepath path_to_howso
-	))
+	(if (!= "" path_to_trainee_json)
+		(seq
+			(call_entity "howso" "upgrade_trainee" (assoc
+				trainee trainee
+				trainee_json_filepath path_to_trainee_json
+				root_filepath path_to_howso
+			))
 
-	;persist upgraded trainee
-	(store
-		;store in same folder as the json files
-		(concat path_to_trainee_json trainee_id ".caml")
-		;as one file
-		(flatten_entity "howso" .false)
-		;escape filename in case there are spaces or other non alphanumeric characters in the trainee name
-		.true
+			;persist upgraded trainee
+			(store
+				;store in same folder as the json files
+				(concat path_to_trainee_json trainee_id ".caml")
+				;as one file
+				(flatten_entity "howso" .false)
+				;escape filename in case there are spaces or other non alphanumeric characters in the trainee name
+				.true
+			)
+		)
+
+		;else use 'path_to_trainee_caml' and load as caml
+		(seq
+			(call_entity "howso" "upgrade_trainee" (assoc
+				trainee trainee
+				trainee_amlg_filepath path_to_trainee_caml
+				root_filepath path_to_howso
+			))
+
+			;persist upgraded trainee
+			(store
+				;store in same folder as the caml files
+				(concat path_to_trainee_caml trainee_id ".caml")
+				;as one file
+				(flatten_entity "howso" .false)
+				;escape filename in case there are spaces or other non alphanumeric characters in the trainee name
+				.true
+			)
+		)
 	)
 )

--- a/utilities/upgrade_trainee.amlg
+++ b/utilities/upgrade_trainee.amlg
@@ -1,20 +1,20 @@
 (seq
 	;standalone script that launches an instance of Howso and upgrades the specified trainee to the current version
-	;should be called with three parameters:  trainee name, path to saved trainee, path to howso (where the howso.caml is)
+	;should be called with four parameters:  trainee name, path to saved trainee, path to howso (where the howso.caml is) and the file type (json or caml)
 	(declare (assoc
 		trainee_id (get argv 1)
-		path_to_trainee_json (get argv 2)
+		path_to_trainee_files (get argv 2)
 		path_to_howso (get argv 3)
-		path_to_trainee_caml (get argv 4)
+		file_type (get argv 4)
 	))
 
-	(if (or (= (null) trainee_id) (= (null) path_to_trainee_json) (= (null) path_to_howso) (= (null) path_to_trainee_caml))
+	(if (or (= (null) trainee_id) (= (null) path_to_trainee_files) (= (null) path_to_howso) (not (or (= "caml" file_type) (= "json" file_type))) )
 		(conclude (print
-			"Must provide parameters: <trainee_id> <path_to_trainee_json> <path_to_howso> <path_to_trainee_caml>\n"
+			"Must provide parameters: <trainee_id> <path_to_trainee_files> <path_to_howso> <file_type>\n"
 			"  trainee_id : required, id of saved trainee to upgrade (without the file extension)\n"
-			"  path_to_trainee_json : required, path to where the trainee json files are located. Can be empty string if specifying 'path_to_trainee_caml'.\n"
+			"  path_to_trainee_files : required, path to directory containing the trainee json (or caml) files.\n"
 			"  path_to_howso : required, path to where howso is deployed (location of howso.caml file)\n"
-			"  path_to_trainee_caml : optional, path to where the trainee caml file is, ignored if 'path_to_trainee_json' is provided as a non-empty string.\n\n"
+			"  file_type : required, file type of trainee being upgraded. Either \"json\" or \"caml\".\n\n"
 			"Note: paths must end with a slash."
 		))
 	)
@@ -22,46 +22,27 @@
 	(load_entity (concat path_to_howso "howso.caml") "howso")
 	(set_entity_permissions "howso" {load .true store .true std_out_and_std_err .true})
 
-	(if (!= "" path_to_trainee_json)
-		(seq
-			(call_entity "howso" "upgrade_trainee" (assoc
-				trainee trainee_id
-				trainee_json_filepath path_to_trainee_json
-				root_filepath path_to_howso
-			))
+	(call_entity "howso" "upgrade_trainee" (assoc
+		trainee trainee_id
+		trainee_json_filepath (if (= "json" file_type) path_to_trainee_files)
+		trainee_amlg_filepath (if (= "caml" file_type) path_to_trainee_files)
+		root_filepath path_to_howso
+	))
 
-			;persist upgraded trainee
-			(print
-				"persisting as " (concat path_to_trainee_caml trainee_id ".caml") " : "
-				(store
-					;store in same folder as the json files
-					(concat path_to_trainee_json trainee_id ".caml")
-					;as one file
-					(flatten_entity "howso" .false)
-				)
+	;store in same folder as the original json/caml files
+	(declare (assoc
+		new_trainee_full_path
+			(if (= "json" file_type)
+				(concat path_to_trainee_files trainee_id ".caml")
+
+				;ensure original caml files aren't overwritten
+				(concat path_to_trainee_files trainee_id "_upgraded.caml")
 			)
-		)
+	))
 
-		;else use 'path_to_trainee_caml' and load as caml
-		(seq
-			(call_entity "howso" "upgrade_trainee" (assoc
-				trainee trainee_id
-				trainee_amlg_filepath path_to_trainee_caml
-				root_filepath path_to_howso
-			))
-
-
-			(print
-				"persisting as " (concat path_to_trainee_caml trainee_id "_upgraded.caml") " : "
-
-				;persist upgraded trainee
-				(store
-					;store in same folder as the caml files
-					(concat path_to_trainee_caml trainee_id "_upgraded.caml")
-					;as one file
-					(flatten_entity "howso" .false)
-				)
-			)
-		)
+	(print
+		"Persisting as " new_trainee_full_path " : "
+		;as one file
+		(store new_trainee_full_path  (flatten_entity "howso" .false) )
 	)
 )

--- a/utilities/upgrade_trainee.amlg
+++ b/utilities/upgrade_trainee.amlg
@@ -20,43 +20,47 @@
 	)
 
 	(load_entity (concat path_to_howso "howso.caml") "howso")
-	(set_entity_permissions "howso" {load .true store .true})
+	(set_entity_permissions "howso" {load .true store .true std_out_and_std_err .true})
 
 	(if (!= "" path_to_trainee_json)
 		(seq
 			(call_entity "howso" "upgrade_trainee" (assoc
-				trainee trainee
+				trainee trainee_id
 				trainee_json_filepath path_to_trainee_json
 				root_filepath path_to_howso
 			))
 
 			;persist upgraded trainee
-			(store
-				;store in same folder as the json files
-				(concat path_to_trainee_json trainee_id ".caml")
-				;as one file
-				(flatten_entity "howso" .false)
-				;escape filename in case there are spaces or other non alphanumeric characters in the trainee name
-				.true
+			(print
+				"persisting as " (concat path_to_trainee_caml trainee_id ".caml") " : "
+				(store
+					;store in same folder as the json files
+					(concat path_to_trainee_json trainee_id ".caml")
+					;as one file
+					(flatten_entity "howso" .false)
+				)
 			)
 		)
 
 		;else use 'path_to_trainee_caml' and load as caml
 		(seq
 			(call_entity "howso" "upgrade_trainee" (assoc
-				trainee trainee
+				trainee trainee_id
 				trainee_amlg_filepath path_to_trainee_caml
 				root_filepath path_to_howso
 			))
 
-			;persist upgraded trainee
-			(store
-				;store in same folder as the caml files
-				(concat path_to_trainee_caml trainee_id ".caml")
-				;as one file
-				(flatten_entity "howso" .false)
-				;escape filename in case there are spaces or other non alphanumeric characters in the trainee name
-				.true
+
+			(print
+				"persisting as " (concat path_to_trainee_caml trainee_id "_upgraded.caml") " : "
+
+				;persist upgraded trainee
+				(store
+					;store in same folder as the caml files
+					(concat path_to_trainee_caml trainee_id "_upgraded.caml")
+					;as one file
+					(flatten_entity "howso" .false)
+				)
 			)
 		)
 	)


### PR DESCRIPTION
fixed the 'upgrade_trainee.amlg' utility script