### PR TITLE
25641: Improves initial deviation to be less sensitive to outlier max gaps

### DIFF
--- a/module/analysis_weights.amlg
+++ b/module/analysis_weights.amlg
@@ -333,30 +333,32 @@
 								;else normal continuous feature, pull cached max gap
 								(get !cachedFeatureMaxGapMap (current_index 1))
 							)
-						min_gap
-							(if (contains_index !editDistanceFeatureTypesMap (current_index 1))
-								0
-
-								(compute_on_contained_entities
-									(query_min_difference (current_index 1) (get !cyclicFeaturesMap (current_index 1)) )
-								)
-							)
 						;pull from cached marginal stats
 						num_buckets (get !featureMarginalStatsMap [weight_feature (current_index 2) "uniques"])
 						num_values (get !featureMarginalStatsMap [weight_feature (current_index 2) "count"])
+
+						; (range / 2) / num_gaps = ((max - min) / 2) / (num_values - 1)
+						average_half_gap
+							(/
+								(-
+									(get !featureMarginalStatsMap [weight_feature (current_index 2) "max"])
+									(get !featureMarginalStatsMap [weight_feature (current_index 2) "min"])
+								)
+								(* 2 (- (get !featureMarginalStatsMap [weight_feature (current_index 2) "count"]) 1))
+							)
 					)
 
 					;infinity means there was no gap, and nan means all values are null and can't compute gap
