### PR TITLE
25811: Adds support for `leave_case_out` with `context_values` for `react`, MINOR

### DIFF
--- a/module/details.amlg
+++ b/module/details.amlg
@@ -162,6 +162,25 @@
 			k_parameter_value (if (~ 0 (get hyperparam_map "k")) (get hyperparam_map "k") (get hyperparam_map ["k" 1]) )
 			local_cases_tuple .null
 			react_feature_deviations .null
+
+			;flag to represent whether computed features defined in the computedFeaturesMap can have their values retrieved for existing cases
+			;rather than computed
+			can_use_computed_feature_values
+				(and
+					;if computing SC for an existing case when it already was computed and stored
+					;from react_into_features with the same parameters, instead just retrieve it
+					existing_case_id
+					;no extra specified constraints
+					(= .null constraints)
+					(=
+						(zip features)
+						(zip (get !computedFeaturesMap "context_features"))
+					)
+					(if use_case_weights
+						(= weight_feature (get !computedFeaturesMap "weight_feature"))
+						(= .null (get !computedFeaturesMap "weight_feature"))
+					)
+				)
 		))
 
 		(if (get hyperparam_map "subtraineeName")
@@ -243,16 +262,28 @@
 				output
 					(assoc
 						"similarity_conviction"
-							(get
-								(call !SimilarityConviction (assoc
-									features features
-									feature_values (unzip case_values_map features)
-									filtering_queries filtering_queries
-									use_case_weights use_case_weights
-									weight_feature weight_feature
-									distance_contribution_feature (get !storedDistanceContributionsFeatureMap (apply "concat" (sort features)))
-								))
-								"similarity_conviction"
+							(if (and
+									;if computing SC for an existing case when it already was computed and stored
+									;from react_into_features with the same parameters, instead just retrieve it
+									can_use_computed_feature_values
+									(contains_index (get !computedFeaturesMap "computed_map") "similarity_conviction")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "similarity_conviction"]) ))
+
+								)
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "similarity_conviction"]) )
+
+								;otherwise compute it
+								(get
+									(call !SimilarityConviction (assoc
+										features features
+										feature_values (unzip case_values_map features)
+										filtering_queries filtering_queries
+										use_case_weights use_case_weights
+										weight_feature weight_feature
+										distance_contribution_feature (get !storedDistanceContributionsFeatureMap (apply "concat" (sort features)))
+									))
+									"similarity_conviction"
+								)
 							)
 					)
 			))
@@ -436,14 +467,24 @@
 				output
 					(assoc
 						"residual_contribution"
-							(call !ResidualContribution (assoc
-								features features
-								feature_values (unzip case_values_map features)
-								use_case_weights use_case_weights
-								weight_feature weight_feature
-								dataset_size dataset_size
-								filtering_queries filtering_queries
-							))
+							(if (and
+									;if computing RC for an existing case when it already was computed and stored
+									;from react_into_features with the same parameters, instead just retrieve it
+									can_use_computed_feature_values
+									(contains_index (get !computedFeaturesMap "computed_map") "residual_contribution")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "residual_contribution"]) ))
+								)
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "residual_contribution"]) )
+
+								(call !ResidualContribution (assoc
+									features features
+									feature_values (unzip case_values_map features)
+									use_case_weights use_case_weights
+									weight_feature weight_feature
+									dataset_size dataset_size
+									filtering_queries filtering_queries
+								))
+							)
 					)
 			))
 		)
@@ -453,23 +494,34 @@
 				output
 					(assoc
 						"distance_contribution"
-							(first
-								(compute_on_contained_entities
-									filtering_queries
-									(query_distance_contributions
-										k_parameter
-										features
-										[(unzip case_values_map features)]
-										p_parameter
-										feature_weights
-										!queryFeatureAttributeTypeMap
-										feature_deviations
-										features
-										(if (= dt_parameter "surprisal_to_prob") "surprisal" dt_parameter )
-										(if use_case_weights weight_feature .null)
-										(rand)
-										.null ;radius
-										!numericalPrecision
+							(if (and
+									;if computing DC for an existing case when it already was computed and stored
+									;from react_into_features with the same parameters, instead just retrieve it
+									can_use_computed_feature_values
+									(contains_index (get !computedFeaturesMap "computed_map") "distance_contribution")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "distance_contribution"]) ))
+								)
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "distance_contribution"]) )
+
+								;otherwise compute it
+								(first
+									(compute_on_contained_entities
+										filtering_queries
+										(query_distance_contributions
+											k_parameter
+											features
+											[(unzip case_values_map features)]
+											p_parameter
+											feature_weights
+											!queryFeatureAttributeTypeMap
+											feature_deviations
+											features
+											(if (= dt_parameter "surprisal_to_prob") "surprisal" dt_parameter )
+											(if use_case_weights weight_feature .null)
+											(rand)
+											.null ;radius
+											!numericalPrecision
+										)
 									)
 								)
 							)

