### PR TITLE
24845: Adds `value_robust_contributions_buckets` parameter to `#react_aggregate`, MINOR

### DIFF
--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -124,6 +124,10 @@
 			;action feature being predicted whose accuracy and prediction affects should be computed by 'value_robust_contributions_features'
 			;when computing any of the "value_*" details.
 			value_robust_contributions_action_feature (null)
+			;{type "assoc" values {type "list" values {type "list" min_size 2 max_size 2}}}
+			;An assoc mapping continuous feature names to lists of ranges defining buckets to compute metrics for when using any of the "value_*" details. When undefined
+			;buckets are automatically determined using the probability masses of the data.
+			value_robust_contributions_buckets (null)
 			;{type "number" exclusive_min 0}
 			;number of maximum buckets to bin continuous values into when using any of the "value_*" details, defaults to 30 when unspecified
 			value_robust_contributions_num_buckets 30
@@ -1123,6 +1127,7 @@
 								action_feature value_robust_contributions_action_feature
 								value_robust_contributions_features value_robust_contributions_features
 								max_num_buckets value_robust_contributions_num_buckets
+								value_robust_contributions_buckets value_robust_contributions_buckets
 								value_robust_contributions_min_samples value_robust_contributions_min_samples
 								valid_weight_feature valid_weight_feature
 								compute_ac (get details "value_robust_accuracy_contributions")
@@ -1147,6 +1152,7 @@
 								action_feature value_robust_contributions_action_feature
 								value_robust_contributions_features value_robust_contributions_features
 								max_num_buckets value_robust_contributions_num_buckets
+								value_robust_contributions_buckets value_robust_contributions_buckets
 								value_robust_contributions_min_samples value_robust_contributions_min_samples
 								valid_weight_feature valid_weight_feature
 							))

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -125,7 +125,7 @@
 			;when computing any of the "value_*" details.
 			value_robust_contributions_action_feature (null)
 			;{type "assoc" values {type "list" values {type "list" min_size 2 max_size 2}}}
-			;An assoc mapping continuous feature names to lists of ranges defining buckets to compute metrics for when using any of the "value_*" details. When undefined
+			;An assoc mapping continuous feature names to lists of lists defining inclusive ranges to be used as buckets to compute metrics for when using any of the "value_*" details. When undefined,
 			;buckets are automatically determined using the probability masses of the data.
 			value_robust_contributions_buckets (null)
 			;{type "number" exclusive_min 0}

--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -397,21 +397,31 @@
 		(declare (assoc
 			continuous_feature_buckets_map
 				(map
-					(lambda (let
-						(assoc ac_feature_index (get contribution_feature_index_map (current_index 1)) )
-						(call !BinValuesByQuantiles (assoc
-							max_num_buckets max_num_buckets
-							sorted_unique_values
-								;sort is descending order
-								(sort
-									(lambda (< (current_value) (current_value 1)) )
-									(values
-										(map (lambda (get (current_value) [3 ac_feature_index])) case_ac_pc_tuples)
-										.true
-									)
-								)
-						))
-					))
+					(lambda
+						(if (contains_index value_robust_contributions_buckets (current_index))
+							(zip
+								(range 1 (size (get value_robust_contributions_buckets (current_index))))
+								(get value_robust_contributions_buckets (current_index))
+							)
+
+							;determine buckets automatically
+							(let
+								(assoc ac_feature_index (get contribution_feature_index_map (current_index 1)) )
+								(call !BinValuesByQuantiles (assoc
+									max_num_buckets max_num_buckets
+									sorted_unique_values
+										;sort is descending order
+										(sort
+											(lambda (< (current_value) (current_value 1)) )
+											(values
+												(map (lambda (get (current_value) [3 ac_feature_index])) case_ac_pc_tuples)
+												.true
+											)
+										)
+								))
+							)
+						)
+					)
 					(zip (filter
 						(lambda (not (contains_index !nominalsMap (current_value))))
 						value_robust_contributions_features
@@ -1248,21 +1258,31 @@
 		(declare (assoc
 			continuous_feature_buckets_map
 				(map
-					(lambda (let
-						(assoc ac_feature_index (get ac_feature_index_map (current_index 1)) )
-						(call !BinValuesByQuantiles (assoc
-							max_num_buckets max_num_buckets
-							sorted_unique_values
-								;sort is descending order
-								(sort
-									(lambda (< (current_value) (current_value 1)) )
-									(values
-										(map (lambda (get (current_value) [1 ac_feature_index])) case_surprisal_asymmetries)
-										.true
-									)
-								)
-						))
-					))
+					(lambda
+						(if (contains_index value_robust_contributions_buckets (current_index))
+							(zip
+								(range 1 (size (get value_robust_contributions_buckets (current_index))))
+								(get value_robust_contributions_buckets (current_index))
+							)
+
+							;otherwise automatically determine buckets
+							(let
+								(assoc ac_feature_index (get ac_feature_index_map (current_index 1)) )
+								(call !BinValuesByQuantiles (assoc
+									max_num_buckets max_num_buckets
+									sorted_unique_values
+										;sort is descending order
+										(sort
+											(lambda (< (current_value) (current_value 1)) )
+											(values
+												(map (lambda (get (current_value) [1 ac_feature_index])) case_surprisal_asymmetries)
+												.true
+											)
+										)
+								))
+							)
+						)
+					)
 					(zip (filter
 						(lambda (not (contains_index !nominalsMap (current_value))))
 						value_robust_contributions_features


### PR DESCRIPTION
Adds parameter allowing users to specify explicit bucket boundaries for continuous features when using any of the values contributions details.