### PR TITLE
25772: Fixes an issue in the datetime format validation of "series_stop_maps" on `react_series`

### DIFF
--- a/module/input_validation.amlg
+++ b/module/input_validation.amlg
@@ -407,13 +407,29 @@
 						(if (contains_index !featureDateTimeMap (current_index))
 							(map
 								(lambda
-									(call !CheckDateTimeFormat (assoc
-										datetime_feature (current_index 2)
-										datetime_string (current_value 1)
-										parameter_name "series_stop_maps"
-									))
+									(if (~ [] (current_value))
+										;if this value is for a stop condition using "values",
+										;each value must be checked individually
+										(map
+											(lambda
+												(call !CheckDateTimeFormat (assoc
+													datetime_feature (current_index 3)
+													datetime_string (current_value 1)
+													parameter_name "series_stop_maps"
+												))
+											)
+											(current_value)
+										)
+
+										;else just check value
+										(call !CheckDateTimeFormat (assoc
+											datetime_feature (current_index 2)
+											datetime_string (current_value 1)
+											parameter_name "series_stop_maps"
+										))
+									)
 								)
-								;individual stop map: (assoc max __ min __)
+								;individual stop map: (assoc max __ min __ values [__ ___ ___])
 								(current_value)
 							)
 						)
@@ -426,9 +442,9 @@
 			(if series_stop_map (list series_stop_map) series_stop_maps)
 		)
 		(if invalid_value_message
-			(conclude (conclude
+			(conclude
 				(call !Return (assoc errors (list invalid_value_message) ))
-			))
+			)
 		)
 	)
 


### PR DESCRIPTION
If using the "values" property of the "series_stop_maps" parameter on `react_series` for a feature using datetime strings, then an empty response would be returned.