### PR TITLE
24821: Adds reduce_only flag to analyze(), optimizes analyze functionality for reduce_data() flows, MINOR

### DIFF
--- a/howso/analysis.amlg
+++ b/howso/analysis.amlg
@@ -108,6 +108,9 @@
 			;The minumum size of the first batch of cases used when dynamically sampling robust residuals used to determine feature probabilities
 			;	Default of 5000
 			convergence_min_size 5000
+			;{type "boolean"}
+			;when true, used by reduce_data flow to simplify analyze flow by skipping computation of feature weights
+			reduce_only .false
 		)
 
 		(call !ValidateParameters)
@@ -254,6 +257,7 @@
 					"convergence_threshold" convergence_threshold
 					"convergence_samples_growth_rate" convergence_samples_growth_rate
 					"convergence_min_size" convergence_min_size
+					"reduce_only" reduce_only
 				)
 		))
 
@@ -275,6 +279,7 @@
 				weight_feature weight_feature
 				use_dynamic_deviations use_dynamic_deviations
 				use_sdm use_sdm
+				reduce_only reduce_only
 			))
 		)
 

--- a/howso/analysis_weights.amlg
+++ b/howso/analysis_weights.amlg
@@ -288,9 +288,8 @@
 	#!ConvergeTargetless
 	(declare
 		(assoc
-			num_iterations 4
-
-			;local method variables, not parameters
+			;don't need to do the last iteration if running reduce_only flow
+			num_iterations (if reduce_only 3 4)
 			iteration 0
 			hyperparam_map (assoc)
 		)
@@ -405,9 +404,9 @@
 		;At this point the hyperparameters and residuals and weights are stable enough for use.
 		(while (< iteration num_iterations)
 
-			;compute mda on last iteration
+			;compute mda on last iteration, but only if not doing a reduce_only analyze
 			(assign (assoc
-				computing_mda (= iteration (- num_iterations 1))
+				computing_mda (and (= reduce_only .false) (= iteration (- num_iterations 1)) )
 			))
 
 			(assign (assoc

--- a/howso/hyperparameters.amlg
+++ b/howso/hyperparameters.amlg
@@ -900,6 +900,9 @@
 			;The minimum size of the first batch of cases used when dynamically sampling robust residuals used to determine feature probabilities
 			;	Default of 5000
 			convergence_min_size 5000
+			;{type "boolean"}
+			;when true, used by reduce_data flow to simplify analyze flow by skipping computation of feature weights
+			reduce_only .false
 		)
 		(call !ValidateParameters)
 
@@ -964,6 +967,7 @@
 				convergence_threshold
 				convergence_samples_growth_rate
 				convergence_min_size
+				reduce_only
 			)
 			(seq
 				(if (= (null) targeted_model)
@@ -1004,6 +1008,7 @@
 							"convergence_threshold" convergence_threshold
 							"convergence_samples_growth_rate" convergence_samples_growth_rate
 							"convergence_min_size" convergence_min_size
+							"reduce_only" reduce_only
 						))
 				))
 			)


### PR DESCRIPTION
skips computing AC  feature weights if flag is set to true