### PR TITLE
25140: Adds validation to all derived code attributes

### DIFF
--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -331,56 +331,7 @@
 				(size constraint_referenced_features_map)
 			)
 			(assign (assoc
-				code_errors
-					(filter (map
-						(lambda (if
-							(or
-								(contains_index custom_derived_features_map (current_index))
-								(contains_index constraint_referenced_features_map (current_index))
-								(contains_index post_process_map (current_index))
-							)
-							;it's possible for a feature to have all these attributes defined
-							;check all for each feature and append any errors
-							(filter (append
-								(if (contains_index constraint_referenced_features_map (current_index))
-									(call !ValidateDerivedCodeForFeatures (assoc
-										code (get (current_value 1) ["bounds" "constraint"])
-										feature (current_index 1)
-										attribute_type "'bounds'->'constraint'"
-									))
-								)
-								(if (contains_index post_process_map (current_index))
-									(call !ValidateDerivedCodeForFeatures (assoc
-										code (get (current_value 1) "post_process")
-										feature (current_index 1)
-										attribute_type "'post_process'"
-									))
-								)
-								(if (and
-										(contains_index custom_derived_features_map (current_index))
-										(contains_index (current_value) "derived_feature_code")
-									)
-									(call !ValidateDerivedCodeForFeatures (assoc
-										code (get (current_value 1) "derived_feature_code")
-										feature (current_index 1)
-										attribute_type "'derived_feature_code'"
-									))
-								)
-								(if (and
-										(contains_index custom_derived_features_map (current_index))
-										(contains_index (current_value) "auto_derive_on_train")
-										(get (current_value) ["auto_derive_on_train" "code"])
-									)
-									(call !ValidateDerivedCodeForFeatures (assoc
-										code (get (current_value 1) ["auto_derive_on_train" "code"])
-										feature (current_index 1)
-										attribute_type "'auto_derive_on_train'->'code'"
-									))
-								)
-							))
-						))
-						feature_attributes
-					))
+				code_errors (call !FeatureAttributeCodeValidation)
 			))
 		)
 		(if (size (filter (lambda (size (current_value))) code_errors))

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -313,7 +313,7 @@
 				(call !Return (assoc
 					errors
 						(list (concat
-							"Features must reference their own value for a constraint to be valid. The following have an invalid constraint defined: "
+							"Features must reference their own value for a constraint to be valid. The following features have an invalid constraint defined: "
 							(apply "concat" (weave invalid_constraint_features " "))
 						))
 				))

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -310,14 +310,83 @@
 
 		(if (size invalid_constraint_features)
 			(conclude
-				(call !Return (assoc errors
-					(list (concat
-						"The following features have an invalid constraint defined: "
-						(apply "concat" (weave
-							invalid_constraint_features
-							(range " " 1 (size invalid_constraint_features) 1)
+				(call !Return (assoc
+					errors
+						(list (concat
+							"The following features have an invalid constraint defined: "
+							(apply "concat" (weave
+								invalid_constraint_features
+								(range " " 1 (size invalid_constraint_features) 1)
+							))
 						))
+				))
+			)
+		)
+
+		(declare (assoc code_errors (null) ))
+
+		(if (or
+				(size post_process_map)
+				(size custom_derived_features_map)
+				(size constraint_referenced_features_map)
+			)
+			(assign (assoc
+				code_errors
+					(filter (map
+						(lambda (if
+							(or
+								(contains_index custom_derived_features_map (current_index))
+								(contains_index constraint_referenced_features_map (current_index))
+								(contains_index post_process_map (current_index))
+							)
+							;it's possible for a feature to have all these attributes defined
+							;check all for each feature and append any errors
+							(filter (append
+								(if (contains_index constraint_referenced_features_map (current_index))
+									(call !ValidateDerivedCodeForFeatures (assoc
+										code (get (current_value 1) ["bounds" "constraint"])
+										feature (current_index 1)
+										attribute_type "'bounds'->'constraint'"
+									))
+								)
+								(if (contains_index post_process_map (current_index))
+									(call !ValidateDerivedCodeForFeatures (assoc
+										code (get (current_value 1) "post_process")
+										feature (current_index 1)
+										attribute_type "'post_process'"
+									))
+								)
+								(if (and
+										(contains_index custom_derived_features_map (current_index))
+										(contains_index (current_value) "derived_feature_code")
+									)
+									(call !ValidateDerivedCodeForFeatures (assoc
+										code (get (current_value 1) "derived_feature_code")
+										feature (current_index 1)
+										attribute_type "'derived_feature_code'"
+									))
+								)
+								(if (and
+										(contains_index custom_derived_features_map (current_index))
+										(contains_index (current_value) "auto_derive_on_train")
+										(get (current_value) ["auto_derive_on_train" "code"])
+									)
+									(call !ValidateDerivedCodeForFeatures (assoc
+										code (get (current_value 1) ["auto_derive_on_train" "code"])
+										feature (current_index 1)
+										attribute_type "'auto_derive_on_train'->'code'"
+									))
+								)
+							))
+						))
+						feature_attributes
 					))
+			))
+		)
+		(if (size (filter (lambda (size (current_value))) code_errors))
+			(conclude
+				(call !Return (assoc
+					errors (apply "append" (values code_errors))
 				))
 			)
 		)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -313,11 +313,8 @@
 				(call !Return (assoc
 					errors
 						(list (concat
-							"Features must reference their own value for a constraint to be valid, the following have an invalid constraint defined: "
-							(apply "concat" (weave
-								invalid_constraint_features
-								(range " " 1 (size invalid_constraint_features) 1)
-							))
+							"Features must reference their own value for a constraint to be valid. The following have an invalid constraint defined: "
+							(apply "concat" (weave invalid_constraint_features " "))
 						))
 				))
 			)

--- a/howso/attributes.amlg
+++ b/howso/attributes.amlg
@@ -313,7 +313,7 @@
 				(call !Return (assoc
 					errors
 						(list (concat
-							"The following features have an invalid constraint defined: "
+							"Features must reference their own value for a constraint to be valid, the following have an invalid constraint defined: "
 							(apply "concat" (weave
 								invalid_constraint_features
 								(range " " 1 (size invalid_constraint_features) 1)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -265,6 +265,54 @@
 		)
 
 		(declare (assoc
+			all_valid_features_map
+				(append
+					(call !AllValidFeaturesSet (assoc output_built_ins .true))
+					(zip !trainedFeatures)
+				)
+		))
+		(declare (assoc
+			code_errors
+				(filter (map
+					(lambda
+						(call !ValidateDerivedCodeForFeatures (assoc
+							code (current_value 1)
+							feature (current_index 1)
+							attribute_type "'feature_to_code_map'"
+						))
+					)
+					features_to_code_map
+				))
+		))
+		(if (!= (null) aggregation_code)
+			(let
+				(assoc
+					agg_code_errors
+						(filter {
+							""
+							(call !ValidateDerivedCodeForFeatures (assoc
+								code aggregation_code
+								feature "Error"
+								attribute_type "'aggregation_code'"
+							))
+						})
+				)
+
+				(if (size agg_code_errors)
+					(accum (assoc code_errors agg_code_errors ))
+				)
+			)
+		)
+		(if (size (filter (lambda (size (current_value))) code_errors))
+			(conclude
+				(call !Return (assoc
+					errors (apply "append" (values code_errors))
+				))
+			)
+		)
+
+
+		(declare (assoc
 			has_aggregation (!= (null) aggregation_code)
 			case_ids (call !AllCases)
 		))
@@ -802,7 +850,7 @@
 	;output a set of all valid features that can be used in this dataset by appending all
 	;valid built-in features, specified features from feature_attributes and all possible derived time series features
 	#!AllValidFeaturesSet
-	;!AllValidFeatures
+	;!AllValidFeaturesSet
 	(let
 		(assoc
 			built_ins
@@ -820,6 +868,10 @@
 					".probability_mass"
 					".cluster_id"
 				]
+		)
+
+		(if output_built_ins
+			(conclude (zip built_ins))
 		)
 
 		(declare (assoc

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -818,8 +818,11 @@
 		;accumulate any basic parse errors, such as mismatching parenthesis
 		(declare (assoc
 			errors
-				(zip (last
-					(parse code .false .true)
+				(zip (map
+					(lambda (concat attribute_type " " (current_value)) )
+					(last
+						(parse code .false .true)
+					)
 				))
 		))
 
@@ -834,7 +837,7 @@
 							(unparse (current_value 2))
 							(concat "(call value {feature \"" (current_value) "\"})")
 						)
-						(not (contains_index feature_attributes (current_value)))
+						(not (contains_index all_valid_features_map (current_value)))
 					)
 					(accum (assoc
 						errors (associate (concat attribute_type " references an invalid feature name " (unparse (current_value 2)) " "))
@@ -852,4 +855,143 @@
 			)
 		)
 	)
+
+	;output a set of all valid features that can be used in this dataset by appending all
+	;valid built-in features, specified features from feature_attributes and all possible derived time series features
+	#!AllValidFeaturesSet
+	;!AllValidFeatures
+	(let
+		(assoc
+			built_ins
+				[
+					".reverse_series_index"
+					".time_to_horizon"
+					".synchronous_counter"
+					".series_index"
+					".case_weight"
+					".session"
+					".session_training_index"
+					".imputed"
+					".case_edit_history"
+					".influence_weight_entropy"
+					".probability_mass"
+					".cluster_id"
+				]
+		)
+
+		(declare (assoc
+			ts_features
+				(if (size time_series_feature)
+					(apply "append"
+						(filter (map
+							(lambda
+								(if (contains_index (current_value) "time_series")
+									(let
+										(assoc
+											order (or (get (current_value 1) ["time_series" "order"]) 1)
+											has_rate (= "rate" (get (current_value 1) ["time_series" "type"]))
+											lags
+												(or
+													(get (current_value 1) ["time_series" "lags"])
+													(range
+														1
+														(or (get (current_value 1) ["time_series" "num_lags"]) 1)
+													)
+												)
+											prefix (concat "." (current_index 1) "_")
+										)
+
+										(append
+											(range
+												(lambda (concat prefix "delta_" (current_index)))
+												1 order 1
+											)
+											(if has_rate
+												(range
+													(lambda (concat prefix "rate_" (current_index)))
+													1 order 1
+												)
+												[]
+											)
+											(map
+												(lambda (concat prefix "lag_" (current_value)))
+												lags
+											)
+										)
+									)
+								)
+							)
+							feature_attributes
+						))
+					)
+					;else set to empty list
+					[]
+				)
+		))
+
+		;output the set
+		(zip (append built_ins (indices feature_attributes) ts_features) )
+	)
+
+
+	;helper method to validate all possible derived feature code strings from feature_attributes
+	;outputs an assoc of feature -> list of parse/derive errors, if any are found
+	#!FeatureAttributeCodeValidation
+	;!FeatureAttributeCodeValidation
+	(let
+		(assoc
+			all_valid_features_map (call !AllValidFeaturesSet)
+		)
+
+		(filter (map
+			(lambda (if
+				(or
+					(contains_index custom_derived_features_map (current_index))
+					(contains_index constraint_referenced_features_map (current_index))
+					(contains_index post_process_map (current_index))
+				)
+				;it's possible for a feature to have all these attributes defined
+				;check all for each feature and append any errors
+				(filter (append
+					(if (contains_index constraint_referenced_features_map (current_index))
+						(call !ValidateDerivedCodeForFeatures (assoc
+							code (get (current_value 1) ["bounds" "constraint"])
+							feature (current_index 1)
+							attribute_type "'bounds'->'constraint'"
+						))
+					)
+					(if (contains_index post_process_map (current_index))
+						(call !ValidateDerivedCodeForFeatures (assoc
+							code (get (current_value 1) "post_process")
+							feature (current_index 1)
+							attribute_type "'post_process'"
+						))
+					)
+					(if (and
+							(contains_index custom_derived_features_map (current_index))
+							(contains_index (current_value) "derived_feature_code")
+						)
+						(call !ValidateDerivedCodeForFeatures (assoc
+							code (get (current_value 1) "derived_feature_code")
+							feature (current_index 1)
+							attribute_type "'derived_feature_code'"
+						))
+					)
+					(if (and
+							(contains_index custom_derived_features_map (current_index))
+							(contains_index (current_value) "auto_derive_on_train")
+							(get (current_value) ["auto_derive_on_train" "code"])
+						)
+						(call !ValidateDerivedCodeForFeatures (assoc
+							code (get (current_value 1) ["auto_derive_on_train" "code"])
+							feature (current_index 1)
+							attribute_type "'auto_derive_on_train'->'code'"
+						))
+					)
+				))
+			))
+			feature_attributes
+		))
+	)
+
 )

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -292,7 +292,7 @@
 							""
 							(call !ValidateDerivedCodeForFeatures (assoc
 								code aggregation_code
-								feature "Error"
+								feature (null)
 								attribute_type "'aggregation_code'"
 							))
 						})
@@ -1001,7 +1001,7 @@
 		(assoc
 			code ""
 			attribute_type ""
-			feature ""
+			feature (null)
 		)
 
 		;accumulate any basic parse errors, such as mismatching parenthesis
@@ -1013,6 +1013,7 @@
 						(parse code .false .true)
 					)
 				))
+			feature_str (if feature (concat feature ": ") "")
 		))
 
 		;accumulate any invalid feature references, i.e., typos in feature names or features that are not in the dataset
@@ -1039,7 +1040,7 @@
 		;output accumulated errors
 		(if (size errors)
 			(map
-				(lambda (concat feature ": " (current_value)))
+				(lambda (concat feature_str (current_value)))
 				(indices errors)
 			)
 		)

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -799,63 +799,6 @@
 		)
 	)
 
-
-	;helper method that outputs any parse or invalit feature errors for a specified code string
-	;parameters:
-	; feature: string, name of feature
-	; code: string of custom code to parse and validate
-	; attribute_type: string, the feature attribute for the code string is being validated to add to output to error
-	;				i.e., 'constraint' or 'derived_feature_code' or 'post_process'
-	#!ValidateDerivedCodeForFeatures
-	;!ValidateDerivedCodeForFeatures
-	(declare
-		(assoc
-			code ""
-			attribute_type ""
-			feature ""
-		)
-
-		;accumulate any basic parse errors, such as mismatching parenthesis
-		(declare (assoc
-			errors
-				(zip (map
-					(lambda (concat attribute_type " " (current_value)) )
-					(last
-						(parse code .false .true)
-					)
-				))
-		))
-
-		;accumulate any invalid feature references, i.e., typos in feature names or features that are not in the dataset
-		(rewrite
-			(lambda
-				;if it's a string, check if it's a feature name
-				(if (and
-						(~ "" (current_value))
-						;if node 2 levels up is: (call value {feature "<current_value>"}) then (current_value) is referencing a feature
-						(=
-							(unparse (current_value 2))
-							(concat "(call value {feature \"" (current_value) "\"})")
-						)
-						(not (contains_index all_valid_features_map (current_value)))
-					)
-					(accum (assoc
-						errors (associate (concat attribute_type " references an invalid feature name " (unparse (current_value 2)) " "))
-					))
-				)
-			)
-			(parse code)
-		)
-
-		;output accumulated errors
-		(if (size errors)
-			(map
-				(lambda (concat feature ": " (current_value)))
-				(indices errors)
-			)
-		)
-	)
-
 	;output a set of all valid features that can be used in this dataset by appending all
 	;valid built-in features, specified features from feature_attributes and all possible derived time series features
 	#!AllValidFeaturesSet
@@ -992,6 +935,62 @@
 			))
 			feature_attributes
 		))
