### PR TITLE
25671: Updates `get_distances` to return sparse distance matrix outputs by default, MAJOR

### DIFF
--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -428,7 +428,7 @@
 		# 		"column_numeric_indices" {
 		# 			type "list"
 		#			values {type "list" values "number"}
-		# 			description "The 2-d list of numeric column indices for the distance entries returned for each row in distances."
+		# 			description "The 2-d list of numeric column indices for the distance entries returned for each row in distances. Only returned for sparse distances."
 		# 		}
 		# 		"row_case_indices" {
 		# 			ref "CaseIndices"
@@ -467,7 +467,7 @@
 			;The number of nearest cases to return distance for if sparse is true. If null, will automatically choose a number based on hyperparameters.
 			#{type "number" min 1}
 			num_nearest_neighbors 20
-			;flag, if true will return a sparse distance matrix. When true, the returned distance matrix will be sparsified,
+			;flag, if true, then the returned distance matrix will be sparsified,
 			;with "distances" being of shape (n, k) where "row_case_indices" will define the case indices for each row and
 			;"column_case_indices" will be a 2d list with the nearest case indices corresponding to each distance defined for each row.
 			#{type "boolean"}
@@ -476,16 +476,14 @@
 			;if sparse is true.
 			#{type "number"}
 			column_offset 0
-			;starting row index of the full matrix of cases for which to compute distances. default value is 0. This parameter is ignored
-			;if sparse is true.
+			;starting row index of the full matrix of cases for which to compute distances. default value is 0.
 			#{type "number"}
 			row_offset 0
 			;number of columns to compute in the matrix.  If unspecified, is set to the same number as all the cases. This parameter is ignored
 			;if sparse is true.
 			#{type "number"}
 			column_count .null
-			;number of rows to compute in the matrix.  If unspecified, is set to the same number as all the cases. This parameter is ignored
-			;if sparse is true.
+			;number of rows to compute in the matrix.  If unspecified, is set to the same number as all the cases.
 			#{type "number"}
 			row_count .null
 		)

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -468,7 +468,7 @@
 			;	case weights will be used if the trainee has them.
 			#{ref "UseCaseWeights"}
 			use_case_weights .null
-			;The number of nearest cases to return distance for if sparse is true. If null, will automatically choose a number based on hyperparameters.
+			;The number of nearest cases to return distance for if sparse is true.
 			#{type "number" min 1}
 			num_nearest_neighbors 20
 			;flag, if true, then the returned distance matrix will be sparsified,

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -444,9 +444,6 @@
 			;which features to use when computing case distances. If unspecified uses all features.
 			#{type "list" values "string"}
 			features .null
-			;if specified, returns case distances of the local data relative to these values, ignores case_indices parameter.
-			#{type "list"}
-			feature_values .null
 			;if specified, uses targeted hyperparameters used to predict this action_feature, otherwise uses targetless hyperparameters.
 			#{type "string"}
 			action_feature .null
@@ -489,20 +486,16 @@
 		)
 		(call !ValidateParameters)
 
