### PR TITLE
25097: Fixes PC value decomposition for nominal action features

### DIFF
--- a/howso/value_contributions.amlg
+++ b/howso/value_contributions.amlg
@@ -373,44 +373,6 @@
 							without_ac_features_action_pair
 								(let
 									(assoc
-										interpolated_value
-											(if compute_pc
-												(call !InterpolateOrDeriveActionValues (assoc
-													feature action_feature
-													output_categorical_action_probabilities .true
-													candidate_cases_lists
-														(if (= 0 (size  react_context_features))
-															[[][][]]
-
-															(compute_on_contained_entities
-																(query_not_in_entity_list [(replace case_id)])
-																(if ignore_null_action_feature (query_not_equals action_feature (null)))
-																(if (size context_condition_filter_query) context_condition_filter_query)
-																dependent_queries_list
-																fanout_features_queries
-																time_series_filter_query
-																(query_nearest_generalized_distance
-																	k_parameter
-																	(replace react_context_features)
-																	(replace (unzip case_values_map react_context_features))
-																	p_parameter
-																	all_feature_weights
-																	!queryDistanceTypeMap
-																	query_feature_attributes_map
-																	feature_deviations
-																	;feature weight rebalancing feature
-																	action_feature
-																	dt_parameter
-																	(if valid_weight_feature weight_feature)
-																	tie_break_random_seed
-																	(null) ;radius
-																	!numericalPrecision
-																	action_feature
-																)
-															)
-														)
-												))
-											)
 										diff
 											(if compute_ac
 												(call !InterpolateAndComputeDiffToCase (assoc
@@ -449,11 +411,56 @@
 											)
 									)
 
+									;clear out categorical_action_probabilities_map for nominals so it can be populated for the P.C. react below
+									(if (and compute_pc feature_is_nominal)
+										(assign (assoc categorical_action_probabilities_map (assoc) ))
+									)
+									(declare (assoc
+										interpolated_value
+											(if compute_pc
+												(call !InterpolateOrDeriveActionValues (assoc
+													feature action_feature
+													output_categorical_action_probabilities .true
+													candidate_cases_lists
+														(if (= 0 (size  react_context_features))
+															[[][][]]
+
+															(compute_on_contained_entities
+																(query_not_in_entity_list [(replace case_id)])
+																(if ignore_null_action_feature (query_not_equals action_feature (null)))
+																(if (size context_condition_filter_query) context_condition_filter_query)
+																dependent_queries_list
+																fanout_features_queries
+																time_series_filter_query
+																(query_nearest_generalized_distance
+																	k_parameter
+																	(replace react_context_features)
+																	(replace (unzip case_values_map react_context_features))
+																	p_parameter
+																	all_feature_weights
+																	!queryDistanceTypeMap
+																	query_feature_attributes_map
+																	feature_deviations
+																	;feature weight rebalancing feature
+																	action_feature
+																	dt_parameter
+																	(if valid_weight_feature weight_feature)
+																	tie_break_random_seed
+																	(null) ;radius
+																	!numericalPrecision
+																	action_feature
+																)
+															)
+														)
+												))
+											)
+									))
+
 									[
 										diff
-										;the original categorical action probability for a nominal is 1-difference
+										;get the original categorical action probability for the nominal
 										(if feature_is_nominal
-											(- 1 diff)
+											(or (get categorical_action_probabilities_map [action_feature (get case_values_map action_feature)] ))
 											;else output the predicted value for continuous
 											interpolated_value
 										)
@@ -498,40 +505,6 @@
 							with_ac_features_action_pair
 								(let
 									(assoc
-										interpolated_value
-											(if compute_pc
-												(call !InterpolateOrDeriveActionValues (assoc
-													feature action_feature
-													output_categorical_action_probabilities .true
-													candidate_cases_lists
-														(compute_on_contained_entities
-															(query_not_in_entity_list [(replace case_id)])
-															(if ignore_null_action_feature (query_not_equals action_feature (null)))
-															(if (size context_condition_filter_query) context_condition_filter_query)
-															dependent_queries_list
-															fanout_features_queries
-															time_series_filter_query
-															(query_nearest_generalized_distance
-																k_parameter
-																(replace react_context_features)
-																(replace (unzip case_values_map react_context_features))
-																p_parameter
-																all_feature_weights
-																!queryDistanceTypeMap
-																query_feature_attributes_map
-																feature_deviations
-																;feature weight rebalancing
-																action_feature
-																dt_parameter
-																(if valid_weight_feature weight_feature)
-																tie_break_random_seed
-																(null) ;radius
-																!numericalPrecision
-																action_feature
-															)
-														)
-												))
-											)
 										diff
 											(if compute_ac
 												(call !InterpolateAndComputeDiffToCase (assoc
@@ -567,11 +540,52 @@
 											)
 									)
 
+									;clear out categorical_action_probabilities_map for nominals so it can be populated for the P.C. react below
+									(if (and compute_pc feature_is_nominal)
+										(assign (assoc categorical_action_probabilities_map (assoc) ))
+									)
+									(declare (assoc
+										interpolated_value
+											(if compute_pc
+												(call !InterpolateOrDeriveActionValues (assoc
+													feature action_feature
+													output_categorical_action_probabilities .true
+													candidate_cases_lists
+														(compute_on_contained_entities
+															(query_not_in_entity_list [(replace case_id)])
+															(if ignore_null_action_feature (query_not_equals action_feature (null)))
+															(if (size context_condition_filter_query) context_condition_filter_query)
+															dependent_queries_list
+															fanout_features_queries
+															time_series_filter_query
+															(query_nearest_generalized_distance
+																k_parameter
+																(replace react_context_features)
+																(replace (unzip case_values_map react_context_features))
+																p_parameter
+																all_feature_weights
+																!queryDistanceTypeMap
+																query_feature_attributes_map
+																feature_deviations
+																;feature weight rebalancing
+																action_feature
+																dt_parameter
+																(if valid_weight_feature weight_feature)
+																tie_break_random_seed
+																(null) ;radius
+																!numericalPrecision
+																action_feature
+															)
+														)
+												))
+											)
+									))
+
 									[
 										diff
-										;the original categorical action probability for a nominal is 1-difference
+										;get the original categorical action probability for the nominal
 										(if feature_is_nominal
-											(- 1 diff)
+											(or (get categorical_action_probabilities_map [action_feature (get case_values_map action_feature)] ))
 											;else output the predicted value for continuous
 											interpolated_value
 										)
@@ -1206,7 +1220,9 @@
 								))
 						))
 
-
+						(if action_feature_is_nominal
+							(assign (assoc categorical_action_probabilities_map (assoc) ))
+						)
 
 						;now predict each of value_robust_contributions_features without action_feature as a context
 						(declare (assoc
@@ -1217,6 +1233,7 @@
 											ac_feature (current_value 1)
 											dependent_queries_list (null)
 											ac_feature_fanout_features_queries (null)
+											categorical_action_probabilities_map (assoc)
 										)
 
 										(if (get ac_feature_is_dependent_map ac_feature)
@@ -1390,6 +1407,7 @@
 											ac_feature (current_value 1)
 											dependent_queries_list (null)
 											ac_feature_fanout_features_queries (null)
+											categorical_action_probabilities_map (assoc)
 										)
 
 										(if (get ac_feature_is_dependent_map ac_feature)


### PR DESCRIPTION
ensures that PC reacts for nominals are using the output from the PC react and not the AC react by separating them into individual define calls and pulling the PC C.A.P. value directly 