### PR TITLE
25441: Fixes stats and feature weights for  features computed by react_into_features

### DIFF
--- a/module/analysis.amlg
+++ b/module/analysis.amlg
@@ -597,6 +597,7 @@
 		(call !UpdateHyperparameters (assoc
 			use_weights .false
 			use_deviations .false
+			features (values (append context_features action_features) .true)
 		))
 
 		(if (= "targetless" targeted_model)

--- a/module/hyperparameters.amlg
+++ b/module/hyperparameters.amlg
@@ -95,7 +95,7 @@
 					;if not using weights, set them to 1, TODO: 24602: sets all featureWeights to .null instead so the defaults can be handled internally
 					(if (= .false use_weights)
 						(assoc
-							"featureWeights" (map 1 (zip !trainedFeatures))
+							"featureWeights" (map 1 (zip features))
 						)
 
 						(assoc)

--- a/module/marginal.amlg
+++ b/module/marginal.amlg
@@ -415,10 +415,22 @@
 			;nominal probabilities and null ratios below
 			(accum_to_entities (assoc
 				!featureMarginalStatsMap
-					(if (= (assoc) !featureMarginalStatsMap)
+					(if (or
+							(= (assoc) !featureMarginalStatsMap)
+							;there are features that were specified that haven't been stored in !featureMarginalStatsMap
+							(size
+								(remove
+									(zip features)
+									(indices (get !featureMarginalStatsMap (if weight_feature weight_feature ".none")))
+								)
+							)
+						)
 						(associate
 							(if weight_feature weight_feature ".none")
-							(call !CalculateMarginalStats (assoc store_stats .false) )
+							(call !CalculateMarginalStats (assoc
+								store_stats .false
+								features features
+							))
 						)
 
 						;else don't accumulate anything because marginal stats are already stored
@@ -765,12 +777,14 @@
 	;parameters:
 	; weight_feature: optional, name of case weight feature
 	; store_stats: optional, flag, default to true. when false will output stats without caching them
+	; features: optional, list of features to compute stats for, if unspecified uses default !trainedFeatures
 	!CalculateMarginalStats
 		(declare
 			(assoc
 				weight_feature .null
 				filtering_queries (list)
 				store_stats .true
+				features !trainedFeatures
 			)
 
 			(declare (assoc
@@ -937,7 +951,7 @@
 								entropy entropy
 							)
 						))
-						(zip !trainedFeatures)
+						(zip features)
 					)
 			))
 


### PR DESCRIPTION
ensures that if analyze is executed with a new/different set of features, those features will have their marginal stats computed and default feature weights specified