-		(declare (assoc
-			error_text
-				(if (and feature_values features (!= (size features) (size feature_values)))
-					"Specified features must be of same length as feature_values."
+		(if (and (!= .null case_indices) (<= (size case_indices) 1) )
+			(conclude (call !Return (assoc
+				errors (list "If providing case_indices, must provide at least 2 cases for computation.")
+			)))
+		)
 
-					(and (!= .null case_indices) (<= (size case_indices) 1) )
-					"If providing case_indices, must provide at least 2 cases for computation."
-				)
+		(declare (assoc
 			;local variables, should not be passed in as a parameter
 			valid_weight_feature .false
 		))
-		(if error_text
-			(conclude (call !Return (assoc errors (list error_text) )) )
-		)
 
 		(if (= .null features)
 			(assign (assoc features !trainedFeatures))
@@ -538,39 +531,7 @@
 			dt_value (get hyperparam_map "dt")
 		))
 
-		(if feature_values
-			;local data of case_ids
-			(assign (assoc
-				case_ids
-					(contained_entities
-						(query_nearest_generalized_distance
-							k_value
-							features
-							(if !hasFeaturesNeedEncodingFromInput
-								(call !ConvertFromInput (assoc
-									feature_values feature_values
-									features features
-								))
-
-								;else use values as-is
-								feature_values
-							)
-							p_value
-							feature_weights
-							!queryFeatureAttributeTypeMap
-							feature_deviations
-							.null
-							dt_value
-							(if valid_weight_feature weight_feature .null)
-							(rand)
-							.null ;radius
-							!numericalPrecision
-						)
-					)
-			))
-
-			;else user specified case_indices
-			(> (size case_indices) 1)
+		(if (> (size case_indices) 1)
 			(assign (assoc
 				case_ids
 					(map
@@ -998,131 +959,4 @@
 		)
 	)
 
-
-	;Returns an assoc with case distances, containing a list of case session indices and a list of lists (matrix) of the computed distances.
-	#{read_only .true idempotent .true}
-	get_distances_sparse
-	(declare
-		#returns {
-		# 	type "assoc"
-		#	additional_indices .false
-		# 	indices {
-		# 		"column_case_indices" {
-		# 			ref "CaseIndices"
-		# 			description "The case indices of the cases represented by the columns of the distance matrix."
-		# 		}
-		# 		"row_case_indices" {
-		# 			ref "CaseIndices"
-		# 			description "The case indices of the cases represented by the columns of the distance matrix."
-		# 		}
-		# 		"distances" {
-		# 			type "list"
-		#			required .true
-		# 			values {
-		# 				type "list"
-		# 				values "number"
-		# 			}
-		# 			description "The case indices of the cases represented by the columns of the distance matrix."
-		# 		}
-		# 	}
-		# }
-		(assoc
-			;which features to use when computing case distances. If unspecified uses all features.
-			#{type "list" values "string"}
-			features .null
-			;if specified, uses targeted hyperparameters used to predict this action_feature, otherwise uses targetless hyperparameters.
-			#{type "string"}
-			action_feature .null
-			;list of pair (list) of session id and index, where index is the original 0-based session_training_index of the case as it was
-			;	trained. If specified, returns pairwise distances for all of these cases. Ignored if feature_values is provided. If neither feature_values nor
-			;	case_indices is specified, runs on the full dataset.
-			#{ref "CaseIndices"}
-			case_indices .null
-			;name of feature whose values to use as case weights
-			#{type "string"}
-			weight_feature ".case_weight"
-			;flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
-			;	case weights will be used if the trainee has them.
-			#{ref "UseCaseWeights"}
-			use_case_weights .null
-		)
-		(call !ValidateParameters)
-
-		(declare (assoc
-			error_text
-				(if (and feature_values features (!= (size features) (size feature_values)))
-					"Specified features must be of same length as feature_values."
-
-					(and (!= .null case_indices) (<= (size case_indices) 1) )
-					"If providing case_indices, must provide at least 2 cases for computation."
-				)
-			;local variables, should not be passed in as a parameter
-			valid_weight_feature .false
-		))
-		(if error_text
-			(conclude (call !Return (assoc errors (list error_text) )) )
-		)
-
-		(if (= .null features)
-			(assign (assoc features !trainedFeatures))
-		)
-
-		;if user doesn't want to use case weights, change weight_feature to '.none'
-		(if (not use_case_weights)
-			(assign (assoc weight_feature ".none"))
-		)
-
-		(declare (assoc
-			hyperparam_map
-				(call !GetHyperparameters (assoc
-					context_features features
-					feature (if action_feature action_feature)
-					weight_feature weight_feature
-				))
-			row_case_ids (list)
-			column_case_ids (list)
-			session_indices_map (assoc)
-			column_case_indices .null
-			row_case_indices .null
-		))
-
-		(call !UpdateCaseWeightParameters)
-
-		(declare (assoc
-			feature_weights (get hyperparam_map "featureWeights")
-			feature_deviations (get hyperparam_map "featureDeviations")
-			p_value (get hyperparam_map "p")
-			k_value (get hyperparam_map "k")
-			dt_value (get hyperparam_map "dt")
-		))
-
-		(if (~ [] k_value)
-			(assign (assoc k_value (last k_value) ))
-		)
-
-		(declare (assoc
-			case_ids
-				(if (> (size case_indices) 1)
-					(map
-						(lambda (let
-							(assoc
-								session (first (current_value 1))
-								case_index (last (current_value 1))
-							)
-
-							;if session_indices_map doesn't have this session, add it
-							(if (not (contains_index session_indices_map session))
-								(accum (assoc session_indices_map (associate session (retrieve_from_entity session ".indices_map")) ))
-							)
-
-							(get session_indices_map (list session case_index))
-						))
-						case_indices
-					)
-
-					;else all cases
-					(call !AllCases)
-				)
-		))
-	)
 }

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -428,7 +428,11 @@
 		# 		"column_numeric_indices" {
 		# 			type "list"
 		#			values {type "list" values "number"}
-		# 			description "The 2-d list of numeric column indices for the distance entries returned for each row in distances. Only returned for sparse distances."
+		# 			description (concat
+		#				"The 2-d list of numeric column indices for the distance entries returned for each row in distances. Only returned for sparse distances. "
+		#				"The returned numeric indices indicate the numeric column index for each nearest case returned for each row, allowing the sparse distances "
+		#				"to be paged and not require the full set of case_indices to be returned before session-index tuples can be resolved to their numeric index in the matrix."
+		#			)
 		# 		}
 		# 		"row_case_indices" {
 		# 			ref "CaseIndices"
@@ -716,6 +720,7 @@
 			))
 		)
 