+	)
+
+	;helper method that outputs any parse or invalid feature errors for a specified code string
+	;parameters:
+	; feature: string, name of feature
+	; code: string of custom code to parse and validate
+	; attribute_type: string, the feature attribute for the code string is being validated to add to output to error
+	;				i.e., 'constraint' or 'derived_feature_code' or 'post_process'
+	#!ValidateDerivedCodeForFeatures
+	;!ValidateDerivedCodeForFeatures
+	(declare
+		(assoc
+			code ""
+			attribute_type ""
+			feature ""
+		)
+
+		;accumulate any basic parse errors, such as mismatching parenthesis
+		(declare (assoc
+			errors
+				(zip (map
+					(lambda (concat attribute_type " " (current_value)) )
+					(last
+						(parse code .false .true)
+					)
+				))
+		))
+
+		;accumulate any invalid feature references, i.e., typos in feature names or features that are not in the dataset
+		(rewrite
+			(lambda
+				;if it's a string, check if it's a feature name
+				(if (and
+						(~ "" (current_value))
+						;if node 2 levels up is: (call value {feature "<current_value>"}) then (current_value) is referencing a feature
+						(=
+							(unparse (current_value 2))
+							(concat "(call value {feature \"" (current_value) "\"})")
+						)
+						(not (contains_index all_valid_features_map (current_value)))
+					)
+					(accum (assoc
+						errors (associate (concat attribute_type " references an invalid feature name " (unparse (current_value 2)) " "))
+					))
+				)
+			)
+			(parse code)
+		)
+
+		;output accumulated errors
+		(if (size errors)
+			(map
+				(lambda (concat feature ": " (current_value)))
+				(indices errors)
+			)
+		)
 	)
 
 )

