### PR TITLE
25830: Adds `contributions_context_features` detail to `react` and updates internal tracking behavior of computed features, MAJOR

### DIFF
--- a/module/analysis.amlg
+++ b/module/analysis.amlg
@@ -499,7 +499,7 @@
 
 		;if there's a !computedFeaturesMap call react_into_features to recompute them,
 		;only if not being called from react_into_features to prevent infinite loop
-		(if (and !computedFeaturesMap (not from_react_into_features))
+		(if (and (get !computedFeaturesMap "analyze") (not from_react_into_features))
 			(call react_into_features (append
 				(get !computedFeaturesMap "computed_map")
 				{
@@ -853,8 +853,8 @@
 			))
 		)
 
-		;if there are computed features (e.g., 'similarity_conviction') append them to context_features
-		(if !computedFeaturesMap
+		;if there are computed features that are to be analyzed (e.g., 'similarity_conviction') append them to context_features
+		(if (get !computedFeaturesMap "analyze")
 			(assign (assoc
 				context_features
 					(append
@@ -907,7 +907,7 @@
 		)
 
 		;This is being called from react_into_features
-		(if (and !computedFeaturesMap from_react_into_features)
+		(if (and (get !computedFeaturesMap "analyze") from_react_into_features)
 			;remove old hyperparameters for this feature set and from paths if they are found
 			(if (= 0 (size !hyperparameterParamPaths))
 				(assign_to_entities (assoc

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -303,7 +303,7 @@
 							"context_features" features
 							"weight_feature" (if use_case_weights weight_feature)
 						)
-					!autoAnalyzeEnabled .true
+					!autoAnalyzeEnabled analyze
 					!queryFeatureAttributeTypeMap (append !queryFeatureAttributeTypeMap (zip (values computed_map) {"difference_type" "continuous" "data_type" "number"}) )
 				))
 

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -281,7 +281,7 @@
 			))
 		)
 
-		(if (and analyze (= .null case_ids))
+		(if (= .null case_ids)
 			(seq
 				(assign_to_entities (assoc
 					!computedFeaturesMap
@@ -299,6 +299,7 @@
 									(modify computed_map "distance_contribution" .false)
 									computed_map
 								)
+							"analyze" analyze
 							"context_features" features
 							"weight_feature" (if use_case_weights weight_feature)
 						)

--- a/module/details.amlg
+++ b/module/details.amlg
@@ -162,10 +162,12 @@
 			k_parameter_value (if (~ 0 (get hyperparam_map "k")) (get hyperparam_map "k") (get hyperparam_map ["k" 1]) )
 			local_cases_tuple .null
 			react_feature_deviations .null
+		))
 
+		(declare (assoc
 			;flag to represent whether computed features defined in the computedFeaturesMap can have their values retrieved for existing cases
 			;rather than computed
-			can_use_computed_feature_values
+			can_use_computed_contribution_values
 				(and
 					;if computing SC for an existing case when it already was computed and stored
 					;from react_into_features with the same parameters, instead just retrieve it
@@ -173,7 +175,10 @@
 					;no extra specified constraints
 					(= .null constraints)
 					(=
-						(zip features)
+						(if (get details "contributions_context_features")
+							(zip (get details "contributions_context_features"))
+							(zip features)
+						)
 						(zip (get !computedFeaturesMap "context_features"))
 					)
 					(if use_case_weights
@@ -265,18 +270,44 @@
 							(if (and
 									;if computing SC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
-									can_use_computed_feature_values
+									can_use_computed_contribution_values
 									(contains_index (get !computedFeaturesMap "computed_map") "similarity_conviction")
 									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "similarity_conviction"]) ))
 
 								)
 								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "similarity_conviction"]) )
 
+								(and
+									;if the case was clustered, then DC and SC were already computed using the context features.
+									;if those context features match what should be used to compute the SC, then pull the previously
+									;computed value
+									(contains_index details "non_clustered_similarity_conviction")
+									(=
+										(zip context_features)
+										(if (get details "contributions_context_features")
+											(zip (get details "contributions_context_features"))
+											(zip features)
+										)
+									)
+								)
+								(get details "non_clustered_similarity_conviction")
+
 								;otherwise compute it
 								(get
 									(call !SimilarityConviction (assoc
-										features features
-										feature_values (unzip case_values_map features)
+										features
+											(if (get details "contributions_context_features")
+												(get details "contributions_context_features")
+												features
+											)
+										feature_values
+											(unzip
+												case_values_map
+												(if (get details "contributions_context_features")
+													(get details "contributions_context_features")
+													features
+												)
+											)
 										filtering_queries filtering_queries
 										use_case_weights use_case_weights
 										weight_feature weight_feature
@@ -470,15 +501,26 @@
 							(if (and
 									;if computing RC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
-									can_use_computed_feature_values
+									can_use_computed_contribution_values
 									(contains_index (get !computedFeaturesMap "computed_map") "residual_contribution")
 									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "residual_contribution"]) ))
 								)
 								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "residual_contribution"]) )
 
 								(call !ResidualContribution (assoc
-									features features
-									feature_values (unzip case_values_map features)
+									features
+										(if (get details "contributions_context_features")
+											(get details "contributions_context_features")
+											features
+										)
+									feature_values
+										(unzip
+											case_values_map
+											(if (get details "contributions_context_features")
+												(get details "contributions_context_features")
+												features
+											)
+										)
 									use_case_weights use_case_weights
 									weight_feature weight_feature
 									dataset_size dataset_size
@@ -497,11 +539,26 @@
 							(if (and
 									;if computing DC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
-									can_use_computed_feature_values
+									can_use_computed_contribution_values
 									(contains_index (get !computedFeaturesMap "computed_map") "distance_contribution")
 									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "distance_contribution"]) ))
 								)
 								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "distance_contribution"]) )
