### PR TITLE
24940: Updates reduce_data to remove entire series if not enough series cases remaining

### DIFF
--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -775,7 +775,12 @@
 						(accum (assoc
 							cases
 								(apply "append" (map
-									(lambda (contained_entities (current_value)))
+									(lambda
+										(contained_entities
+											(query_not_in_entity_list cases)
+											(current_value)
+										)
+									)
 									entire_series_removal_id_queries
 								))
 						))

--- a/howso/ablation.amlg
+++ b/howso/ablation.amlg
@@ -725,15 +725,62 @@
 			)
 
 			(if !tsTimeFeature
-				;do not remove first (.series_index == 0) or last (.reverse_series_index == 0) cases for any series
-				(assign (assoc
-					cases
-						(contained_entities
-							(query_in_entity_list cases)
-							(query_not_equals ".reverse_series_index" 0)
-							(query_not_equals ".series_index" 0)
-						)
-				))
+				(let
+					(assoc
+						entire_series_removal_id_queries
+							;select those series identifiers where there will be less than 3 cases remaining after this removal pass
+							;because these entire series should be removed at that point
+							(filter
+								(lambda
+									(<
+										(size (contained_entities
+											(query_not_in_entity_list cases)
+											;(current_value) is in the format of (list (query_equals "series_feature_id" value) ... ) for all affected series ids
+											(current_value)
+										))
+										3
+									)
+								)
+								;a list of affected series identifier queries for this batch of 'cases'
+								(call !GenerateUniqueSeriesQueries (assoc
+									series_id_features (get !tsFeaturesMap "series_id_features")
+									case_ids
+										;of the selected cases, only keep those that were either the first or last case from a series
+										(append
+											(contained_entities
+												(query_in_entity_list cases)
+												(query_equals ".reverse_series_index" 0)
+											)
+											(contained_entities
+												(query_in_entity_list cases)
+												(query_equals ".series_index" 0)
+											)
+										)
+								))
+							)
+					)
+
+					;do not remove first (.series_index == 0) or last (.reverse_series_index == 0) cases for any series
+					(assign (assoc
+						cases
+							(contained_entities
+								(query_in_entity_list cases)
+								(query_not_equals ".reverse_series_index" 0)
+								(query_not_equals ".series_index" 0)
+							)
+					))
+
+					;there were series that will need to be entirely removed, add all those series cases for removal
+					(if (size entire_series_removal_id_queries)
+						(accum (assoc
+							cases
+								(apply "append" (map
+									(lambda (contained_entities (current_value)))
+									entire_series_removal_id_queries
+								))
+						))
+					)
+				)
 			)
 
 			(if (size cases)

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -686,7 +686,7 @@
 
 
 	(call_entity "howso" "set_auto_ablation_params" (assoc min_num_cases 10 ))
-	(call_entity "howso" "reduce_data")
+	(call_entity "howso" "reduce_data" (assoc reduce_max_cases 10))
 	(assign (assoc
 		result (call_entity "howso" "get_cases" (assoc features [".series_index" ".reverse_series_index" "stock"]))
 	))
@@ -700,19 +700,6 @@
 				(get result "cases")
 			)
 	))
-
-	(print "There should be exactly 4 'first series' cases: ")
-	(call assert_same (assoc
-		exp 4
-		obs (size first_series_cases)
-	))
-	(print "Each with a unique stock id: ")
-	(call assert_same (assoc
-		exp 4
-		obs (size (zip (map (lambda (last (current_value))) first_series_cases)))
-	))
-
-	;get all cases that have a .reverse_series_index of 0
 	(declare (assoc
 		last_series_cases
 			(filter
@@ -720,17 +707,14 @@
 				(get result "cases")
 			)
 	))
-	(print "There should be exactly 4 'last series' cases: ")
+
+	(print "There should be the same amount of 'first' and 'last' series cases: ")
 	(call assert_same (assoc
-		exp 4
-		obs (size last_series_cases)
+		exp (size last_series_cases)
+		obs (size first_series_cases)
 	))
-	(print "Each with a unique stock id: ")
-	(call assert_same (assoc
-		exp 4
-		obs (size (zip (map (lambda (last (current_value))) last_series_cases)))
-	))
-	(call exit_if_failures (assoc msg "Reducing data keeps first and last series cases."))
+
+	(call exit_if_failures (assoc msg "Reducing data keeps first and last series cases if keeping a series."))
 
 	(call exit_if_failures (assoc msg unit_test_name))
 )


### PR DESCRIPTION
In reduce flow, if there are <= 3 cases for a series left when attempting to remove a start/end case, the entire series should be removed 