--- a/howso/derive_utilities.amlg
+++ b/howso/derive_utilities.amlg
@@ -798,4 +798,58 @@
 			))
 		)
 	)
+
+
+	;helper method that outputs any parse or invalit feature errors for a specified code string
+	;parameters:
+	; feature: string, name of feature
+	; code: string of custom code to parse and validate
+	; attribute_type: string, the feature attribute for the code string is being validated to add to output to error
+	;				i.e., 'constraint' or 'derived_feature_code' or 'post_process'
+	#!ValidateDerivedCodeForFeatures
+	;!ValidateDerivedCodeForFeatures
+	(declare
+		(assoc
+			code ""
+			attribute_type ""
+			feature ""
+		)
+
+		;accumulate any basic parse errors, such as mismatching parenthesis
+		(declare (assoc
+			errors
+				(zip (last
+					(parse code .false .true)
+				))
+		))
+
+		;accumulate any invalid feature references, i.e., typos in feature names or features that are not in the dataset
+		(rewrite
+			(lambda
+				;if it's a string, check if it's a feature name
+				(if (and
+						(~ "" (current_value))
+						;if node 2 levels up is: (call value {feature "<current_value>"}) then (current_value) is referencing a feature
+						(=
+							(unparse (current_value 2))
+							(concat "(call value {feature \"" (current_value) "\"})")
+						)
+						(not (contains_index feature_attributes (current_value)))
+					)
+					(accum (assoc
+						errors (associate (concat attribute_type " references an invalid feature name " (unparse (current_value 2)) " "))
+					))
+				)
+			)
+			(parse code)
+		)
+
+		;output accumulated errors
+		(if (size errors)
+			(map
+				(lambda (concat feature ": " (current_value)))
+				(indices errors)
+			)
+		)
+	)
 )

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -35,7 +35,7 @@
 	(print "Validate invalid constraint: ")
 	(call assert_same (assoc
 		obs (get result (list 1 "detail"))
-		exp "Features must reference their own value for a constraint to be valid, the following have an invalid constraint defined: x "
+		exp "Features must reference their own value for a constraint to be valid. The following have an invalid constraint defined: x "
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -44,12 +44,12 @@
 				"x"
 					(assoc
 						"type" "continuous"
-						"bounds"
-							(assoc
-								"min" 0
-								"max" 300
-								"allow_null" .false
-							)
+						"bounds" { "min" 0 "max" 300 "allow_null" .false }
+					)
+				"y"
+					(assoc
+						"type" "continuous"
+						"bounds" { "min" 0 "max" 300 "allow_null" .false }
 					)
 				"z"
 					(assoc
@@ -204,12 +204,12 @@
 				"x"
 					(assoc
 						"type" "continuous"
-						"bounds"
-							(assoc
-								"min" 0
-								"max" 300
-								"allow_null" .false
-							)
+						"bounds" { "min" 0 "max" 300 "allow_null" .false }
+					)
+				"y"
+					(assoc
+						"type" "continuous"
+						"bounds" { "min" 0 "max" 300 "allow_null" .false }
 					)
 				"z"
 					(assoc

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -35,7 +35,7 @@
 	(print "Validate invalid constraint: ")
 	(call assert_same (assoc
 		obs (get result (list 1 "detail"))
-		exp "The following features have an invalid constraint defined: x "
+		exp "Features must reference their own value for a constraint to be valid, the following have an invalid constraint defined: x "
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -35,7 +35,7 @@
 	(print "Validate invalid constraint: ")
 	(call assert_same (assoc
 		obs (get result (list 1 "detail"))
-		exp "Features must reference their own value for a constraint to be valid. The following have an invalid constraint defined: x "
+		exp "Features must reference their own value for a constraint to be valid. The following features have an invalid constraint defined: x "
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_derive_custom.amlg
+++ b/unit_tests/ut_h_derive_custom.amlg
@@ -35,12 +35,46 @@
         default_hyperparameter_map (assoc "k" 3 "p" 1 "dt" -1)
     ))
 
+	;TEST code parsing validation
+	(assign (assoc
+		result
+			(call_entity "howso" "set_feature_attributes" (assoc
+				feature_attributes
+				(assoc
+					".custom2"
+						{
+							"type" "continuous"
+							;bad opcode
+							"derived_feature_code" "(bad opcode)"
+							;bad feature, mismatching parenthesis
+							"post_process" "(+ .true (call value {feature \"nonexistent\"})"
+							;mismatching parenthesis
+							"bounds" { "min" 0 "max" 10 "constraint" "(!= .true (call value {feature \".custom2\"})"  }
+							"auto_derive_on_train"
+								{
+									"derive_type" "custom"
+									;bad opcode, bad feature, bad parenthesis
+									"code" "(all (call value {feature \"nonexistent\"}) issues"
+								}
+						}
+				)
+			))
+	))
+	(call keep_result_errors)
+	(print "All 7 code parsing errors are caught:\n ")
+	(print result)
+	(call assert_same (assoc
+		obs (size result)
+		;1 for derived_feature_code, 1 for bounds, 2 for post_process and 3 in auto_derive_on_train
+		exp 7
+	))
+
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes
 			(assoc
 				"sender" (assoc "type" "nominal" )
 				"reciever" (assoc "type" "nominal" )
-				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" .true) "derived_feature_code" "(* (call value {feature \"mult\"}) (call value {feature \"number\"})")
+				"time" (assoc "type" "continuous" "bounds" (assoc "min" 900 "max" 4000 "allow_null" .true) "derived_feature_code" "(* (call value {feature \"mult\"}) (call value {feature \"number\"}))")
 				"number" (assoc "type" "continuous" "decimal_places"  0 "bounds" (assoc "min"  5.0 "max"  50 "allow_null" .true))
 				"mult" (assoc "type" "continuous" "derived_feature_code" "(* 10 (call value {feature \"number\"}))")
 				".time_delta"

--- a/unit_tests/ut_h_post_process.amlg
+++ b/unit_tests/ut_h_post_process.amlg
@@ -23,6 +23,29 @@
 		start (system_time)
 	))
 
+	(declare (assoc
+		result
+			(call_entity "howso" "set_feature_attributes" (assoc
+				feature_attributes
+					(assoc
+						"petal_length" (assoc "type" "continuous" "bounds" (assoc max 10.0) "post_process" "(+ (call value {feature \"petal_len\" }) 40.0)")
+						"target"
+							(assoc
+								"type" "nominal"
+								"post_process" "(while .true (% 5 2)"
+							)
+					)
+			))
+	))
+	(call keep_result_errors)
+	(print "Invalid post_process code string error out:\n")
+	(print result)
+	;3 errors:  target has mismatching parenthesis and invalid % opcode, petal_legth references an invalid feature
+	(call assert_same (assoc
+		exp 3
+		obs (size result)
+	))
+
 	(while (and (< num_tries max_tries) (not obs))
 		(call_entity "howso" "set_feature_attributes" (assoc
 			feature_attributes
@@ -41,7 +64,8 @@
 					"target"
 						(assoc
 							"type" "nominal"
-							"post_process" "(while .true (% 5 2))"
+							;should cause infinite loop and output a null
+							"post_process" "(while .true (mod 5 2))"
 						)
 				)
 		))


### PR DESCRIPTION
all feature attributes where custom Amalgam code can be specified is now validated that
a) it parses correctly (to catch invalid opcodes or mismatching parenthesis)
b) references to feature values are valid and don't reference features that aren't in the dataset (to catch feature name typos)