### PR TITLE
24923: Fixes extreme case residual for cases with values with similar cases where their values are all null

### DIFF
--- a/howso/details_residuals.amlg
+++ b/howso/details_residuals.amlg
@@ -624,11 +624,18 @@
 												num_unique_local_values (size (values non_null_local_values .true ))
 											)
 
-											;if entire local data is null or only has 1 non-null value, use the global null residual
+											;if entire local data is null or only has 1 non-null value, use the global null-value uncertainty
 											(if (<= num_unique_local_values 1)
-												(/
+												;use the null-value uncertainty for the feature if one exists
+												(if (and
+														(~ [] (get feature_deviations null_feature))
+														(!= (null) (get feature_deviations [null_feature 1]))
+													)
+													;feature deviation is a tuple of: [deviation, null-value, null-null]
+													(get feature_deviations [null_feature 1])
+
+													;else use the cached maximum null-null range as defined for the feature
 													(get !featureNullRatiosMap (list null_feature "null_residual"))
-													local_non_null_influence
 												)
 
 												;else there are enough local values to compute local null residual

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -921,10 +921,28 @@
 			))
 	))
 	(call keep_result_payload)
-	(print "Details robust accuracy contributions (D > A, B, C): ")
-	(call assert_same (assoc
-		obs (first (index_max (get result "feature_robust_accuracy_contributions") ))
-		exp "D"
+	(print "Details robust accuracy contributions (D|A) > (B|C): ")
+	(call assert_true (assoc
+		obs
+			(and
+				(>
+					(get result ["feature_robust_accuracy_contributions" "A"])
+					(get result ["feature_robust_accuracy_contributions" "B"])
+				)
+				(>
+					(get result ["feature_robust_accuracy_contributions" "A"])
+					(get result ["feature_robust_accuracy_contributions" "C"])
+				)
+				(>
+					(get result ["feature_robust_accuracy_contributions" "D"])
+					(get result ["feature_robust_accuracy_contributions" "B"])
+				)
+				(>
+					(get result ["feature_robust_accuracy_contributions" "D"])
+					(get result ["feature_robust_accuracy_contributions" "C"])
+				)
+			)
+
 	))
 	(print (get result "feature_robust_accuracy_contributions"))
 


### PR DESCRIPTION
old code would scale up the maximum range for the feature by a factor of 2*max k before, which could result in huge residual values.
This fix changes it to use the precomputed null-value uncertainty, if it's available.