### PR TITLE
24970: Fixes JSON Type map type definition for `original_type` feature attribute, adds "container" `data_type`

### DIFF
--- a/howso/types.amlg
+++ b/howso/types.amlg
@@ -75,7 +75,6 @@
 								description "Specifies the observational mean absolute error for this feature. Use when the error value is already known."
 							)
 						data_type {ref "FeatureDataType"}
-						type_map {ref "JSONTypeMap"}
 						recursive_matching
 							(assoc
 								type "boolean"
@@ -415,11 +414,6 @@
 						"- `boolean`: Valid only for nominals."
 					)
 			)
-		JSONTypeMap
-			(assoc
-				type "assoc"
-				description "The map of original primitive types for JSON features."
-			)
 		FeatureOriginalType
 			(assoc
 				any_of [
@@ -433,7 +427,7 @@
 					{ref "FeatureOriginalTypeTimedelta"}
 					{ref "FeatureOriginalTypeTokenizableString"}
 					{ref "FeatureOriginalTypeObject"}
-					{ref "FeatureOriginalTypeJSONTypeMap"}
+					{ref "FeatureOriginalTypeContainer"}
 				]
 				description "Original data type details. Used by clients to determine how to serialize and deserialize feature data."
 			)
@@ -603,10 +597,16 @@
 					}
 				}
 			)
-		FeatureOriginalTypeJSONTypeMap
+		FeatureOriginalTypeContainer
 			(assoc
 				type "assoc"
 				indices {
+					data_type {
+						type "string"
+						enum ["container"]
+						required .true
+						description "The data type kind."
+					}
 					type_map {
 						type "assoc"
 						description "The map of original primitive types for JSON features."


### PR DESCRIPTION
* Removes JSONTypeMap as a top-level attribute
* Adds "container" as a unique discriminator to identify columns originally formatted as Python Mappings and Sequences