--- a/module/react.amlg
+++ b/module/react.amlg
@@ -360,7 +360,8 @@
 			;list of semi-structured features whose values will be mutated, possibly changing their schema in generative reacts. Ignored in discriminative reacts.
 			#{type "list" values "string"}
 			mutate_schema_features (list)
-			;flag, if set to true and specified along with case_indices, will set ignore_case to the one specified by case_indices.
+			;flag, if set to true and specified along with case_indices, will ignore the case specified by case_indices.
+			;if set to true with no specified case_indices, will ignore the first trained case matching all given context values if any exist.
 			#{type "boolean"}
 			leave_case_out .null
 			;flag, default is true, only applicable if a substitution value map has been set. If set to false, will not substitute categorical feature values.
@@ -788,7 +789,8 @@
 			;	only to discriminative reacts.
 			#{type "boolean"}
 			allow_nulls .false
-			;flag, if set to true and specified along with case_indices, will set ignore_case to the one specified by case_indices.
+			;flag, if set to true and specified along with case_indices, will ignore the case specified by case_indices.
+			;if set to true with no specified case_indices, will ignore the first trained case matching all given context values if any exist.
 			#{type "boolean"}
 			leave_case_out .null
 			;pair (list) of session id and index, where index is the original 0-based session_training_index of the case as it was

--- a/module/react_discriminative.amlg
+++ b/module/react_discriminative.amlg
@@ -30,6 +30,7 @@
 	; preserve_feature_values : optional, list of features that will preserve their values from the case specified by case_indices, appending and
 	;			overwriting the specified context and context features as necessary.
 	; leave_case_out: flag, if set to true and specified along with case_indices, will set ignore_case to the one specified by case_indices
+	;				if set to true with no specified case_indices, will ignore the first trained case matching all given context values if any exist.
 	; impute_react: optional flag, if true will not ignore future data for time series reacts
 	;
 	; return_action_values_only: if set to true and details is not specified, output will be just the raw list of action values
@@ -81,6 +82,48 @@
 			;local variables, should not be passed in as a parameter
 			valid_weight_feature .false
 			existing_case_id .null
+		)
+
+		;if leave_case_out is true and no case indices are specified, then
+		;search for any trained cases with the given contexts.
+		;If one is found, edit the inputs to make the react use the given case instead
+		(if (and leave_case_out (= .null case_indices) (= .null ignore_case))
+			(let
+				(assoc
+					duplicate_cases
+						(contained_entities
+							(values (map
+								(lambda
+									(query_equals (current_index) (current_value))
+								)
+								;context value map. possibly encoded
+								(zip
+									context_features
+									(if (and !hasFeaturesNeedEncodingFromInput (not skip_encoding))
+										(call !ConvertFromInput (assoc
+											feature_values context_values
+											features context_features
+										))
+
+										;else
+										context_values
+									)
+								)
+							))
+						)
+				)
+
+				(if (size duplicate_cases)
+					;if duplicates are found, select the first as the case to react to.
+					(assign (assoc
+						case_indices
+							[
+								(retrieve_from_entity (first duplicate_cases) !internalLabelSession)
+								(retrieve_from_entity (first duplicate_cases) !internalLabelSessionTrainingIndex)
+							]
+					))
+				)
+			)
 		)
 
 		;determine the case to ignore based on specified case_indices and use that cases's values by preserve_feature_values

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -777,6 +777,28 @@
 		auto_ablation_enabled .false
 	))
 
+	(declare (assoc
+		react_to_dupe
+			(get
+				(call_entity "howso" "single_react" (assoc
+					context_features (append context_labels action_labels)
+					context_values (list 4.9 2.5 4.5 1.7 "virginica") ;This is the third case in the dataset
+					details {"influential_cases" .true}
+					leave_case_out .true
+				))
+				(list 1 "payload")
+			)
+	))
+	(print "Reacting to a duplicate case with leave_case_out=True ignores the trained duplicate: ")
+	(call assert_true (assoc
+		obs
+			(!=
+				2 ;Reacting to the third case, the first influential case's index should be 2 if it was not ignored properly
+				(get react_to_dupe ["influential_cases" 0 ".session_training_index"])
+			)
+	))
+
+
 	(print "TIME TO EXECUTE IRIS TEST: " (- (system_time) START) "\n")
 	(call exit_if_failures (assoc msg unit_test_name))
 


### PR DESCRIPTION
This change adds support to the `leave_case_out` parameter of react that allows it to be used with the `context_values` parameter rather than just `case_indices`. When `leave_case_out` is .true without specified `case_indices`, the Engine will ignore one trained case with matching context values if any exist.