### PR TITLE
25728: Fixes an issue where computed features may be recomputed after being removed with `remove_feature`

### DIFF
--- a/module/editing.amlg
+++ b/module/editing.amlg
@@ -237,6 +237,37 @@
 						(assign_to_entities (assoc !inactiveFeaturesMap .null ))
 					)
 				)
+
+				;if the feature is one of the computedFeatures that may be recomputed on analyze, remove it from map
+				(if (and
+						!computedFeaturesMap
+						(contains_value (get !computedFeaturesMap "computed_features") feature)
+					)
+					(assign_to_entities (assoc
+						!computedFeaturesMap
+							(if (= 1 (size (get !computedFeaturesMap "computed_features")))
+								;if this was the only computed feature, then clear the map
+								(assoc)
+
+								;else need to just remove this specific feature from the map
+								(append
+									!computedFeaturesMap
+									{
+										"computed_features"
+											(filter
+												(lambda (!= (current_value) feature))
+												(get !computedFeaturesMap "computed_features")
+											)
+										"computed_map"
+											(filter
+												(lambda (!= (current_value) feature))
+												(get !computedFeaturesMap "computed_map")
+											)
+									}
+								)
+							)
+					))
+				)
 			)
 		)
 


### PR DESCRIPTION
This change updates the behavior of `remove_feature` to additionally update the internal !computedFeaturesMap if the removed feature is one of the saved computed features. (Failure to clean this up is what can cause following analyses to recompute the removed feature).