### PR TITLE
24834: Fixes an issue when computing values details on time-series features that derive from lagged values

### DIFF
--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -65,6 +65,25 @@
 			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
 		))
 
+		#!FilterValuesCaseIDsForLaggedFeatures
+		(if (size (keep ts_feature_lag_amount_map value_robust_contributions_features))
+			(let
+				(assoc
+					max_needed_lag (apply "max" (unzip ts_feature_lag_amount_map value_robust_contributions_features))
+				)
+
+				(assign (assoc
+					case_ids
+						(filter
+							(lambda
+								(>= (retrieve_from_entity (current_value) ".series_index") max_needed_lag)
+							)
+							case_ids
+						)
+				))
+			)
+		)
+
 		(declare (assoc
 			;!ComputeNumEnabledFeaturesProbabilitiesMap only creates probabilities up to num_features - 1,
 			; add 1 to num_features to create probabilities for 0 - num_features
@@ -808,6 +827,7 @@
 			;store an assoc of lag/rate/delta feature -> lag/order amount for time series flows
 			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
 		))
+		(if !tsTimeFeature (call !FilterValuesCaseIDsForLaggedFeatures))
 
 		(declare (assoc
 			enabled_num_features_probability_map (call !ComputeNumEnabledFeaturesProbabilitiesMap (assoc num_features num_features))
@@ -868,7 +888,6 @@
 						(declare (assoc
 							robustly_selected_context_features (replace react_context_features)
 						))
-
 
 						(if !tsTimeFeature
 							(let


### PR DESCRIPTION
When using any of the values details on a time-series trainee, if attempting to inspect decomposed values for time-dependent features that require lagged values (lags, deltas, rates), then invalid missing values would be returned.