### PR TITLE
25385: Improves validation of conditions for continuous numeric features

### DIFF
--- a/howso/input_validation.amlg
+++ b/howso/input_validation.amlg
@@ -181,8 +181,9 @@
 			)
 	))
 
-	;Validates input maps for conditions (and goal feature maps)
-	;verifies that the indices are either trained features (or built-in features)
+	;Validates input maps for condition maps.
+	;verifies that the indices are either trained features (or built-in features) and continuous numeric features
+	;have valid conditions defined (single value or two-value lists defining legal bounds)
 	;returns .null if no error, string error if input is invalid
 	!ValidateConditionMap
 	(declare
@@ -199,24 +200,81 @@
 		))
 
 		(if (size unknown_features)
+			(conclude
+				(concat
+					"The given map for `" parameter_name "` contains the following undefined features: "
+					(apply "concat" (trunc (weave unknown_features ", ")))
+				)
+			)
+		)
+
+		(if (size !encodingNeededFeaturesSet)
+			(assign (assoc
+				given_map (call !EncodeConditionMap (assoc condition given_map))
+			))
+		)
+
+		(declare (assoc
+			numeric_continuous_conditions_map
+				(filter
+					(lambda
+						(and
+							(not (contains_index !categoricalFeaturesSet (current_index)))
+							(not (contains_index !editDistanceFeatureTypesMap (current_index)))
+						)
+					)
+					given_map
+				)
+		))
+
+		(declare (assoc
+			invalid_continuous_conditions
+				(indices (filter
+					(lambda
+						(if (~ [] (current_value))
+							(or
+								;list conditions are invalid if not of size 2
+								(!= 2 (size (current_value)))
+								;or both bounds are defined and the first is larger than the second.
+								(and
+									(not (contains_value (current_value) .null))
+									(apply ">" (current_value))
+								)
+							)
+						)
+					)
+					numeric_continuous_conditions_map
+				))
+		))
+
+		(if (size invalid_continuous_conditions)
 			(concat
-				"The given map for `" parameter_name "` contains the following undefined features: "
-				(apply "concat" (trunc (weave unknown_features ", ")))
+				"The given map for `" parameter_name "` contains the invalid conditions for the following continuous numeric features: "
+				(apply "concat" (trunc (weave invalid_continuous_conditions ", "))) ". "
+				"Conditions for continuous numeric features must either be a single value or a two-element list defining a lower and upper bound."
 			)
 		)
 	)
 
-	;Macro for validating the `goal_features_map` parameter for labels that accept it
+	;Macro for validating the `goal_features_map` parameter for labels that accept it.
+	;Validation just checks if there are any undefined features
 	!ValidateGoalFeaturesMap
 	(if (size goal_features_map)
 		(let
 			(assoc
 				goal_map_error
-					(call !ValidateConditionMap (assoc
-						given_map goal_features_map
-						parameter_name "goal_features_map"
-					))
+					(let
+						(assoc
+							unknown_features (indices (remove goal_features_map !definedFeatures))
+						)
 
+						(if (size unknown_features)
+							(concat
+								"The given map for `goal_features_map` contains the following undefined features: "
+								(apply "concat" (trunc (weave unknown_features ", ")))
+							)
+						)
+					)
 			)
 
 			(if goal_map_error

--- a/unit_tests/ut_h_input_validation.amlg
+++ b/unit_tests/ut_h_input_validation.amlg
@@ -209,6 +209,42 @@
 	))
 	(call exit_if_failures (assoc msg "Invalid features in condition/goal maps." ))
 
+	(call_entity "howso" "set_feature_attributes" (assoc
+		feature_attributes
+			(assoc
+				"x" (assoc "type" "continuous")
+				"y" (assoc "type" "continuous")
+			)
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "get_cases" (assoc
+				condition {"x" [1 2 3]}
+			))
+	))
+
+	(print "3-element condition for continuous feature errors: ")
+	(call assert_same (assoc
+		obs (first result)
+		exp 0
+	))
+
+	(assign (assoc
+		result
+			(call_entity "howso" "get_cases" (assoc
+				condition {"x" [3 1]}
+			))
+	))
+
+	(print "lower bound > upper bound condition errors: ")
+	(call assert_same (assoc
+		obs (first result)
+		exp 0
+	))
+
+	(call exit_if_failures (assoc msg "Malformed conditions for continuous numeric features." ))
+
 	(call exit_if_failures (assoc msg unit_test_name ))
 )
 

--- a/unit_tests/ut_h_input_validation.amlg
+++ b/unit_tests/ut_h_input_validation.amlg
@@ -229,6 +229,9 @@
 		obs (first result)
 		exp 0
 	))
+	(call assert_true (assoc
+		obs (< 50 (size (get result [1 "detail"])) )
+	))
 
 	(assign (assoc
 		result
@@ -242,7 +245,9 @@
 		obs (first result)
 		exp 0
 	))
-
+	(call assert_true (assoc
+		obs (< 50 (size (get result [1 "detail"])) )
+	))
 	(call exit_if_failures (assoc msg "Malformed conditions for continuous numeric features." ))
 
 	(call exit_if_failures (assoc msg unit_test_name ))


### PR DESCRIPTION
Updates the validation for "condition" parameters to additionally check that continuous numeric features have valid conditions defined. (one value or two element lists defining valid bounds).