### PR TITLE
25839: Updates `react_into_features` to hold out some of the time-series built-in features from the contexts when `features` is unspecified

### DIFF
--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -1272,7 +1272,7 @@
 					)
 					(if (and !tsTimeFeature (contains_index case_values_map ".series_index"))
 						;if time-series and we have the .series_index of the case, then we can only compute
-						;surprisals for the defined featues (outside of the null triangle)
+						;surprisals for the defined features (outside of the null triangle)
 						(call !FilterContextsBySeriesIndex (assoc
 							all_context_features features
 							series_index (get case_values_map ".series_index")

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -202,7 +202,25 @@
 		)
 
 		(if (= .null features)
-			(assign (assoc features !trainedFeatures))
+			(assign (assoc
+				features
+					(if !tsTimeFeature
+						(filter
+							(lambda
+								;no omniscient built-ins (no built-ins aside from .series_index)
+								(not (contains_value
+									[".reverse_series_index" ".time_to_horizon"
+									".synchronous_counter" ".synchronous_counter_lag_1"]
+									(current_value)
+								))
+							)
+							!trainedFeatures
+						)
+
+						;otherwise all features
+						!trainedFeatures
+					)
+			))
 		)
 
 		;flag set to true if similarity_conviction was requested without distance_contribution
@@ -281,6 +299,20 @@
 			))
 		)
 
+		(declare (assoc
+			hyperparam_map
+				(call !GetHyperparameters (assoc
+					feature .null
+					context_features features
+					weight_feature weight_feature
+				))
+			dataset_size (call !GetNumTrainingCases)
+		))
+
+		;This must be above the belw block that populates
+		;!computedFeaturesMap so the weight_feature key is correct.
+		(call !UpdateCaseWeightParameters)
+
 		(if (= .null case_ids)
 			(seq
 				(assign_to_entities (assoc
@@ -314,18 +346,6 @@
 				))
 			)
 		)
-
-		(declare (assoc
-			hyperparam_map
-				(call !GetHyperparameters (assoc
-					feature .null
-					context_features features
-					weight_feature weight_feature
-				))
-			dataset_size (call !GetNumTrainingCases)
-		))
-
-		(call !UpdateCaseWeightParameters)
 
 		(declare (assoc
 			feature_weights
@@ -892,13 +912,14 @@
 				;was computed and stored into 'case_to_dc_map' earlier in the flow.  This method is being called for each case,
 				;thus if case_id is specified, this is part of computing similarity_conviction on the entire dataset,
 				;and 'case_to_dc_map' already exists, pull distance contribution value from 'case_to_dc_map' instead of computing it
-				(if case_id
+				(if (and case_id (contains_index case_to_dc_map case_id))
 					(get case_to_dc_map case_id)
 
 					;else compute distance contribution for the provided case feature_values
 					(first
 						(compute_on_contained_entities
 							filtering_queries
+							(if case_id (query_not_in_entity_list [case_id]) [])
 							(query_distance_contributions
 								(get hyperparam_map "k")
 								features

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -309,7 +309,7 @@
 			dataset_size (call !GetNumTrainingCases)
 		))
 
-		;This must be above the belw block that populates
+		;This must be above the below block that populates
 		;!computedFeaturesMap so the weight_feature key is correct.
 		(call !UpdateCaseWeightParameters)
 

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -967,7 +967,7 @@
 
 		(declare (assoc
 			local_distance_contributions_map
-				(if case_id
+				(if (and case_id (contains_index case_to_dc_map case_id))
 					(zip local_cases (unzip case_to_dc_map local_cases))
 
 					(or

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -360,7 +360,14 @@
 			;get the min k if using dynamic k
 			k_parameter_value (if (~ 0 (get hyperparam_map "k")) (get hyperparam_map "k") (get hyperparam_map ["k" 1]) )
 			case_to_dc_map .null
+
+			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
+			max_lag_index_value .null
 		))
+		(if ts_feature_lag_amount_map
+			(assign (assoc max_lag_index_value (apply "max" ts_feature_lag_amount_map) ))
+		)
+
 
 		;output a warning when trainee has not been analyzed (using default hyperparameters w/o residuals)
 		(if (and
@@ -1263,7 +1270,16 @@
 							)
 						)
 					)
-					features
+					(if (and !tsTimeFeature (contains_index case_values_map ".series_index"))
+						;if time-series and we have the .series_index of the case, then we can only compute
+						;surprisals for the defined featues (outside of the null triangle)
+						(call !FilterContextsBySeriesIndex (assoc
+							all_context_features features
+							series_index (get case_values_map ".series_index")
+						))
+
+						features
+					)
 				)
 		))
 

--- a/module/details.amlg
+++ b/module/details.amlg
@@ -311,6 +311,7 @@
 										filtering_queries filtering_queries
 										use_case_weights use_case_weights
 										weight_feature weight_feature
+										case_id ignore_case
 										distance_contribution_feature (get !storedDistanceContributionsFeatureMap (apply "concat" (sort features)))
 									))
 									"similarity_conviction"
@@ -525,6 +526,7 @@
 									weight_feature weight_feature
 									dataset_size dataset_size
 									filtering_queries filtering_queries
+									case_id ignore_case
 								))
 							)
 					)
@@ -564,6 +566,7 @@
 								(first
 									(compute_on_contained_entities
 										filtering_queries
+										(if ignore_case (query_not_in_entity_list [ignore_case]) [])
 										(query_distance_contributions
 											k_parameter
 											;optionally use the given context features, or all the features

--- a/module/details.amlg
+++ b/module/details.amlg
@@ -162,7 +162,12 @@
 			k_parameter_value (if (~ 0 (get hyperparam_map "k")) (get hyperparam_map "k") (get hyperparam_map ["k" 1]) )
 			local_cases_tuple .null
 			react_feature_deviations .null
+			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
+			max_lag_index_value .null
 		))
+		(if ts_feature_lag_amount_map
+			(assign (assoc max_lag_index_value (apply "max" ts_feature_lag_amount_map) ))
+		)
 
 		(declare (assoc
 			;flag to represent whether computed features defined in the computedFeaturesMap can have their values retrieved for existing cases

--- a/module/react_group.amlg
+++ b/module/react_group.amlg
@@ -322,7 +322,12 @@
 				)
 			feature_deviations (get hyperparam_map "featureDeviations")
 			closest_k (get hyperparam_map "k")
+			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
+			max_lag_index_value .null
 		))
+		(if ts_feature_lag_amount_map
+			(assign (assoc max_lag_index_value (apply "max" ts_feature_lag_amount_map) ))
+		)
 
 		;closest k must be at least 2 smaller than dataset size, i.e., a dataset of 5 needs a K of 3 or less:
 		;when knocking out a case during conviction calculations, each remaining case searches for K cases around itself


### PR DESCRIPTION
Also patches up some logic about reacting to existing cases for some `react` details.