### PR TITLE
25057: Adds support for per-feature thresholds with `value_robust_contributions_min_cases`, MINOR

### DIFF
--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -899,6 +899,29 @@
 												;scrap any empty lists/assocs
 												(lambda (size (current_value)))
 												(append
+													(if (contains_index specification "values")
+														(map
+															(lambda
+																(call !SingleTypeCheck (append
+																	(assoc given_value (current_value 1))
+																	(if (~ (assoc) (get specification "values"))
+																		(assoc
+																			specification (get specification "values")
+																			exp_type (contains_index specification ["values" "type"])
+																		)
+
+																		;otherwise, "values" should just be a string
+																		(assoc
+																			specification (assoc)
+																			exp_type (get specification "values")
+																		)
+																	)
+																))
+															)
+															given_value
+														)
+														{}
+													)
 													(if (contains_index specification "indices")
 														(map
 															(lambda

--- a/howso/react_aggregate.amlg
+++ b/howso/react_aggregate.amlg
@@ -136,9 +136,10 @@
 			;The minimum number of samples necessary to report a metric value for a combination of feature values when computing any of the values
 			;details.
 			value_robust_contributions_min_samples 15
-			;{type "number" exclusive_min 0}
+			;{any_of [{type "number" exclusive_min 0} {type "assoc" values "number"}]}
 			;The minimum number of unique cases for a given nominal class or continuous bucket to be used as a possible feature value when collecting
-			;all combinations of feature values in the data to report metrics over. If unspecified, there is no filtering based on number of unique cases.
+			;all combinations of feature values in the data to report metrics over. Can be specified as single value to apply to all features or
+			;an assoc with thresholds defined for each feature (and undefined features will use a threshold of 15). If unspecified, there is no filtering based on number of unique cases.
 			value_robust_contributions_min_cases 15
 			;{type "boolean"}
 			;flag, if true will filter out cases with duplicate values to the case being reacted to.
@@ -254,6 +255,13 @@
 			(call !MultipleFeatureCheck (assoc
 				param_name "feature_influences_action_feature"
 				given_feature_names value_robust_contributions_features
+			))
+		)
+		(if (~ {} value_robust_contributions_min_cases)
+			;if this is an assoc, check that the indices are valid features.
+			(call !MultipleFeatureCheck (assoc
+				param_name "value_robust_contributions_min_cases"
+				given_feature_names (indices value_robust_contributions_min_cases)
 			))
 		)
 

--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -169,15 +169,10 @@
 				)
 		))
 
-		(if (> value_robust_contributions_min_cases 1)
+		(if (or (~ value_robust_contributions_min_cases {}) (> value_robust_contributions_min_cases 1))
 			;helper macro for values details to filter down case_ids and feature_values_lists_map based on marginal mass
 			#!FilterCasesAndValuesByMarginalCounts
 			(seq
-				(declare (assoc
-					;this is a parameter to react_aggregate, should be non-null if this label is called
-					num_required_cases value_robust_contributions_min_cases
-				))
-
 				;define if marginal values are significant enough to continue on with .true if value is significant, .false otherwise
 				(declare (assoc
 					marginal_feature_value_skip_map
@@ -205,7 +200,11 @@
 													)
 												))
 											)
-											num_required_cases
+											(if (~ value_robust_contributions_min_cases {})
+												;if an assoc, get the value for this feature (default to 15 if the feature is missing from the assoc)
+												(or (get value_robust_contributions_min_cases (current_index 1)) 15)
+												value_robust_contributions_min_cases
+											)
 										)
 									)
 									;current value here is a list of unique values (classes or buckets)


### PR DESCRIPTION
Also fixes a "hole" of sorts in the type validation logic where the "values" property of "assoc" typed values was not being verified.