+		;If case indices were not given, this variable is not populated yet for the case_ids that will be computed
 		(if (not (size case_indices))
 			(assign (assoc
 				case_indices
@@ -729,6 +734,8 @@
 			))
 		)
 
+		;construct maps of case_id -> session-index tuples and
+		;case_id -> numeric index to be used for the column_numeric_indices return value
 		(declare (assoc
 			case_id_to_case_index_map (zip case_ids case_indices)
 			case_id_to_index_map (zip case_ids (indices case_ids))
@@ -744,6 +751,7 @@
 			))
 		)
 
+		;for each case being computed, compute its nearest `num_nearest_neighbors` neighbors among available cases
 		(declare (assoc
 			nearest_case_id_distances_pairs
 				||(map
@@ -779,6 +787,7 @@
 					"distances" (map (lambda (last (current_value))) nearest_case_id_distances_pairs)
 					"row_case_indices" (unzip case_id_to_case_index_map row_case_ids)
 					"column_case_indices"
+						;convert nearest case-ids to their session-index tuples
 						(map
 							(lambda
 								(unzip case_id_to_case_index_map (first (current_value)))
@@ -786,6 +795,7 @@
 							nearest_case_id_distances_pairs
 						)
 					"column_numeric_indices"
+						;convert nearest case-ids to their numeric index (matching that of the row index for each case-id)
 						(map
 							(lambda
 								(unzip case_id_to_index_map (first (current_value)))

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -423,7 +423,10 @@
 		# 	indices {
 		# 		"column_case_indices" {
 		# 			any_of [{ref "CaseIndices"} {type "list" values {ref "CaseIndices"}}]
-		# 			description "The case indices of the cases represented by the columns of the distance matrix."
+		# 			description (concat
+		#				"The case indices of the cases represented by the columns of the distance matrix. This is a 2D list of case indices when "
+		#				"computing sparse distances and 1D list of case indices otherwise."
+		#			)
 		# 		}
 		# 		"column_numeric_indices" {
 		# 			type "list"
@@ -707,11 +710,6 @@
 				(assign (assoc
 					row_case_ids (unzip case_ids (range row_offset (+ row_offset (- row_count 1))))
 				))
-				(if (> (size case_indices) 1)
-					(assign (assoc
-						row_case_indices (unzip case_indices (range row_offset (+ row_offset (- row_count 1))))
-					))
-				)
 			)
 
 			;else iterate over the all of the cases

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -602,12 +602,12 @@
 		(if sparse
 			(call !ComputeSparseGetDistances)
 
-			(call !ComputePagedGetDistances)
+			(call !ComputeDenseGetDistances)
 		)
 	)
 
 	;helper for get_distances when not computing sparse distances
-	!ComputePagedGetDistances
+	!ComputeDenseGetDistances
 	(seq
 		(declare (assoc
 			num_cases (size case_ids)
@@ -724,6 +724,33 @@
 	;helper for get_distances when computing sparse distances
 	!ComputeSparseGetDistances
 	(seq
+		(if (= .null row_count)
+			(assign (assoc row_count num_cases))
+		)
+
+		;if user custom-specified offsets or sizes:
+		(if (or (> row_offset 0) (!= row_count num_cases))
+			(seq
+				;size can't exceed dimension of matrix
+				(assign (assoc
+					row_count (min row_count (- num_cases row_offset))
+				))
+				(assign (assoc
+					row_case_ids (unzip case_ids (range row_offset (+ row_offset (- row_count 1))))
+				))
+				(if (> (size case_indices) 1)
+					(assign (assoc
+						row_case_indices (unzip case_indices (range row_offset (+ row_offset (- row_count 1))))
+					))
+				)
+			)
+
+			;else iterate over the all of the cases
+			(assign (assoc
+				row_case_ids case_ids
+			))
+		)
+
 		(if (not (size case_indices))
 			(assign (assoc
 				case_indices
@@ -741,10 +768,6 @@
 			case_id_to_case_index_map (zip case_ids case_indices)
 		))
 
-		(declare (assoc
-			num_cases (size case_ids)
-		))
-
 		(if (= .null num_nearest_cases)
 			(assign (assoc
 				num_nearest_cases
@@ -760,6 +783,7 @@
 				||(map
 					(lambda
 						(compute_on_contained_entities
+							(query_in_entity_list case_ids)
 							(query_not_in_entity_list [(current_value 1)])
 							(query_nearest_generalized_distance
 								num_nearest_cases
@@ -779,7 +803,7 @@
 							)
 						)
 					)
-					case_ids
+					row_case_ids
 				)
 		))
 
@@ -787,7 +811,7 @@
 			payload
 				(assoc
 					"distances" (map (lambda (last (current_value))) nearest_case_id_distances_pairs)
-					"row_case_indices" case_indices
+					"row_case_indices" (unzip case_id_to_case_index_map row_case_ids)
 					"column_case_indices"
 						(map
 							(lambda

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -422,12 +422,12 @@
 		#	additional_indices .false
 		# 	indices {
 		# 		"column_case_indices" {
-		# 			ref "CaseIndices"
+		# 			any_of [{ref "CaseIndices"} {type "list" values {ref "CaseIndices"}}]
 		# 			description "The case indices of the cases represented by the columns of the distance matrix."
 		# 		}
 		# 		"row_case_indices" {
 		# 			ref "CaseIndices"
-		# 			description "The case indices of the cases represented by the columns of the distance matrix."
+		# 			description "The case indices of the cases represented by the rows of the distance matrix."
 		# 		}
 		# 		"distances" {
 		# 			type "list"
@@ -436,7 +436,7 @@
 		# 				type "list"
 		# 				values "number"
 		# 			}
-		# 			description "The case indices of the cases represented by the columns of the distance matrix."
+		# 			description "The full two-dimensional list of distances."
 		# 		}
 		# 	}
 		# }
@@ -462,16 +462,28 @@
 			;	case weights will be used if the trainee has them.
 			#{ref "UseCaseWeights"}
 			use_case_weights .null
-			;starting column index of the full matrix of cases for which to compute distances. default value is 0
+			;The number of nearest cases to return distance for if sparse is true. If null, will automatically choose a number based on hyperparameters.
+			#{type "number"min 1}
+			num_nearest_cases .null
+			;flag, if true will return a sparse distance matrix. When true, the returned distance matrix will be sparsified,
+			;with "distances" being of shape (n, k) where "row_case_indices" will define the case indices for each row and
+			;"column_case_indices" will be a 2d list with the nearest case indices corresponding to each distance defined for each row.
+			#{type "boolean"}
+			sparse .true
+			;starting column index of the full matrix of cases for which to compute distances. default value is 0. This parameter is ignored
+			;if sparse is true.
 			#{type "number"}
 			column_offset 0
-			;starting row index of the full matrix of cases for which to compute distances. default value is 0
+			;starting row index of the full matrix of cases for which to compute distances. default value is 0. This parameter is ignored
+			;if sparse is true.
 			#{type "number"}
 			row_offset 0
-			;number of columns to compute in the matrix.  If unspecified, is set to the same number as all the cases.
+			;number of columns to compute in the matrix.  If unspecified, is set to the same number as all the cases. This parameter is ignored
+			;if sparse is true.
 			#{type "number"}
 			column_count .null
-			;number of rows to compute in the matrix.  If unspecified, is set to the same number as all the cases.
+			;number of rows to compute in the matrix.  If unspecified, is set to the same number as all the cases. This parameter is ignored
+			;if sparse is true.
 			#{type "number"}
 			row_count .null
 		)
@@ -586,6 +598,17 @@
 			(assign (assoc case_ids (call !AllCases) ))
 		)
 
+		;both of these methods end in the appropriate Return call.
+		(if sparse
+			(call !ComputeSparseGetDistances)
+
+			(call !ComputePagedGetDistances)
+		)
+	)
+
+	;helper for get_distances when not computing sparse distances
+	!ComputePagedGetDistances
+	(seq
 		(declare (assoc
 			num_cases (size case_ids)
 			column_row_are_same .true
@@ -697,6 +720,85 @@
 				)
 		))
 	)
+
+	;helper for get_distances when computing sparse distances
+	!ComputeSparseGetDistances
+	(seq
+		(if (not (size case_indices))
+			(assign (assoc
+				case_indices
+					(map
+						(lambda
+							;pair of: session, session training index
+							(retrieve_from_entity (current_value) (list !internalLabelSession !internalLabelSessionTrainingIndex))
+						)
+						case_ids
+					)
+			))
+		)
+
+		(declare (assoc
+			case_id_to_case_index_map (zip case_ids case_indices)
+		))
+
+		(declare (assoc
+			num_cases (size case_ids)
+		))
+
+		(if (= .null num_nearest_cases)
+			(assign (assoc
+				num_nearest_cases
+					(if (~ [] k_value)
+						(last k_value)
+						k_value
+					)
+			))
+		)
+
+		(declare (assoc
+			nearest_case_id_distances_pairs
+				||(map
+					(lambda
+						(compute_on_contained_entities
+							(query_not_in_entity_list [(current_value 1)])
+							(query_nearest_generalized_distance
+								num_nearest_cases
+								features
+								(retrieve_from_entity (current_value) features)
+								p_value
+								feature_weights
+								!queryFeatureAttributeTypeMap
+								feature_deviations
+								.null
+								(if (= "surprisal_to_prob" dt_value) "surprisal" 1)
+								(if valid_weight_feature weight_feature .null)
+								"fixed rand seed"
+								.null ;radius
+								!numericalPrecision
+								.true
+							)
+						)
+					)
+					case_ids
+				)
+		))
+
+		(call !Return (assoc
+			payload
+				(assoc
+					"distances" (map (lambda (last (current_value))) nearest_case_id_distances_pairs)
+					"row_case_indices" case_indices
+					"column_case_indices"
+						(map
+							(lambda
+								(unzip case_id_to_case_index_map (first (current_value)))
+							)
+							nearest_case_id_distances_pairs
+						)
+				)
+		))
+	)
+
 
 	;given a list of entity ids, determine the minimum distance between
 	; all of those cases. Returns the minimum entity distance.
@@ -870,5 +972,133 @@
 				)
 			)
 		)
+	)
+
+
+	;Returns an assoc with case distances, containing a list of case session indices and a list of lists (matrix) of the computed distances.
+	#{read_only .true idempotent .true}
+	get_distances_sparse
+	(declare
+		#returns {
+		# 	type "assoc"
+		#	additional_indices .false
+		# 	indices {
+		# 		"column_case_indices" {
+		# 			ref "CaseIndices"
+		# 			description "The case indices of the cases represented by the columns of the distance matrix."
+		# 		}
+		# 		"row_case_indices" {
+		# 			ref "CaseIndices"
+		# 			description "The case indices of the cases represented by the columns of the distance matrix."
+		# 		}
+		# 		"distances" {
+		# 			type "list"
+		#			required .true
+		# 			values {
+		# 				type "list"
+		# 				values "number"
+		# 			}
+		# 			description "The case indices of the cases represented by the columns of the distance matrix."
+		# 		}
+		# 	}
+		# }
+		(assoc
+			;which features to use when computing case distances. If unspecified uses all features.
+			#{type "list" values "string"}
+			features .null
+			;if specified, uses targeted hyperparameters used to predict this action_feature, otherwise uses targetless hyperparameters.
+			#{type "string"}
+			action_feature .null
+			;list of pair (list) of session id and index, where index is the original 0-based session_training_index of the case as it was
+			;	trained. If specified, returns pairwise distances for all of these cases. Ignored if feature_values is provided. If neither feature_values nor
+			;	case_indices is specified, runs on the full dataset.
+			#{ref "CaseIndices"}
+			case_indices .null
+			;name of feature whose values to use as case weights
+			#{type "string"}
+			weight_feature ".case_weight"
+			;flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
+			;	case weights will be used if the trainee has them.
+			#{ref "UseCaseWeights"}
+			use_case_weights .null
+		)
+		(call !ValidateParameters)
+
+		(declare (assoc
+			error_text
+				(if (and feature_values features (!= (size features) (size feature_values)))
+					"Specified features must be of same length as feature_values."
+
+					(and (!= .null case_indices) (<= (size case_indices) 1) )
+					"If providing case_indices, must provide at least 2 cases for computation."
+				)
+			;local variables, should not be passed in as a parameter
+			valid_weight_feature .false
+		))
+		(if error_text
+			(conclude (call !Return (assoc errors (list error_text) )) )
+		)
+
+		(if (= .null features)
+			(assign (assoc features !trainedFeatures))
+		)
+
+		;if user doesn't want to use case weights, change weight_feature to '.none'
+		(if (not use_case_weights)
+			(assign (assoc weight_feature ".none"))
+		)
+
+		(declare (assoc
+			hyperparam_map
+				(call !GetHyperparameters (assoc
+					context_features features
+					feature (if action_feature action_feature)
+					weight_feature weight_feature
+				))
+			row_case_ids (list)
+			column_case_ids (list)
+			session_indices_map (assoc)
+			column_case_indices .null
+			row_case_indices .null
+		))
+
+		(call !UpdateCaseWeightParameters)
+
+		(declare (assoc
+			feature_weights (get hyperparam_map "featureWeights")
+			feature_deviations (get hyperparam_map "featureDeviations")
+			p_value (get hyperparam_map "p")
+			k_value (get hyperparam_map "k")
+			dt_value (get hyperparam_map "dt")
+		))
+
+		(if (~ [] k_value)
+			(assign (assoc k_value (last k_value) ))
+		)
+
+		(declare (assoc
+			case_ids
+				(if (> (size case_indices) 1)
+					(map
+						(lambda (let
+							(assoc
+								session (first (current_value 1))
+								case_index (last (current_value 1))
+							)
+
+							;if session_indices_map doesn't have this session, add it
+							(if (not (contains_index session_indices_map session))
+								(accum (assoc session_indices_map (associate session (retrieve_from_entity session ".indices_map")) ))
+							)
+
+							(get session_indices_map (list session case_index))
+						))
+						case_indices
+					)
+
+					;else all cases
+					(call !AllCases)
+				)
+		))
 	)
 }

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -425,6 +425,11 @@
 		# 			any_of [{ref "CaseIndices"} {type "list" values {ref "CaseIndices"}}]
 		# 			description "The case indices of the cases represented by the columns of the distance matrix."
 		# 		}
+		# 		"column_numeric_indices" {
+		# 			type "list"
+		#			values {type "list" values "number"}
+		# 			description "The 2-d list of numeric column indices for the distance entries returned for each row in distances."
+		# 		}
 		# 		"row_case_indices" {
 		# 			ref "CaseIndices"
 		# 			description "The case indices of the cases represented by the rows of the distance matrix."
@@ -460,8 +465,8 @@
 			#{ref "UseCaseWeights"}
 			use_case_weights .null
 			;The number of nearest cases to return distance for if sparse is true. If null, will automatically choose a number based on hyperparameters.
-			#{type "number"min 1}
-			num_nearest_cases .null
+			#{type "number" min 1}
+			num_nearest_neighbors 20
 			;flag, if true will return a sparse distance matrix. When true, the returned distance matrix will be sparsified,
 			;with "distances" being of shape (n, k) where "row_case_indices" will define the case indices for each row and
 			;"column_case_indices" will be a 2d list with the nearest case indices corresponding to each distance defined for each row.
@@ -559,6 +564,8 @@
 			(assign (assoc case_ids (call !AllCases) ))
 		)
 
+		(declare (assoc num_cases (size case_ids) ))
+
 		;both of these methods end in the appropriate Return call.
 		(if sparse
 			(call !ComputeSparseGetDistances)
@@ -571,7 +578,6 @@
 	!ComputeDenseGetDistances
 	(seq
 		(declare (assoc
-			num_cases (size case_ids)
 			column_row_are_same .true
 		))
 
@@ -727,11 +733,12 @@
 
 		(declare (assoc
 			case_id_to_case_index_map (zip case_ids case_indices)
+			case_id_to_index_map (zip case_ids (indices case_ids))
 		))
 
-		(if (= .null num_nearest_cases)
+		(if (= .null num_nearest_neighbors)
 			(assign (assoc
-				num_nearest_cases
+				num_nearest_neighbors
 					(if (~ [] k_value)
 						(last k_value)
 						k_value
@@ -747,7 +754,7 @@
 							(query_in_entity_list case_ids)
 							(query_not_in_entity_list [(current_value 1)])
 							(query_nearest_generalized_distance
-								num_nearest_cases
+								num_nearest_neighbors
 								features
 								(retrieve_from_entity (current_value) features)
 								p_value
@@ -777,6 +784,13 @@
 						(map
 							(lambda
 								(unzip case_id_to_case_index_map (first (current_value)))
+							)
+							nearest_case_id_distances_pairs
+						)
+					"column_numeric_indices"
+						(map
+							(lambda
+								(unzip case_id_to_index_map (first (current_value)))
 							)
 							nearest_case_id_distances_pairs
 						)

--- a/unit_tests/ut_h_pairwise_distances.amlg
+++ b/unit_tests/ut_h_pairwise_distances.amlg
@@ -108,6 +108,7 @@
 				features (list "x")
 				action_feature "y"
 				case_indices (list (list "session" 0) (list "session" 1) (list "session2" 3))
+				sparse .false
 			))
 	))
 	(call keep_result_payload)
@@ -138,6 +139,7 @@
 				features (list "x")
 				action_feature "y"
 				case_indices (list (list "session" 0))
+				sparse .false
 			))
 	))
 	(call keep_result_errors)
@@ -157,6 +159,7 @@
 			(call_entity "howso" "get_distances" (assoc
 				features (list "x" "y")
 				feature_values (list 4.9 4.9)
+				sparse .false
 			))
 	))
 	(call keep_result_payload)
@@ -183,7 +186,7 @@
 
 
 	(assign (assoc
-		result (call_entity "howso" "get_distances" (assoc features (list "x" "y") ))
+		result (call_entity "howso" "get_distances" (assoc features (list "x" "y") sparse .false))
 	))
 	(call keep_result_payload)
 
@@ -234,6 +237,7 @@
 				column_count 5
 				row_offset 6
 				row_count 5
+				sparse .false
 			))
 	))
 	(call keep_result_payload)
