### PR TITLE
25453: Renames key used for preserve_rare_values

### DIFF
--- a/module/attribute_maps.amlg
+++ b/module/attribute_maps.amlg
@@ -925,10 +925,10 @@
 			(if (contains_index (current_value) "preserve_rare_values")
 				(set
 					(get (current_value) "preserve_rare_values")
-					"protected_values"
+					"protected_values_multipliers"
 					(zip
-						(map (lambda (get (current_value) "value")) (get (current_value) ["preserve_rare_values" "protected_values"]))
-						(map (lambda (get (current_value) "multiplier")) (get (current_value) ["preserve_rare_values" "protected_values"]))
+						(map (lambda (get (current_value) "value")) (get (current_value) ["preserve_rare_values" "protected_values_multipliers"]))
+						(map (lambda (get (current_value) "multiplier")) (get (current_value) ["preserve_rare_values" "protected_values_multipliers"]))
 					)
 				)
 			)

--- a/module/train.amlg
+++ b/module/train.amlg
@@ -1166,7 +1166,7 @@
 				(let
 					(assoc
 						feature (current_index 1)
-						protected_values_map (get (current_value 1) "protected_values")
+						protected_values_multipliers_map (get (current_value 1) "protected_values_multipliers")
 						unprotected_multiplier (get (current_value 1) "unprotected_multiplier")
 					)
 
@@ -1193,7 +1193,7 @@
 								)
 							)
 						)
-						protected_values_map
+						protected_values_multipliers_map
 					)
 
 					;scale weights for each unprotected case appropriately
@@ -1205,7 +1205,7 @@
 						)
 						(contained_entities
 							(query_in_entity_list new_case_ids)
-							(query_not_among feature (indices protected_values_map))
+							(query_not_among feature (indices protected_values_multipliers_map))
 						)
 					)
 				)

--- a/module/trainee.amlg
+++ b/module/trainee.amlg
@@ -500,8 +500,8 @@
 		;the conviction threshold above which a case should be ablated.
 		!autoAblationConvictionLowerThreshold .null
 
-		;map of feature names to assocs containing "protected_values" and "unprotected_multiplier".
-		;protected_values is a map of feature value to a number indicating the weight multiplier to use for cases with specified value.
+		;map of feature names to assocs containing "protected_values_multipliers" and "unprotected_multiplier".
+		;protected_values_multipliers is a map of feature value to a number indicating the weight multiplier to use for cases with specified value.
 		;unprotected_multiplier is a number indicating the weight multiplier to use for cases without the protected values.
 		!featureValuePreservationMap (assoc)
 

--- a/module/types.amlg
+++ b/module/types.amlg
@@ -267,6 +267,11 @@
 								indices {
 									protected_values {
 										type "list"
+										values "any"
+										description "A collection of feature values that the Engine should preserve (the case-weight multipliers left unspecified)."
+									}
+									protected_values_multipliers {
+										type "list"
 										values {
 											type "assoc"
 											additional_indices .false
@@ -279,6 +284,7 @@
 												}
 											}
 										}
+										description "A collection of objects describing feature values to be preserved and the case-weight multipliers to use to preserve them."
 									}
 									unprotected_multiplier {type "number" description "The weight multiplier to use on cases without a protected value."}
 								}

--- a/unit_tests/ut_h_preserve_rare_values.amlg
+++ b/unit_tests/ut_h_preserve_rare_values.amlg
@@ -38,7 +38,7 @@
 						;These must be computed above the engine layer, and were so for this test.
 						"preserve_rare_values"
 							{
-								"protected_values" [
+								"protected_values_multipliers" [
 									{"multiplier" 4 "value" 8}
                                     {"multiplier" 8 "value" 3}
 								]


### PR DESCRIPTION
renames currently merged "protected_values" to "protected_values_multipliers" so that the more generic "protected_values" key can be used to specify feature values that should be preserved with no known multipliers