### PR TITLE
24930: Fixes deviations and ac value contributions computed for edit distance features

### DIFF
--- a/howso/mda_weight.amlg
+++ b/howso/mda_weight.amlg
@@ -168,6 +168,11 @@
 									feature_is_nominal (contains_index !nominalsMap (current_value 1))
 									output_categorical_action_probabilities .true
 									categorical_action_probabilities_map (assoc)
+									feature_is_edit_distance (contains_index !editDistanceFeatureTypesMap (current_value 1))
+									feature_is_non_string_edit_distance .false
+								)
+								(if (and feature_is_edit_distance (!= "string_mixable" (get !editDistanceFeatureTypesMap feature)) )
+									(assign (assoc feature_is_non_string_edit_distance .true))
 								)
 
 								;see comment where 'single_query_per_case' is defined above.

--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -32,7 +32,7 @@
 			feature_is_dependent (contains_index !dependentFeatureMap action_feature)
 			feature_is_non_string_edit_distance .false
 		))
-		(if (and feature_is_edit_distance (!= "string_mixable" (get !editDistanceFeatureTypesMap feature)) )
+		(if (and feature_is_edit_distance (!= "string_mixable" (get !editDistanceFeatureTypesMap action_feature)) )
 			(assign (assoc feature_is_non_string_edit_distance .true))
 		)
 

--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -30,7 +30,12 @@
 			feature_is_nominal (contains_index !nominalsMap action_feature)
 			feature_is_edit_distance (contains_index !editDistanceFeatureTypesMap action_feature)
 			feature_is_dependent (contains_index !dependentFeatureMap action_feature)
+			feature_is_non_string_edit_distance .false
 		))
+		(if (and feature_is_edit_distance (!= "string_mixable" (get !editDistanceFeatureTypesMap feature)) )
+			(assign (assoc feature_is_non_string_edit_distance .true))
+		)
+
 		(if (= (null) hyperparam_map)
 			(assign (assoc
 				hyperparam_map

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -1,6 +1,6 @@
 (seq
 	#unit_test (direct_assign_to_entities (assoc unit_test (load "unit_test.amlg")))
-	(call (load "unit_test_howso.amlg") (assoc name "ut_h_react_explain.amlg"))
+	(call (load "unit_test_howso.amlg") (assoc name "ut_h_react_explain.amlg" retries 1))
 
 	(call_entity "howso" "set_feature_attributes" (assoc feature_attributes (assoc "E" (assoc "type" "nominal"))))
 


### PR DESCRIPTION
edit distance features weren't using (edit_distance) to compute the diff when computing deviations