@@ -291,6 +295,7 @@
 				column_count 2
 				row_offset 1
 				row_count 3
+				sparse .false
 			))
 	))
 	(call keep_result_payload)

--- a/unit_tests/ut_h_pairwise_distances.amlg
+++ b/unit_tests/ut_h_pairwise_distances.amlg
@@ -199,6 +199,22 @@
 	(print "\n")
 
 	(assign (assoc
+		result (call_entity "howso" "get_distances" (assoc features (list "x" "y") sparse .true num_nearest_neighbors 5))
+	))
+	(call keep_result_payload)
+
+	(print "Each row only has num_nearest_neighbors distances when computing sparse distances: ")
+	(call assert_true (assoc
+		obs (apply "=" (append [5] (map (lambda (size (current_value))) (get result "distances"))))
+	))
+
+	(print "Each row's first distance is 2 (smallest) when computing sparse distances: ")
+	(call assert_true (assoc
+		obs (apply "=" (append [2] (map (lambda (first (current_value))) (get result "distances"))))
+	))
+
+
+	(assign (assoc
 		result
 			(call_entity "howso" "get_distances" (assoc
 				features (list "x" "y")

--- a/unit_tests/ut_h_pairwise_distances.amlg
+++ b/unit_tests/ut_h_pairwise_distances.amlg
@@ -154,36 +154,6 @@
 
 	(call exit_if_failures (assoc msg "Distances with case_indices." ))
 
-	(assign (assoc
-		result
-			(call_entity "howso" "get_distances" (assoc
-				features (list "x" "y")
-				feature_values (list 4.9 4.9)
-				sparse .false
-			))
-	))
-	(call keep_result_payload)
-
-	(print "pairwise distances for feature_values: ")
-	(call assert_same (assoc
-		obs (get result "distances")
-		exp (list
-				(list 0 2 4)
-				(list 2 0 2)
-				(list 4 2 0)
-			)
-	))
-	;nearest 3 neighbors are 4, 5 and 6 (which has index 0 for session2)
-	(call assert_same (assoc
-		obs (get result "column_case_indices")
-		exp (list (list "session" 4) (list "session" 5) (list "session2" 0) )
-	))
-	(call assert_same (assoc
-		obs (get result "row_case_indices")
-		exp (list (list "session" 4) (list "session" 5) (list "session2" 0) )
-	))
-	(print "\n")
-
 
 	(assign (assoc
 		result (call_entity "howso" "get_distances" (assoc features (list "x" "y") sparse .false))


### PR DESCRIPTION
Removes the "feature_values" parameter from get_distances and adds: "num_nearest_neighbors" and "sparse" parameters. The endpoint now returns sparse distances matrices by default.