### PR TITLE
25004: Fixes bug with inactive features with a specified domain would not be synthed

### DIFF
--- a/howso/synthesis.amlg
+++ b/howso/synthesis.amlg
@@ -210,10 +210,14 @@
 
 						;inactive features simply output the one inactive value
 						(if (contains_index !inactiveFeaturesMap feature)
-							;if inactive is a null, only skip it if nulls are allowed (allow_null is either .true or not specified)
-							(if (or
-									(!= (null) (get !inactiveFeaturesMap feature))
-									(!= .false (get feature_bounds_map [feature "allow_null"]))
+							;if inactive is a null, only skip it if the domain isn't explicitly specified and
+							;nulls are allowed (allow_null is either .true or not specified)
+							(if (and
+									(= 0 (size (get feature_bounds_map [feature "allowed"])))
+									(or
+										(!= (null) (get !inactiveFeaturesMap feature))
+										(!= .false (get feature_bounds_map [feature "allow_null"]))
+									)
 								)
 								(seq
 									(assign (assoc


### PR DESCRIPTION
if RL trains a feature with all the same values, it should not be considered inactive for synth purposes because its domain (allowed values) were explicitly provided