-					(if (or (= .null min_gap) (= .infinity min_gap) (= .infinity max_gap))
+					(if (or (= .null max_gap) (= .infinity max_gap))
 						1
 
-						;use the smaller of of max_gap * (1 - 1/num_buckets) or
-						;(average of max_gap/2 and min_gap/2) * sqrt(avg_num_values_per_bucket)
+						;use the smaller of max_gap * (1 - 1/num_buckets) or
+						;(average of average half gap * sqrt(avg_num_values_per_bucket)
 						(min
 							(* max_gap (- 1 (/ 1 num_buckets)) )
 							(*
 								(sqrt (/ num_values num_buckets))
-								(/ (+ (/ max_gap 2) (/ min_gap 2)) 2)
+								average_half_gap
 							)
 						)
 					)

--- a/module/analysis_weights.amlg
+++ b/module/analysis_weights.amlg
@@ -293,80 +293,121 @@
 	)
 
 	!ComputeInitialResiduals
-	(map
-		(lambda
-			;for nominals, random chance of getting a prediction wrong is: 1 - 1/num_classes
-			;set initial value to (1 - 1/num_classes) / 2
-			(if (contains_index !nominalsMap (current_index))
-				(-
-					0.5
-					;pull number of classes for this feature corresponding to the weight_feature being used during this analyze
-					(/ 0.5 (or (size (get !nominalClassProbabilitiesMap [weight_feature (current_index 1)]))) 2)
-				)
-
-				;else continuous values
-				(let
-					(assoc
-						max_gap
-							;edit distance features, use max length: size for strings, or total_size for code
-							(if (contains_index !editDistanceFeatureTypesMap (current_index 1))
-								(let
-									(assoc edit_dist_feature (current_index 2) )
-									(declare (assoc
-										feature_values
-											(filter (map
-												(lambda (retrieve_from_entity (current_value) edit_dist_feature))
-												(call !AllCases)
-											))
-									))
-
-									(if (or
-											(= "string" (get !editDistanceFeatureTypesMap edit_dist_feature))
-											(= "string_mixable" (get !editDistanceFeatureTypesMap edit_dist_feature))
-										)
-										(apply "max" (map (lambda (size (current_value))) feature_values))
-
-										(apply "max" (map (lambda (total_size (current_value))) feature_values))
-									)
-								)
-
-								;else normal continuous feature, pull cached max gap
-								(get !cachedFeatureMaxGapMap (current_index 1))
-							)
-						;pull from cached marginal stats
-						num_buckets (get !featureMarginalStatsMap [weight_feature (current_index 2) "uniques"])
-						num_values (get !featureMarginalStatsMap [weight_feature (current_index 2) "count"])
-
-						; (range / 2) / num_gaps = ((max - min) / 2) / (num_values - 1)
-						average_half_gap
-							(/
+	(let
+		(assoc
+			ranges_map
+				;log of the range of each continuous feature will be used to scale the computed initial deviations
+				;so that initial deviations aren't scaled linearly with ranges, but rather on a log scale.
+				;e.g., if one feature is has a range of 0-10 and another 0-40,
+				;the initial deviations for the second feature won't simply be 4x of those of the first, but rather ln(4) ~1.6x
+				(map
+					(lambda (let
+						(assoc feature (current_index 1))
+						(log
+							(max
 								(-
-									(get !featureMarginalStatsMap [weight_feature (current_index 2) "max"])
-									(get !featureMarginalStatsMap [weight_feature (current_index 2) "min"])
+									(get !featureMarginalStatsMap [weight_feature feature "max"])
+									(get !featureMarginalStatsMap [weight_feature feature "min"])
 								)
-								(* 2 (- (get !featureMarginalStatsMap [weight_feature (current_index 2) "uniques"]) 1))
+								2
 							)
+						)
+					))
+					(remove (zip features) (indices !nominalsMap))
+				)
+		)
+
+		(declare (assoc mean_range (generalized_mean ranges_map) ))
+
+
+		;normalize the computed range logs so that deviations aren't scaled drastically if these values are large
+		(assign (assoc
+			ranges_map
+				(map
+					(lambda (/ (current_value) mean_range))
+					ranges_map
+				)
+		))
+
+		(map
+			(lambda
+				;for nominals, random chance of getting a prediction wrong is: 1 - 1/num_classes
+				;set initial value to (1 - 1/num_classes) / 2
+				(if (contains_index !nominalsMap (current_index))
+					(-
+						0.5
+						;pull number of classes for this feature corresponding to the weight_feature being used during this analyze
+						(/ 0.5 (or (size (get !nominalClassProbabilitiesMap [weight_feature (current_index 1)]))) 2)
 					)
 
-					;infinity means there was no gap, and nan means all values are null and can't compute gap
-					(if (or (= .null max_gap) (= .infinity max_gap))
-						1
+					;else continuous values
+					(let
+						(assoc
+							max_gap
+								;edit distance features, use max length: size for strings, or total_size for code
+								(if (contains_index !editDistanceFeatureTypesMap (current_index 1))
+									(let
+										(assoc edit_dist_feature (current_index 2) )
+										(declare (assoc
+											feature_values
+												(filter (map
+													(lambda (retrieve_from_entity (current_value) edit_dist_feature))
+													(call !AllCases)
+												))
+										))
 
-						;use the smaller of max_gap * (1 - 1/num_buckets) or
-						;(average of average half gap * sqrt(avg_num_values_per_bucket)
-						(min
-							(* max_gap (- 1 (/ 1 num_buckets)) )
-							(*
-								(sqrt (/ num_values num_buckets))
-								average_half_gap
+										(if (or
+												(= "string" (get !editDistanceFeatureTypesMap edit_dist_feature))
+												(= "string_mixable" (get !editDistanceFeatureTypesMap edit_dist_feature))
+											)
+											(apply "max" (map (lambda (size (current_value))) feature_values))
+
+											(apply "max" (map (lambda (total_size (current_value))) feature_values))
+										)
+									)
+
+									;else normal continuous feature, pull cached max gap
+									(get !cachedFeatureMaxGapMap (current_index 1))
+								)
+							;pull from cached marginal stats
+							num_buckets (get !featureMarginalStatsMap [weight_feature (current_index 2) "uniques"])
+							num_values (get !featureMarginalStatsMap [weight_feature (current_index 2) "count"])
+
+							; range  / num_gaps = (max - min)  / (num_values - 1)
+							average_gap
+								(/
+									(-
+										(get !featureMarginalStatsMap [weight_feature (current_index 2) "max"])
+										(get !featureMarginalStatsMap [weight_feature (current_index 2) "min"])
+									)
+									(- (get !featureMarginalStatsMap [weight_feature (current_index 2) "uniques"]) 1)
+								)
+						)
+
+						;infinity means there was no gap, and nan means all values are null and can't compute gap
+						(if (or (= .null max_gap) (= .infinity max_gap))
+							1
+
+							;use the smaller of max_gap * (1 - 1/num_buckets) or
+							;(log range scaled average gap * sqrt(avg_num_values_per_bucket)
+							(min
+								(* max_gap (- 1 (/ 1 num_buckets)) )
+								(/
+									(*
+										(sqrt (/ num_values num_buckets))
+										average_gap
+									)
+									;scale by the normalized range
+									(get ranges_map (current_index))
+								)
 							)
 						)
 					)
 				)
-			)
 
+			)
+			(zip features)
 		)
-		(zip features)
 	)
 
 	;updates analyzed_hp_map

--- a/module/analysis_weights.amlg
+++ b/module/analysis_weights.amlg
@@ -344,7 +344,7 @@
 									(get !featureMarginalStatsMap [weight_feature (current_index 2) "max"])
 									(get !featureMarginalStatsMap [weight_feature (current_index 2) "min"])
 								)
-								(* 2 (- (get !featureMarginalStatsMap [weight_feature (current_index 2) "count"]) 1))
+								(* 2 (- (get !featureMarginalStatsMap [weight_feature (current_index 2) "uniques"]) 1))
 							)
 					)
 

--- a/module/mda_weight.amlg
+++ b/module/mda_weight.amlg
@@ -775,7 +775,7 @@
 
 		;set smallest possible probability assuming the Jeffreys prior approach
 		(declare (assoc
-			smallest_probability (/ 1 (+ 0.5 num_training_cases))
+			smallest_probability (/ 1 (+ 0.5 num_training_cases) (size features))
 
 			;baseline isn't specified, declare it on the stack here
 			baseline_hyperparameter_map hyperparam_map

--- a/module/residuals.amlg
+++ b/module/residuals.amlg
@@ -152,8 +152,8 @@
 							;Using n+1, n+2, or n+.5 are all possible considerations of Laplacian smoothing to apply a Bayesian approach for
 							;estimating the probability of having no incorrect predictions.  We chose .5 assuming the Jeffreys prior approach.
 							(if (current_value)
-								;multiply (current_value) by 2 because (current_value) is the 'half gap' value
-								(/ (* 2 (current_value)) (+ 0.5 num_training_cases))
+								;divide by number of features
+								(/ (* 1 (current_value)) (+ 0.5 num_training_cases) (size feature_half_min_gap_map))
 
 								;else gap is 0, prevent a 0 smallest residual
 								(/ 1 (+ 0.5 num_training_cases))

--- a/unit_tests/ut_h_conviction.amlg
+++ b/unit_tests/ut_h_conviction.amlg
@@ -447,8 +447,8 @@
 			)
 		thresh .025
 	))
-	;check the value for E separately expeted to be between 0.000 and 0.008
-	(call assert_approximate (assoc obs E exp 0.004 thresh .004))
+	;check the value for E separately expeted to be between 0.00 and 0.04
+	(call assert_approximate (assoc obs E exp 0.02 thresh .02))
 	(call exit_if_failures (assoc msg "Analyzing for feature deviations"))
 
 	(print "model is restored to original size after holdouts during analyze: ")

--- a/unit_tests/ut_h_value_contributions.amlg
+++ b/unit_tests/ut_h_value_contributions.amlg
@@ -159,7 +159,7 @@
 		exp (get ac_map ["feature_robust_directional_prediction_contributions" "name" 0])
 		thresh 0.5
 	))
-	(print "both computed and sum of decomposed directional PC are < -0.15: ")
+	(print "both computed and sum of decomposed directional PC are < -0.1: ")
 	(print
 		(get ac_map ["feature_robust_directional_prediction_contributions" "name" 0]) " vs "
 		(apply "+" (get result ["value_robust_contributions" "pc_directional_values"])) " : "
@@ -167,8 +167,8 @@
 	(call assert_true (assoc
 		obs
 			(and
-				(< (get ac_map ["feature_robust_directional_prediction_contributions" "name" 0]) -0.15)
-				(< (apply "+" (get result ["value_robust_contributions" "pc_directional_values"])) -0.15)
+				(< (get ac_map ["feature_robust_directional_prediction_contributions" "name" 0]) -0.1)
+				(< (apply "+" (get result ["value_robust_contributions" "pc_directional_values"])) -0.1)
 			)
 	))
 
@@ -200,7 +200,7 @@
 		exp
 			[
 				["anne" "math"]
-				["fiona" "science"]
+				["bill" "math"]
 			]
 	))
 
@@ -215,17 +215,32 @@
 					["anne" "math"]
 					["anne" "history"]
 					["bill" "math"]
-					["fiona" "math"]
+					["david" "math"]
 					["fiona" "science"]
 				]
 			)
 		exp (range (lambda .true) 1 5 1)
 	))
 
+	(declare (assoc
+		name_subject_values (get result ["value_robust_contributions" "feature_values"])
+	))
+	(declare (assoc
+		anne_math_index
+			(first (filter
+				(lambda (= ["anne" "math"] (get name_subject_values (current_index))))
+				(indices name_subject_values)
+			))
+		fiona_science_index
+			(first (filter
+				(lambda (= ["fiona" "science"] (get name_subject_values (current_index))))
+				(indices name_subject_values)
+			))
+	))
 
 	(print "'Anne + math' and 'Fiona + science' both have high P.C. because they are so extreme: ")
 	(call assert_approximate (assoc
-		obs (trunc (get result ["value_robust_contributions" "pc_values"]) 2)
+		obs (unzip (get result ["value_robust_contributions" "pc_values"]) [anne_math_index fiona_science_index])
 		exp [0.25 0.13125]
 		thresh 0.05
 	))
@@ -234,8 +249,8 @@
 		"'Fiona + science' has very low directional P.C. because she always does so poorly: "
 	)
 	(call assert_approximate (assoc
-		obs (trunc (get result ["value_robust_contributions" "pc_directional_values"]) 2)
-		exp [0.25 -0.1]
+		obs (unzip (get result ["value_robust_contributions" "pc_directional_values"]) [anne_math_index fiona_science_index])
+		exp [0.25 -0.06]
 		thresh 0.05
 	))
 	(call exit_if_failures (assoc msg "A.C. and P.C. for two features."))


### PR DESCRIPTION
updated initial deviation value to be average of half gaps, instead of average of half min and half max gap, which would be overly sensitive if the max gap was significantly large