+
+								(and
+									;if the case was clustered, then DC and SC were already computed using the context features.
+									;if those context features match what should be used to compute the DC, then pull the previously
+									;computed value
+									(contains_index details "non_clustered_distance_contribution")
+									(=
+										(zip context_features)
+										(if (get details "contributions_context_features")
+											(zip (get details "contributions_context_features"))
+											(zip features)
+										)
+									)
+								)
+								(get details "non_clustered_distance_contribution")
 
 								;otherwise compute it
 								(first
@@ -509,8 +566,18 @@
 										filtering_queries
 										(query_distance_contributions
 											k_parameter
-											features
-											[(unzip case_values_map features)]
+											;optionally use the given context features, or all the features
+											(if (get details "contributions_context_features")
+												(get details "contributions_context_features")
+												features
+											)
+											[(unzip
+												case_values_map
+												(if (get details "contributions_context_features")
+													(get details "contributions_context_features")
+													features
+												)
+											)]
 											p_parameter
 											feature_weights
 											!queryFeatureAttributeTypeMap
@@ -525,17 +592,6 @@
 									)
 								)
 							)
-					)
-			))
-		)
-
-		;action dc and sc were computed, output them in details
-		(if (contains_index details "non_clustered_distance_contribution")
-			(accum (assoc
-				output
-					(assoc
-						"non_clustered_distance_contribution" (get details "non_clustered_distance_contribution")
-						"non_clustered_similarity_conviction" (get details "non_clustered_similarity_conviction")
 					)
 			))
 		)

--- a/module/editing.amlg
+++ b/module/editing.amlg
@@ -247,7 +247,7 @@
 						!computedFeaturesMap
 							(if (= 1 (size (get !computedFeaturesMap "computed_features")))
 								;if this was the only computed feature, then clear the map
-								(assoc)
+								.null
 
 								;else need to just remove this specific feature from the map
 								(append

--- a/module/react.amlg
+++ b/module/react.amlg
@@ -287,6 +287,10 @@
 			;		 "features" list of features that specifies what features to calculate per-feature details for. (contributions, mda, residuals, etc)
 			; 						when robust computations are False. This should generally preserve compute, but will not when computing details robustly.
 			;
+			;		 "contributions_context_features" list of features that which features should be used as contexts when computing contributions or contribution
+			; 						related details (distance_contribution, similarity_conviction, and residual_contribution). If unspecified, both the given
+			;						context features and the action features of the react call are used.
+			;
 			;		 "generate_attempts" true or false. If true, outputs the total number of attempts to generate the unique case. Only applicable for generative
 			;						reacts. When used with ReactSeries, "series_generate_attempts" is also returned.
 			;

--- a/module/trainee.amlg
+++ b/module/trainee.amlg
@@ -191,6 +191,7 @@
 
 		;map for caching react_into_features parameters used with analyze enabled, allowing use of these reacted features in analyze and inferences,
 		;the following fixed keys store the react_into_features data as specified:
+		;  analyze: boolean, if true then the computed features were analyzed and should be recomputed in future analyses
 		;  computed_features: list of computed features
 		;  computed_map: map of type of computation -> stored feature name
 		;  context_features: list of features used to compute the computed_features

--- a/module/types.amlg
+++ b/module/types.amlg
@@ -1210,6 +1210,18 @@
 										"is not specified."
 									)
 							)
+						contributions_context_features
+							(assoc
+								type "list"
+								values "string"
+								description
+									(concat
+										"A list of feature names that specifies which features will be used as contexts when computing "
+										"contributions or contributions-related details (distance_contribution, similarity_conviction, "
+										"and residual_contribution). If unspecified, both the context features and the action features "
+										"are used."
+									)
+							)
 						feature_deviations
 							(assoc
 								type "boolean"

--- a/unit_tests/ut_h_clustering.amlg
+++ b/unit_tests/ut_h_clustering.amlg
@@ -84,14 +84,6 @@
 		obs (> (get result ["action_values" 0 0]) 0)
 	))
 
-	(print "Outputs non clustered DC and SC in details:")
-	(call assert_not_null (assoc
-		obs (get result ["non_clustered_distance_contribution" 0])
-	))
-	(call assert_not_null (assoc
-		obs (get result ["non_clustered_similarity_conviction" 0])
-	))
-
 	(call exit_if_failures (assoc msg "Predicts case clusters."))
 
 


### PR DESCRIPTION
- Adds `contributions_context_features` detail to `react`, allowing users to specify which features should be used as contexts when computing contributions-related details.
- Removes the automatically added details when predicting cluster_id. But maintains the ability to add them to the response payload for "free" when the details are requested and the feature sets line up as expected.
- Updates the behavior of react_into_features to always track the computed features. This allows react to have the ability to pull computed feature values out of trained cases when applicable, *even when react_into_features was called with analyze=False*