### PR TITLE
25868: Renames internal paramaters for consistency, adds . to all internally computed features, MAJOR

### DIFF
--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -30,5 +30,33 @@
 				))
 		))
 	)
+"119.0.0"
+	(seq
+		;renames of internal parameters
+		(assign_to_entities (assoc
+
+			!dataParametersPaths (get import_metadata_map "!hyperparameterParamPaths")
+			!defaultDataParametersMap (get import_metadata_map "!defaultHyperparameters")
+
+			;replace any 'featureMdaMap' indices with 'featureProbabilitiesMap' by
+			; a) inserting a copy of 'featureMdaMap' as 'featureProbabilitiesMap'
+			; b) then removing the 'featureMdaMap' index
+			!dataParametersMap
+				(rewrite
+					(lambda
+						(if (contains_index (current_value) "featureMdaMap")
+							(remove
+								;insert a copy of featureMdaMap as featureProbabilitiesMap
+								(modify (current_value) "featureProbabilitiesMap" (get (current_value) "featureMdaMap"))
+								;remove featureMdaMap
+								"featureMdaMap"
+							)
+							(current_value)
+						)
+					)
+					(get import_metadata_map "!hyperparameterMetadataMap")
+				)
+		))
+	)
 
 ))

--- a/migrations/migrations.amlg
+++ b/migrations/migrations.amlg
@@ -36,7 +36,6 @@
 		(assign_to_entities (assoc
 
 			!dataParametersPaths (get import_metadata_map "!hyperparameterParamPaths")
-			!defaultDataParametersMap (get import_metadata_map "!defaultHyperparameters")
 
 			;replace any 'featureMdaMap' indices with 'featureProbabilitiesMap' by
 			; a) inserting a copy of 'featureMdaMap' as 'featureProbabilitiesMap'
@@ -55,6 +54,21 @@
 						)
 					)
 					(get import_metadata_map "!hyperparameterMetadataMap")
+				)
+			!defaultDataParametersMap
+				(rewrite
+					(lambda
+						(if (contains_index (current_value) "featureMdaMap")
+							(remove
+								;insert a copy of featureMdaMap as featureProbabilitiesMap
+								(modify (current_value) "featureProbabilitiesMap" (get (current_value) "featureMdaMap"))
+								;remove featureMdaMap
+								"featureMdaMap"
+							)
+							(current_value)
+						)
+					)
+					(get import_metadata_map "!defaultHyperparameters")
 				)
 		))
 	)

--- a/module/ablation.amlg
+++ b/module/ablation.amlg
@@ -656,7 +656,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map (call !GetHyperparameters (assoc weight_feature distribute_weight_feature))
+			hyperparam_map (call !GetDataParameters (assoc weight_feature distribute_weight_feature))
 		))
 
 		(declare (assoc

--- a/module/ablation.amlg
+++ b/module/ablation.amlg
@@ -656,15 +656,15 @@
 		)
 
 		(declare (assoc
-			hyperparam_map (call !GetDataParameters (assoc weight_feature distribute_weight_feature))
+			data_params_map (call !GetDataParameters (assoc weight_feature distribute_weight_feature))
 		))
 
 		(declare (assoc
-			k_parameter (get hyperparam_map "k")
-			p_parameter (get hyperparam_map "p")
-			feature_weights (get hyperparam_map "featureWeights")
-			dt_parameter (get hyperparam_map "dt")
-			feature_deviations (get hyperparam_map "featureDeviations")
+			k_parameter (get data_params_map "k")
+			p_parameter (get data_params_map "p")
+			feature_weights (get data_params_map "featureWeights")
+			dt_parameter (get data_params_map "dt")
+			feature_deviations (get data_params_map "featureDeviations")
 
 			all_case_ids (call !AllCases)
 			done .false

--- a/module/analysis.amlg
+++ b/module/analysis.amlg
@@ -1,4 +1,4 @@
-;Contains methods for hyperparameter analysis and feature deviation and weights calculations.
+;Contains methods for dataset parameter analysis and feature deviation and weights calculations.
 {
 	;automatically analyze the dataset using stored parameters from previous analyze calls
 	#{long_running .true statistically_idempotent .true}
@@ -58,9 +58,9 @@
 			#{type "list" values ["number" "string"]}
 			dt_values .null
 			;enumeration, default is "single_targeted"
-			;   "single_targeted" = analyze hyperparameters for the specified action_features
-			;   "omni_targeted" = analyze hyperparameters for each action feature, using all other features as context_features. if action_features aren't specified, uses all context_features.
-			;   "targetless" = analyze hyperparameters for all context features as possible action features, ignores action_features parameter
+			;   "single_targeted" = analyze dataset parameters for the specified action_features
+			;   "omni_targeted" = analyze dataset parameters for each action feature, using all other features as context_features. if action_features aren't specified, uses all context_features.
+			;   "targetless" = analyze dataset parameters for all context features as possible action features, ignores action_features parameter
 			#{type "string" enum ["single_targeted" "omni_targeted" "targetless"]}
 			targeted_model "single_targeted"
 			;name of feature whose values to use as case weights
@@ -159,14 +159,14 @@
 			)
 		)
 
-		;if this is a time series Trainee, there are no targetless hyperparameters,
+		;if this is a time series Trainee, there are no targetless dataset parameters,
 		; and this analyze is targeted, emit a warning to the user that recommends
 		; a targeted analyze
 		(if (and
 				(!= .null !tsTimeFeature)
 				(=
 					0
-					;the number of saved hyperparameter maps that are targetless
+					;the number of saved dataset parameter maps that are targetless
 					(size (filter (lambda (= "targetless" (first (current_value))) ) !dataParametersPaths))
 				)
 				(!= targeted_model "targetless")
@@ -248,7 +248,7 @@
 										;default the num_samples to 1000
 										num_samples num_deviation_samples
 										robust_residuals .false
-										;use the specific action feature's hyperparameters
+										;use the specific action feature's dataset parameters
 										hyperparameter_feature (current_value 2)
 										weight_feature weight_feature
 										use_case_weights use_case_weights
@@ -261,7 +261,7 @@
 								;updating default hyperparam set with featuredeviations
 								(assign_to_entities (assoc !defaultDataParametersMap hyperparam_map) )
 
-								;update the appropriate hyperparameter set
+								;update the appropriate dataset parameter set
 								(assign_to_entities (assoc !dataParametersMap (modify !dataParametersMap (get hyperparam_map "paramPath") hyperparam_map)) )
 							)
 						)
@@ -368,7 +368,7 @@
 
 		(if (!= "omni_targeted" targeted_model)
 			(if (or (= "targetless" targeted_model) (= 1 (size action_features)))
-				(call !AnalyzeHyperparameters (assoc
+				(call !AnalyzeDataParameters (assoc
 					targeted_model targeted_model
 					context_features context_features
 					action_feature (if (!= "targetless" targeted_model) (first action_features))
@@ -385,7 +385,7 @@
 							action_feature (current_value 1)
 						)
 
-						(call !AnalyzeHyperparameters (assoc
+						(call !AnalyzeDataParameters (assoc
 							targeted_model "single_targeted"
 							context_features accumulated_context_features
 							action_feature action_feature
@@ -407,7 +407,7 @@
 						action_feature (current_value 1)
 					)
 
-					(call !AnalyzeHyperparameters (assoc
+					(call !AnalyzeDataParameters (assoc
 						targeted_model "single_targeted"
 						context_features filtered_context_features
 						action_feature action_feature
@@ -493,7 +493,7 @@
 
 		(if (and !tsTimeFeature !tsTimeFeatureUniversal)
 			(call !UpdateMinimumTimeBound (assoc
-				hyperparam_map (call !GetHyperparameters (assoc feature .null ))
+				hyperparam_map (call !GetDataParameters (assoc feature .null ))
 			))
 		)
 
@@ -527,7 +527,7 @@
 
 				(declare  (assoc
 					hyperparam_map
-						(call !GetHyperparameters (assoc
+						(call !GetDataParameters (assoc
 							context_features features
 							weight_feature weight_feature
 						))
@@ -558,15 +558,15 @@
 
 	;called on none or one action feature at a time by Analyze()
 	; targeted_model: enumeration, default is "single_targeted"
-	;   "single_targeted" = analyze hyperparameters for the specified action_features
-	;   "targetless" = analyze hyperparameters for all context features as possible action features, ignores action_features parameter
+	;   "single_targeted" = analyze dataset parameters for the specified action_features
+	;   "targetless" = analyze dataset parameters for all context features as possible action features, ignores action_features parameter
 	; context_features: list of context features to analyze for
 	; action_features: list of action features to analyze for
 	; num_analysis_samples: optional. number of cases to sample during analysis. only applies for k_folds = 1
 	; num_deviation_samples: optional. initial number of samples to use for computing residuals
-	; derived_auto_analyzed: optional, if true, will set the 'derivedAutoAnalyzed' parameter to true in the hyperparameter set,
+	; derived_auto_analyzed: optional, if true, will set the 'derivedAutoAnalyzed' parameter to true in the dataset parameter set,
 	;			denoting that these parameters were auto-analyzed during derive features flow.
-	!AnalyzeHyperparameters
+	!AnalyzeDataParameters
 	(declare
 		(assoc
 			targeted_model "targetless"
@@ -627,7 +627,7 @@
 			}
 		))
 
-		(call !UpdateHyperparameters (assoc
+		(call !UpdateDataParameters (assoc
 			use_weights .false
 			use_deviations .false
 			features (values (append context_features action_features) .true)
@@ -644,7 +644,7 @@
 					(call !StoreResidualSubTrainee (assoc custom_hyperparam_map baseline_hyperparameter_map) )
 				)
 
-				(call !SetHyperparameters)
+				(call !SetDataParameters)
 			))
 		)
 
@@ -652,14 +652,14 @@
 
 		(call !ProgressUpdate (assoc details "Analysis: Computing feature weights"))
 		(call !ComputeAndUseWeights)
-		(call !TestAccuracyAndKeepOrRevertHyperparameters)  ;w or w/o weights
+		(call !TestAccuracyAndKeepOrRevertDataParameters)  ;w or w/o weights
 
-		(if (= .false use_deviations) (conclude (call !SetHyperparameters)) )
+		(if (= .false use_deviations) (conclude (call !SetDataParameters)) )
 
 		(declare (assoc non_deviation_hp_map baseline_hyperparameter_map))
 
 		;deviations, no weights
-		(call !UpdateHyperparameters (assoc
+		(call !UpdateDataParameters (assoc
 			use_weights .false
 			use_deviations .true
 			feature_deviations (call !ComputeInitialDeviations)
@@ -672,9 +672,9 @@
 		;now with weights
 		(call !ProgressUpdate (assoc details "Analysis: Computing feature weights with deviations"))
 		(call !ComputeAndUseWeights)
-		(call !TestAccuracyAndKeepOrRevertHyperparameters) ;deviations w or w/o weights
+		(call !TestAccuracyAndKeepOrRevertDataParameters) ;deviations w or w/o weights
 
-		;if use of deviations should be auto determined, do that here, compare to non_deviation hyperparameters
+		;if use of deviations should be auto determined, do that here, compare to non_deviation dataset parameters
 		;and revert if to non-deviation if those were as good or better
 		(if (= .null use_deviations)
 			(if (<= (get non_deviation_hp_map "gridSearchError") (get baseline_hyperparameter_map "gridSearchError"))
@@ -700,7 +700,7 @@
 			(call !StoreResidualSubTrainee (assoc custom_hyperparam_map baseline_hyperparameter_map) )
 		)
 
-		(call !SetHyperparameters)
+		(call !SetDataParameters)
 	)
 
 	;helper method for Analyze that stores a subtrainee of case residuals for each feature
@@ -709,7 +709,7 @@
 	;	num_samples: the number of cases to put in the residual subtrainee, default 500
 	;assigns to:
 	;	deviation_subtrainee_name: this variable will store the name of the subtrainee, this name should be stored in the
-	;					resulting hyperparameter assoc under the key "subtraineeName"
+	;					resulting dataset parameter assoc under the key "subtraineeName"
 	!StoreResidualSubTrainee
 	(declare
 		(assoc
@@ -908,7 +908,7 @@
 
 		;This is being called from react_into_features
 		(if (and (get !computedFeaturesMap "analyze") from_react_into_features)
-			;remove old hyperparameters for this feature set and from paths if they are found
+			;remove old dataset parameters for this feature set and from paths if they are found
 			(if (= 0 (size !dataParametersPaths))
 				(assign_to_entities (assoc
 					!dataParametersMap { }
@@ -974,7 +974,7 @@
 			baseline_hyperparameter_map (modify (retrieve_from_entity "!defaultDataParametersMap"))
 		))
 
-		;if using default targetless hyperparameters, set p to 1 as the starting p value and k as dynamic with 0.05 cutoff
+		;if using default targetless dataset parameters, set p to 1 as the starting p value and k as dynamic with 0.05 cutoff
 		(if (and
 				(= "targetless" targeted_model)
 				(= [".default"] (get baseline_hyperparameter_map "paramPath"))
@@ -990,7 +990,7 @@
 			))
 		)
 
-		;store the paramPath for this hyperparameter set so it has a reference to where it's stored in !dataParametersMap
+		;store the paramPath for this dataset parameter set so it has a reference to where it's stored in !dataParametersMap
 		(accum (assoc
 			baseline_hyperparameter_map
 				(assoc
@@ -1078,7 +1078,7 @@
 	)
 
 	;updates baseline_hyperparameter_map
-	;wrapper method to grid searches hyperparameters and backs up the results into previous_analyzed_hp_map
+	;wrapper method to grid searches dataset parameters and backs up the results into previous_analyzed_hp_map
 	!GridSearch
 	(seq
 		(set_rand_seed sampling_random_seed)
@@ -1095,11 +1095,11 @@
 					baseline_hyperparameter_map baseline_hyperparameter_map
 				))
 		))
-		(call !BackupAnalyzedHyperparameters)
+		(call !BackupAnalyzedDataParameters)
 	)
 
-	;autotunes the dataset to use the 'best' hyperparameters using grid-search (with optional k-fold cross validation)
-	;outputs updated hyperparameter map
+	;autotunes the dataset to use the 'best' dataset parameters using grid-search (with optional k-fold cross validation)
+	;outputs updated dataset parameter map
 	;parameters:
 	; context_features: list of context features
 	; action_features: list of action features for action inputs
@@ -1114,7 +1114,7 @@
 	; p_param_categorical_mean : optional parameter to specify the lp space for calculating the mean of Mean Absolute Errors for categorical features
 	; p_param_accuracy_mean : optional parameter to specify the lp space for calculating the mean of Mean Absolute Errors among all features
 	; num_analysis_samples : optional. number of cases to sample during analysis. only applies for k_folds = 1
-	; baseline_hyperparameter_map : the base hyperparameters to use for computation
+	; baseline_hyperparameter_map : the base dataset parameters to use for computation
 	!ComputeResidualsAcrossParametersAndSelectOptimal
 	(declare
 		(assoc
@@ -1142,7 +1142,7 @@
 					(= context_features action_features)
 				)
 			)
-			;return valid existing hyperparameters
+			;return valid existing dataset parameters
 			(conclude baseline_hyperparameter_map)
 		)
 
@@ -1223,7 +1223,7 @@
 			(call !AccumulateErrorsViaKFoldsGridSearch)
 		)
 
-		;convert the list of distances for each hyperparameter tuple into an avg distance
+		;convert the list of distances for each dataset parameter tuple into an avg distance
 		;and while iterating store the best (smallest) distance and corresponding key
 		(assign (assoc
 			accumulated_results_map

--- a/module/analysis.amlg
+++ b/module/analysis.amlg
@@ -167,7 +167,7 @@
 				(=
 					0
 					;the number of saved hyperparameter maps that are targetless
-					(size (filter (lambda (= "targetless" (first (current_value))) ) !hyperparameterParamPaths))
+					(size (filter (lambda (= "targetless" (first (current_value))) ) !dataParametersPaths))
 				)
 				(!= targeted_model "targetless")
 			)
@@ -259,10 +259,10 @@
 
 							(if (= (first (get hyperparam_map "paramPath")) ".default")
 								;updating default hyperparam set with featuredeviations
-								(assign_to_entities (assoc !defaultHyperparameters hyperparam_map) )
+								(assign_to_entities (assoc !defaultDataParametersMap hyperparam_map) )
 
 								;update the appropriate hyperparameter set
-								(assign_to_entities (assoc !hyperparameterMetadataMap (modify !hyperparameterMetadataMap (get hyperparam_map "paramPath") hyperparam_map)) )
+								(assign_to_entities (assoc !dataParametersMap (modify !dataParametersMap (get hyperparam_map "paramPath") hyperparam_map)) )
 							)
 						)
 					)
@@ -909,10 +909,10 @@
 		;This is being called from react_into_features
 		(if (and (get !computedFeaturesMap "analyze") from_react_into_features)
 			;remove old hyperparameters for this feature set and from paths if they are found
-			(if (= 0 (size !hyperparameterParamPaths))
+			(if (= 0 (size !dataParametersPaths))
 				(assign_to_entities (assoc
-					!hyperparameterMetadataMap { }
-					!hyperparameterParamPaths []
+					!dataParametersMap { }
+					!dataParametersPaths []
 				))
 
 				(let
@@ -927,14 +927,14 @@
 								weight_feature
 							)
 					))
-					(if (contains_value !hyperparameterParamPaths orig_context_path)
+					(if (contains_value !dataParametersPaths orig_context_path)
 						(let
 							(assoc
 								;remove the case weight keyed parameters
 								cleaned_hp_map
-									(modify !hyperparameterMetadataMap (trunc orig_context_path)
+									(modify !dataParametersMap (trunc orig_context_path)
 										(remove
-											(get !hyperparameterMetadataMap (trunc orig_context_path))
+											(get !dataParametersMap (trunc orig_context_path))
 											(last orig_context_path)
 										)
 									)
@@ -961,8 +961,8 @@
 							)
 
 							(assign_to_entities (assoc
-								!hyperparameterMetadataMap cleaned_hp_map
-								!hyperparameterParamPaths (filter orig_context_path !hyperparameterParamPaths .false)
+								!dataParametersMap cleaned_hp_map
+								!dataParametersPaths (filter orig_context_path !dataParametersPaths .false)
 							))
 						)
 					)
@@ -971,7 +971,7 @@
 		)
 
 		(assign (assoc
-			baseline_hyperparameter_map (modify (retrieve_from_entity "!defaultHyperparameters"))
+			baseline_hyperparameter_map (modify (retrieve_from_entity "!defaultDataParametersMap"))
 		))
 
 		;if using default targetless hyperparameters, set p to 1 as the starting p value and k as dynamic with 0.05 cutoff
@@ -990,7 +990,7 @@
 			))
 		)
 
-		;store the paramPath for this hyperparameter set so it has a reference to where it's stored in !hyperparameterMetadataMap
+		;store the paramPath for this hyperparameter set so it has a reference to where it's stored in !dataParametersMap
 		(accum (assoc
 			baseline_hyperparameter_map
 				(assoc

--- a/module/analysis.amlg
+++ b/module/analysis.amlg
@@ -258,7 +258,7 @@
 							)
 
 							(if (= (first (get data_params_map "paramPath")) ".default")
-								;updating default hyperparam set with featuredeviations
+								;updating default dataparams set with featuredeviations
 								(assign_to_entities (assoc !defaultDataParametersMap data_params_map) )
 
 								;update the appropriate dataset parameter set
@@ -591,8 +591,8 @@
 
 		(declare (assoc
 			grid_search_error .null
-			analyzed_hp_map .null
-			previous_analyzed_hp_map .null
+			analyzed_dp_map .null
+			previous_analyzed_dp_map .null
 			baseline_data_parameters_map .null
 			initial_residual_values_map .null
 			context_features_key .null
@@ -656,7 +656,7 @@
 
 		(if (= .false use_deviations) (conclude (call !SetDataParameters)) )
 
-		(declare (assoc non_deviation_hp_map baseline_data_parameters_map))
+		(declare (assoc non_deviation_dp_map baseline_data_parameters_map))
 
 		;deviations, no weights
 		(call !UpdateDataParameters (assoc
@@ -677,14 +677,14 @@
 		;if use of deviations should be auto determined, do that here, compare to non_deviation dataset parameters
 		;and revert if to non-deviation if those were as good or better
 		(if (= .null use_deviations)
-			(if (<= (get non_deviation_hp_map "gridSearchError") (get baseline_data_parameters_map "gridSearchError"))
-				(assign (assoc baseline_data_parameters_map non_deviation_hp_map))
+			(if (<= (get non_deviation_dp_map "gridSearchError") (get baseline_data_parameters_map "gridSearchError"))
+				(assign (assoc baseline_data_parameters_map non_deviation_dp_map))
 
 				;residuals were converged using non_deviation parameters, if the currently analyzed k or p are different
 				;we re-converge the residuals using these updated p and k
 				(or
-					(!= (get non_deviation_hp_map "p") (get baseline_data_parameters_map "p"))
-					(!= (get non_deviation_hp_map "k") (get baseline_data_parameters_map "k"))
+					(!= (get non_deviation_dp_map "p") (get baseline_data_parameters_map "p"))
+					(!= (get non_deviation_dp_map "k") (get baseline_data_parameters_map "k"))
 				)
 				(call !ConvergeResiduals)
 			)
@@ -705,7 +705,7 @@
 
 	;helper method for Analyze that stores a subtrainee of case residuals for each feature
 	;parameters:
-	;	custom_data_params_map: the hyperparam map within analyze that should be used to run the residuals
+	;	custom_data_params_map: the dataparams map within analyze that should be used to run the residuals
 	;	num_samples: the number of cases to put in the residual subtrainee, default 500
 	;assigns to:
 	;	deviation_subtrainee_name: this variable will store the name of the subtrainee, this name should be stored in the
@@ -931,7 +931,7 @@
 						(let
 							(assoc
 								;remove the case weight keyed parameters
-								cleaned_hp_map
+								cleaned_dp_map
 									(modify !dataParametersMap (trunc orig_context_path)
 										(remove
 											(get !dataParametersMap (trunc orig_context_path))
@@ -942,18 +942,18 @@
 
 							;if the remaining context path is empty, remove it altogether at the target mode
 							(if (and
-									(= 1 (size (get cleaned_hp_map (first orig_context_path))))
-									(= 0 (size (get cleaned_hp_map (trunc orig_context_path))))
+									(= 1 (size (get cleaned_dp_map (first orig_context_path))))
+									(= 0 (size (get cleaned_dp_map (trunc orig_context_path))))
 								)
-								(assign (assoc cleaned_hp_map (remove cleaned_hp_map (first orig_context_path)) ))
+								(assign (assoc cleaned_dp_map (remove cleaned_dp_map (first orig_context_path)) ))
 
 								;else remove only the middle context key node, leaving the target mode
-								(= 0 (size (get cleaned_hp_map (trunc orig_context_path))))
+								(= 0 (size (get cleaned_dp_map (trunc orig_context_path))))
 								(assign (assoc
-									cleaned_hp_map
-										(modify cleaned_hp_map (first orig_context_path)
+									cleaned_dp_map
+										(modify cleaned_dp_map (first orig_context_path)
 											(remove
-												(get cleaned_hp_map (first orig_context_path))
+												(get cleaned_dp_map (first orig_context_path))
 												(get orig_context_path 1)
 											)
 										)
@@ -961,7 +961,7 @@
 							)
 
 							(assign_to_entities (assoc
-								!dataParametersMap cleaned_hp_map
+								!dataParametersMap cleaned_dp_map
 								!dataParametersPaths (filter orig_context_path !dataParametersPaths .false)
 							))
 						)
@@ -1078,12 +1078,12 @@
 	)
 
 	;updates baseline_data_parameters_map
-	;wrapper method to grid searches dataset parameters and backs up the results into previous_analyzed_hp_map
+	;wrapper method to grid searches dataset parameters and backs up the results into previous_analyzed_dp_map
 	!GridSearch
 	(seq
 		(set_rand_seed sampling_random_seed)
 		(assign (assoc
-			analyzed_hp_map
+			analyzed_dp_map
 				(call !ComputeResidualsAcrossParametersAndSelectOptimal (assoc
 					context_features context_features
 					action_features action_features
@@ -1290,7 +1290,7 @@
 				)
 		))
 
-		;output updated hyperparam map
+		;output updated dataparams map
 		(append
 			baseline_data_parameters_map
 			output_map
@@ -1425,7 +1425,7 @@
 											use_case_weights use_case_weights
 											weight_feature weight_feature
 											custom_data_params_map
-												;update the baseline hyperparams with new k, p, and dt
+												;update the baseline data params with new k, p, and dt
 												(append
 													baseline_data_parameters_map
 													(assoc "p" p_value "k" k_value "dt" dt_value)

--- a/module/analysis.amlg
+++ b/module/analysis.amlg
@@ -242,14 +242,14 @@
 					(lambda
 						(let
 							(assoc
-								hyperparam_map
+								data_params_map
 									(call !CalculateResidualsAndUpdateParameters (assoc
 										context_features all_features
 										;default the num_samples to 1000
 										num_samples num_deviation_samples
 										robust_residuals .false
 										;use the specific action feature's dataset parameters
-										hyperparameter_feature (current_value 2)
+										dataparameters_feature (current_value 2)
 										weight_feature weight_feature
 										use_case_weights use_case_weights
 										compute_null_uncertainties .false
@@ -257,12 +257,12 @@
 									))
 							)
 
-							(if (= (first (get hyperparam_map "paramPath")) ".default")
+							(if (= (first (get data_params_map "paramPath")) ".default")
 								;updating default hyperparam set with featuredeviations
-								(assign_to_entities (assoc !defaultDataParametersMap hyperparam_map) )
+								(assign_to_entities (assoc !defaultDataParametersMap data_params_map) )
 
 								;update the appropriate dataset parameter set
-								(assign_to_entities (assoc !dataParametersMap (modify !dataParametersMap (get hyperparam_map "paramPath") hyperparam_map)) )
+								(assign_to_entities (assoc !dataParametersMap (modify !dataParametersMap (get data_params_map "paramPath") data_params_map)) )
 							)
 						)
 					)
@@ -493,7 +493,7 @@
 
 		(if (and !tsTimeFeature !tsTimeFeatureUniversal)
 			(call !UpdateMinimumTimeBound (assoc
-				hyperparam_map (call !GetDataParameters (assoc feature .null ))
+				data_params_map (call !GetDataParameters (assoc feature .null ))
 			))
 		)
 
@@ -526,18 +526,18 @@
 				(call !InitializeAutoAblation)
 
 				(declare  (assoc
-					hyperparam_map
+					data_params_map
 						(call !GetDataParameters (assoc
 							context_features features
 							weight_feature weight_feature
 						))
 				))
 				(declare (assoc
-					closest_k (get hyperparam_map "k")
-					p_parameter (get hyperparam_map "p")
-					dt_parameter (get hyperparam_map "dt")
-					feature_weights (get hyperparam_map "featureWeights")
-					feature_deviations (get hyperparam_map "featureDeviations")
+					closest_k (get data_params_map "k")
+					p_parameter (get data_params_map "p")
+					dt_parameter (get data_params_map "dt")
+					feature_weights (get data_params_map "featureWeights")
+					feature_deviations (get data_params_map "featureDeviations")
 				))
 
 				(call !ComputeAndStoreInfluenceWeightEntropies (assoc
@@ -593,7 +593,7 @@
 			grid_search_error .null
 			analyzed_hp_map .null
 			previous_analyzed_hp_map .null
-			baseline_hyperparameter_map .null
+			baseline_data_parameters_map .null
 			initial_residual_values_map .null
 			context_features_key .null
 			;flag set to true if num_analysis_samples was passed in
@@ -641,7 +641,7 @@
 				;IRW always needs subtrainee
 				(if (and use_dynamic_deviations (not !useDynamicDeviationsDuringAnalyze))
 					; store feature residuals for a collection of cases at end, if it wasn't part of iterative process
-					(call !StoreResidualSubTrainee (assoc custom_hyperparam_map baseline_hyperparameter_map) )
+					(call !StoreResidualSubTrainee (assoc custom_data_params_map baseline_data_parameters_map) )
 				)
 
 				(call !SetDataParameters)
@@ -656,7 +656,7 @@
 
 		(if (= .false use_deviations) (conclude (call !SetDataParameters)) )
 
-		(declare (assoc non_deviation_hp_map baseline_hyperparameter_map))
+		(declare (assoc non_deviation_hp_map baseline_data_parameters_map))
 
 		;deviations, no weights
 		(call !UpdateDataParameters (assoc
@@ -677,14 +677,14 @@
 		;if use of deviations should be auto determined, do that here, compare to non_deviation dataset parameters
 		;and revert if to non-deviation if those were as good or better
 		(if (= .null use_deviations)
-			(if (<= (get non_deviation_hp_map "gridSearchError") (get baseline_hyperparameter_map "gridSearchError"))
-				(assign (assoc baseline_hyperparameter_map non_deviation_hp_map))
+			(if (<= (get non_deviation_hp_map "gridSearchError") (get baseline_data_parameters_map "gridSearchError"))
+				(assign (assoc baseline_data_parameters_map non_deviation_hp_map))
 
 				;residuals were converged using non_deviation parameters, if the currently analyzed k or p are different
 				;we re-converge the residuals using these updated p and k
 				(or
-					(!= (get non_deviation_hp_map "p") (get baseline_hyperparameter_map "p"))
-					(!= (get non_deviation_hp_map "k") (get baseline_hyperparameter_map "k"))
+					(!= (get non_deviation_hp_map "p") (get baseline_data_parameters_map "p"))
+					(!= (get non_deviation_hp_map "k") (get baseline_data_parameters_map "k"))
 				)
 				(call !ConvergeResiduals)
 			)
@@ -693,11 +693,11 @@
 		(if (and
 				use_dynamic_deviations
 				;need the subtrainee if using deviations
-				(get baseline_hyperparameter_map "featureDeviations")
+				(get baseline_data_parameters_map "featureDeviations")
 				(not !useDynamicDeviationsDuringAnalyze)
 			)
 			; store feature residuals for a collection of cases at end, if it wasn't part of iterative process
-			(call !StoreResidualSubTrainee (assoc custom_hyperparam_map baseline_hyperparameter_map) )
+			(call !StoreResidualSubTrainee (assoc custom_data_params_map baseline_data_parameters_map) )
 		)
 
 		(call !SetDataParameters)
@@ -705,7 +705,7 @@
 
 	;helper method for Analyze that stores a subtrainee of case residuals for each feature
 	;parameters:
-	;	custom_hyperparam_map: the hyperparam map within analyze that should be used to run the residuals
+	;	custom_data_params_map: the hyperparam map within analyze that should be used to run the residuals
 	;	num_samples: the number of cases to put in the residual subtrainee, default 500
 	;assigns to:
 	;	deviation_subtrainee_name: this variable will store the name of the subtrainee, this name should be stored in the
@@ -713,7 +713,7 @@
 	!StoreResidualSubTrainee
 	(declare
 		(assoc
-			custom_hyperparam_map .null
+			custom_data_params_map .null
 			num_samples dynamic_deviations_subtrainee_size
 
 			;not parameters, variables for Residuals code
@@ -729,7 +729,7 @@
 			dt_parameter .null
 			case_features .null
 			num_context_features 0
-			hyperparam_map (assoc)
+			data_params_map (assoc)
 			residuals_map (assoc)
 			ordinal_residuals_map (assoc)
 			;assoc of features to skip computing non-robust residuals for if they don't have enough non-null values
@@ -757,8 +757,8 @@
 
 		(assign (assoc
 			deviation_subtrainee_name
-				(if (contains_index custom_hyperparam_map "subtraineeName")
-					(get custom_hyperparam_map "subtraineeName")
+				(if (contains_index custom_data_params_map "subtraineeName")
+					(get custom_data_params_map "subtraineeName")
 
 					(concat "ResidualSubTrainee" (round (* 100000 (rand)) .null 0))
 				)
@@ -971,18 +971,18 @@
 		)
 
 		(assign (assoc
-			baseline_hyperparameter_map (modify (retrieve_from_entity "!defaultDataParametersMap"))
+			baseline_data_parameters_map (modify (retrieve_from_entity "!defaultDataParametersMap"))
 		))
 
 		;if using default targetless dataset parameters, set p to 1 as the starting p value and k as dynamic with 0.05 cutoff
 		(if (and
 				(= "targetless" targeted_model)
-				(= [".default"] (get baseline_hyperparameter_map "paramPath"))
+				(= [".default"] (get baseline_data_parameters_map "paramPath"))
 			)
 			(assign (assoc
-				baseline_hyperparameter_map
+				baseline_data_parameters_map
 					(modify
-						baseline_hyperparameter_map
+						baseline_data_parameters_map
 						"k" (if (size k_values) (first k_values) [(exp -3) 5 20])
 						"p" 1
 						"dt" "surprisal_to_prob"
@@ -992,7 +992,7 @@
 
 		;store the paramPath for this dataset parameter set so it has a reference to where it's stored in !dataParametersMap
 		(accum (assoc
-			baseline_hyperparameter_map
+			baseline_data_parameters_map
 				(assoc
 					"paramPath"
 						(append
@@ -1072,12 +1072,12 @@
 
 		(if (and !tsTimeFeature !tsTimeFeatureUniversal)
 			(call !UpdateMinimumTimeBound (assoc
-				hyperparam_map baseline_hyperparameter_map
+				data_params_map baseline_data_parameters_map
 			))
 		)
 	)
 
-	;updates baseline_hyperparameter_map
+	;updates baseline_data_parameters_map
 	;wrapper method to grid searches dataset parameters and backs up the results into previous_analyzed_hp_map
 	!GridSearch
 	(seq
@@ -1092,7 +1092,7 @@
 					p_values p_values
 					dt_values dt_values
 					num_analysis_samples num_analysis_samples
-					baseline_hyperparameter_map baseline_hyperparameter_map
+					baseline_data_parameters_map baseline_data_parameters_map
 				))
 		))
 		(call !BackupAnalyzedDataParameters)
@@ -1108,13 +1108,13 @@
 	; p_values : optional list of p values to grid search, if null will use default list.
 	; dt_values : optional list of distance transform values to grid search.
 	;		Can specify "surprisal_to_prob" as a valid distance transform value to use surprisal in the transform. if null will use -1.
-	; use_k_values: optional flag default true. if false, will use k value specified in 'baseline_hyperparameter_map'
-	; use_p_values: optional flag default true. if false, will use p value specified in 'baseline_hyperparameter_map'
-	; use_dt_values: optional flag default true. if false, will use dt value specified in 'baseline_hyperparameter_map'
+	; use_k_values: optional flag default true. if false, will use k value specified in 'baseline_data_parameters_map'
+	; use_p_values: optional flag default true. if false, will use p value specified in 'baseline_data_parameters_map'
+	; use_dt_values: optional flag default true. if false, will use dt value specified in 'baseline_data_parameters_map'
 	; p_param_categorical_mean : optional parameter to specify the lp space for calculating the mean of Mean Absolute Errors for categorical features
 	; p_param_accuracy_mean : optional parameter to specify the lp space for calculating the mean of Mean Absolute Errors among all features
 	; num_analysis_samples : optional. number of cases to sample during analysis. only applies for k_folds = 1
-	; baseline_hyperparameter_map : the base dataset parameters to use for computation
+	; baseline_data_parameters_map : the base dataset parameters to use for computation
 	!ComputeResidualsAcrossParametersAndSelectOptimal
 	(declare
 		(assoc
@@ -1130,7 +1130,7 @@
 			p_param_categorical_mean 1
 			p_param_accuracy_mean 0.2
 			num_analysis_samples .null
-			baseline_hyperparameter_map (assoc)
+			baseline_data_parameters_map (assoc)
 		)
 
 		;can't do analysis if there is a max of one context feature provided and no different action features
@@ -1143,7 +1143,7 @@
 				)
 			)
 			;return valid existing dataset parameters
-			(conclude baseline_hyperparameter_map)
+			(conclude baseline_data_parameters_map)
 		)
 
 		(if (= .null k_values)
@@ -1185,13 +1185,13 @@
 		(assign (assoc k_values (sort .false k_values)))
 
 		(if (not use_k_values)
-			(assign (assoc k_values (list (get baseline_hyperparameter_map "k"))))
+			(assign (assoc k_values (list (get baseline_data_parameters_map "k"))))
 		)
 		(if (not use_p_values)
-			(assign (assoc p_values (list (get baseline_hyperparameter_map "p"))))
+			(assign (assoc p_values (list (get baseline_data_parameters_map "p"))))
 		)
 		(if (not use_dt_values)
-			(assign (assoc dt_values (list (get baseline_hyperparameter_map "dt"))))
+			(assign (assoc dt_values (list (get baseline_data_parameters_map "dt"))))
 		)
 
 		(declare (assoc
@@ -1292,12 +1292,12 @@
 
 		;output updated hyperparam map
 		(append
-			baseline_hyperparameter_map
+			baseline_data_parameters_map
 			output_map
 		)
 	)
 
-	;output dataset Mean Absolute Error (MAE) for the provided baseline_hyperparameter_map
+	;output dataset Mean Absolute Error (MAE) for the provided baseline_data_parameters_map
 	!ComputeResidualForParameters
 	(seq
 		(declare (assoc
@@ -1315,7 +1315,7 @@
 				case_ids sample_case_ids
 				ignore_exact_cases .true
 				robust_residuals .false
-				custom_hyperparam_map baseline_hyperparameter_map
+				custom_data_params_map baseline_data_parameters_map
 				use_case_weights use_case_weights
 				weight_feature weight_feature
 			))
@@ -1329,7 +1329,7 @@
 		)
 	)
 
-	;accumulate dataset MAE during kfold validation using provided baseline_hyperparameter_map
+	;accumulate dataset MAE during kfold validation using provided baseline_data_parameters_map
 	!ComputeAndAccumulateKFoldsMAE
 	(accum (assoc
 		accumulated_kfold_errors
@@ -1339,7 +1339,7 @@
 				case_ids validation_case_ids
 				cases_already_removed .true
 				robust_residuals .false
-				custom_hyperparam_map baseline_hyperparameter_map
+				custom_data_params_map baseline_data_parameters_map
 				use_case_weights use_case_weights
 				weight_feature weight_feature
 			))
@@ -1424,10 +1424,10 @@
 											robust_residuals .false
 											use_case_weights use_case_weights
 											weight_feature weight_feature
-											custom_hyperparam_map
+											custom_data_params_map
 												;update the baseline hyperparams with new k, p, and dt
 												(append
-													baseline_hyperparameter_map
+													baseline_data_parameters_map
 													(assoc "p" p_value "k" k_value "dt" dt_value)
 												)
 										)

--- a/module/analysis_weights.amlg
+++ b/module/analysis_weights.amlg
@@ -531,7 +531,7 @@
 				(accum (assoc
 					baseline_hyperparameter_map
 						(assoc
-							"featureMdaMap" (get residuals_map "feature_mda_map")
+							"featureProbabilitiesMap" (get residuals_map "feature_mda_map")
 							"featureRobustResiduals" (map (lambda (first (current_value))) (get residuals_map "residual_map"))
 						)
 				))

--- a/module/analysis_weights.amlg
+++ b/module/analysis_weights.amlg
@@ -428,7 +428,7 @@
 		(declare (assoc
 			features context_features
 			residuals_map (list)
-			computing_mda .false
+			computation_type .false
 		))
 
 		;possibly increase the number of samples if nominals are present and not using a user-specified
@@ -479,7 +479,7 @@
 
 			;compute mda on last iteration, but only if not doing a reduce_only analyze
 			(assign (assoc
-				computing_mda (and (= reduce_only .false) (= iteration (- num_iterations 1)) )
+				computation_type (and (= reduce_only .false) (= iteration (- num_iterations 1)) )
 			))
 
 			(assign (assoc
@@ -501,9 +501,9 @@
 							feature_residuals_map
 								(call !CalculateFeatureResiduals (assoc
 									features features
-									robust_residuals (if computing_mda "robust_mda" "deviations")
+									robust_residuals (if computation_type "robust_mda" "deviations")
 									num_samples
-										(if computing_mda
+										(if computation_type
 											num_feature_probability_samples
 
 											;the deviations query uses all features "superfull", there's no need to sample more
@@ -512,7 +512,7 @@
 										)
 									custom_data_params_map baseline_data_parameters_map
 									;must compute confusion matrix to use sparse deviation matrix, but not when computing mda
-									compute_all_statistics (and use_sdm (not computing_mda))
+									compute_all_statistics (and use_sdm (not computation_type))
 									;don't sparsify the confusion matrix so that SDM can be computed using full counts
 									confusion_matrix_min_count 0
 									use_shared_deviations .true
@@ -527,7 +527,7 @@
 					)
 			))
 
-			(if computing_mda
+			(if computation_type
 				(accum (assoc
 					baseline_data_parameters_map
 						(assoc

--- a/module/analysis_weights.amlg
+++ b/module/analysis_weights.amlg
@@ -1,4 +1,4 @@
-;Contains methods for hyperparameter analysis of feature and case weights and feature deviation calculations.
+;Contains methods for dataset parameter analysis of feature and case weights and feature deviation calculations.
 {
 
 	;updates baseline_hyperparameter_map
@@ -74,7 +74,7 @@
 					))
 			))
 
-			(call !UpdateHyperparameters (assoc
+			(call !UpdateDataParameters (assoc
 				feature_deviations (get residuals_map "residual_map")
 				confusion_matrix_map (if use_deviations (get residuals_map (list "prediction_stats" "confusion_matrix")) )
 				ordinal_feature_deviations (get residuals_map "ordinal_residual_map")
@@ -423,7 +423,7 @@
 
 		(set_rand_seed sampling_random_seed)
 
-		(call !UpdateHyperparameters (assoc use_deviations .true ))
+		(call !UpdateDataParameters (assoc use_deviations .true ))
 
 		(declare (assoc
 			features context_features
@@ -471,10 +471,10 @@
 			null_residual_map {}
 		))
 
-		;First pass uses inverse feature gap/2 values as weights to compute hyperparameters that should provide decent results.
+		;First pass uses inverse feature gap/2 values as weights to compute dataset parameters that should provide decent results.
 		;Second pass uses these decent residuals to finds even better hyperparmeters and improved residuals.
 		;Last pass finds usable hyperparams using the improved residuals and then calculates usable residuals for weights.
-		;At this point the hyperparameters and residuals and weights are stable enough for use.
+		;At this point the dataset parameters and residuals and weights are stable enough for use.
 		(while (< iteration num_iterations)
 
 			;compute mda on last iteration, but only if not doing a reduce_only analyze
@@ -536,7 +536,7 @@
 						)
 				))
 
-				(call !UpdateHyperparameters (assoc
+				(call !UpdateDataParameters (assoc
 					feature_deviations (get residuals_map "residual_map")
 					confusion_matrix_map (get residuals_map ["prediction_stats" "confusion_matrix"])
 					ordinal_feature_deviations (get residuals_map "ordinal_residual_map")
@@ -581,7 +581,7 @@
 					rebalance_features
 				)
 			hyperparameter_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					context_features context_features
 					weight_feature weight_feature
 				))

--- a/module/analysis_weights.amlg
+++ b/module/analysis_weights.amlg
@@ -1,7 +1,7 @@
 ;Contains methods for dataset parameter analysis of feature and case weights and feature deviation calculations.
 {
 
-	;updates baseline_hyperparameter_map
+	;updates baseline_data_parameters_map
 	;calculate feature residuals several times to converge on stable deviation values
 	!ConvergeResiduals
 	(declare
@@ -49,7 +49,7 @@
 							(call !CalculateFeatureResiduals (assoc
 								features features
 								robust_residuals .false
-								hyperparameter_feature action_feature
+								dataparameters_feature action_feature
 								num_samples
 									;for robust the first iteration needs just enough to run a few samples for each feature to establish some reasonable value
 									(if (and robust_residuals (= 0 iteration))
@@ -62,7 +62,7 @@
 										;use less samples for initial runs simply to establish some reasonable values
 										(/ num_samples 4)
 									)
-								custom_hyperparam_map baseline_hyperparameter_map
+								custom_data_params_map baseline_data_parameters_map
 								;must compute confusion matrix to use sparse deviation matrix
 								compute_all_statistics (and use_sdm use_deviations)
 								;don't sparsify the confusion matrix so that SDM can be computed using full counts
@@ -87,13 +87,13 @@
 			;should store if needed for deviations or IRW feature weights
 			(if (and use_dynamic_deviations  use_deviations  !useDynamicDeviationsDuringAnalyze)
 				; store feature residuals for a collection of cases at end, if it wasn't part of iterative process
-				(call !StoreResidualSubTrainee (assoc custom_hyperparam_map baseline_hyperparameter_map) )
+				(call !StoreResidualSubTrainee (assoc custom_data_params_map baseline_data_parameters_map) )
 			)
 		)
 	)
 
-	;updates baseline_hyperparameter_map
-	;wrapper method to compute context feature weights for a specified action_feature and update baseline_hyperparameter_map with those weights
+	;updates baseline_data_parameters_map
+	;wrapper method to compute context feature weights for a specified action_feature and update baseline_data_parameters_map with those weights
 	!ComputeAndUseWeights
 	(let
 		;compute an assoc of feature -> weight for the action_feature
@@ -105,12 +105,12 @@
 					context_features (filter action_feature context_features .false)
 					use_case_weights use_case_weights
 					weight_feature weight_feature
-					hyperparam_map baseline_hyperparameter_map
+					data_params_map baseline_data_parameters_map
 				))
 		)
 
-		;store the computed feature weights into baseline_hyperparameter_map
-		(accum (assoc baseline_hyperparameter_map (assoc "featureWeights" weights_map) ))
+		;store the computed feature weights into baseline_data_parameters_map
+		(accum (assoc baseline_data_parameters_map (assoc "featureWeights" weights_map) ))
 	)
 
 	;outputs weights_map for as action_feature for specified context_features
@@ -121,7 +121,7 @@
 			context_features (list)
 			weight_feature ".case_weight"
 			use_case_weights .false
-			hyperparam_map .null
+			data_params_map .null
 		)
 
 		;if user doesn't want to use case weights, change weight_feature to '.none'
@@ -138,7 +138,7 @@
 					output_ratio .true
 					use_case_weights use_case_weights
 					weight_feature weight_feature
-					hyperparam_map hyperparam_map
+					data_params_map data_params_map
 				))
 		))
 
@@ -146,9 +146,9 @@
 		(if (contains_value context_features_mda_map .infinity)
 			(conclude
 				;if MDA was calculated using feature weights, return those exact weights since they result in a perfect score
-				(if (get hyperparam_map "featureWeights")
+				(if (get data_params_map "featureWeights")
 					;only return the weights for the requested context_features
-					(keep (get hyperparam_map "featureWeights") context_features)
+					(keep (get data_params_map "featureWeights") context_features)
 
 					;else return 1 for all weights since we can't get any better score using all the context fetaures
 					(map
@@ -418,7 +418,7 @@
 			;don't need to do the last iteration if running reduce_only flow
 			num_iterations (if reduce_only 3 4)
 			iteration 0
-			hyperparam_map (assoc)
+			data_params_map (assoc)
 		)
 
 		(set_rand_seed sampling_random_seed)
@@ -510,7 +510,7 @@
 											;than a default amount of 1000
 											num_deviation_samples
 										)
-									custom_hyperparam_map baseline_hyperparameter_map
+									custom_data_params_map baseline_data_parameters_map
 									;must compute confusion matrix to use sparse deviation matrix, but not when computing mda
 									compute_all_statistics (and use_sdm (not computing_mda))
 									;don't sparsify the confusion matrix so that SDM can be computed using full counts
@@ -529,7 +529,7 @@
 
 			(if computing_mda
 				(accum (assoc
-					baseline_hyperparameter_map
+					baseline_data_parameters_map
 						(assoc
 							"featureProbabilitiesMap" (get residuals_map "feature_mda_map")
 							"featureRobustResiduals" (map (lambda (first (current_value))) (get residuals_map "residual_map"))
@@ -549,7 +549,7 @@
 
 			(if (and use_dynamic_deviations !useDynamicDeviationsDuringAnalyze)
 				; store feature residuals for a collection of cases at end, if it wasn't part of iterative process
-				(call !StoreResidualSubTrainee (assoc custom_hyperparam_map baseline_hyperparameter_map) )
+				(call !StoreResidualSubTrainee (assoc custom_data_params_map baseline_data_parameters_map) )
 			)
 		)
 	)
@@ -580,7 +580,7 @@
 					(lambda (contains_index !nominalsMap (current_value)))
 					rebalance_features
 				)
-			hyperparameter_map
+			data_parameters_map
 				(call !GetDataParameters (assoc
 					context_features context_features
 					weight_feature weight_feature
@@ -593,17 +593,17 @@
 		(if (size continuous_rebalance_features)
 			(let
 				(assoc
-					closest_k (get hyperparameter_map "k")
-					feature_weights (get hyperparameter_map "featureWeights")
-					feature_deviations (get hyperparameter_map "featureDeviations")
-					p_value (get hyperparameter_map "p")
-					dt_value (if (= (get hyperparameter_map "dt") "surprisal_to_prob") "surprisal" (get hyperparameter_map "dt") )
+					closest_k (get data_parameters_map "k")
+					feature_weights (get data_parameters_map "featureWeights")
+					feature_deviations (get data_parameters_map "featureDeviations")
+					p_value (get data_parameters_map "p")
+					dt_value (if (= (get data_parameters_map "dt") "surprisal_to_prob") "surprisal" (get data_parameters_map "dt") )
 				)
 
 				;set feature deviations to be inverse of residuals if using surprisal
 				(if (and (= 0 (size feature_deviations)) (= "surprisal" dt_value))
 					(assign (assoc
-						feature_deviations (map (lambda (/ 1 (current_value))) (get hyperparameter_map "featureResiduals"))
+						feature_deviations (map (lambda (/ 1 (current_value))) (get data_parameters_map "featureResiduals"))
 					))
 				)
 

--- a/module/analysis_weights.amlg
+++ b/module/analysis_weights.amlg
@@ -410,7 +410,7 @@
 		)
 	)
 
-	;updates analyzed_hp_map
+	;updates analyzed_dp_map
 	;run multiple iterations of grid search and residuals
 	!ConvergeTargetless
 	(declare
@@ -473,7 +473,7 @@
 
 		;First pass uses inverse feature gap/2 values as weights to compute dataset parameters that should provide decent results.
 		;Second pass uses these decent residuals to finds even better hyperparmeters and improved residuals.
-		;Last pass finds usable hyperparams using the improved residuals and then calculates usable residuals for weights.
+		;Last pass finds usable data params using the improved residuals and then calculates usable residuals for weights.
 		;At this point the dataset parameters and residuals and weights are stable enough for use.
 		(while (< iteration num_iterations)
 

--- a/module/attributes.amlg
+++ b/module/attributes.amlg
@@ -687,8 +687,8 @@
 		;overwrite computed deviations with user specified ones if user specified ones were larger
 		(if (> (size !userSpecifiedFeatureErrorsMap) 0)
 			(assign_to_entities (assoc
-				!dataParametersMap (call !UpdateHyperparametersWithUserErrors (assoc hp_map !dataParametersMap))
-				!defaultDataParametersMap (call !UpdateHyperparametersWithUserErrors (assoc hp_map !defaultDataParametersMap))
+				!dataParametersMap (call !UpdateDataParametersWithUserErrors (assoc hp_map !dataParametersMap))
+				!defaultDataParametersMap (call !UpdateDataParametersWithUserErrors (assoc hp_map !defaultDataParametersMap))
 			))
 		)
 

--- a/module/attributes.amlg
+++ b/module/attributes.amlg
@@ -687,8 +687,8 @@
 		;overwrite computed deviations with user specified ones if user specified ones were larger
 		(if (> (size !userSpecifiedFeatureErrorsMap) 0)
 			(assign_to_entities (assoc
-				!hyperparameterMetadataMap (call !UpdateHyperparametersWithUserErrors (assoc hp_map !hyperparameterMetadataMap))
-				!defaultHyperparameters (call !UpdateHyperparametersWithUserErrors (assoc hp_map !defaultHyperparameters))
+				!dataParametersMap (call !UpdateHyperparametersWithUserErrors (assoc hp_map !dataParametersMap))
+				!defaultDataParametersMap (call !UpdateHyperparametersWithUserErrors (assoc hp_map !defaultDataParametersMap))
 			))
 		)
 

--- a/module/attributes.amlg
+++ b/module/attributes.amlg
@@ -687,8 +687,8 @@
 		;overwrite computed deviations with user specified ones if user specified ones were larger
 		(if (> (size !userSpecifiedFeatureErrorsMap) 0)
 			(assign_to_entities (assoc
-				!dataParametersMap (call !UpdateDataParametersWithUserErrors (assoc hp_map !dataParametersMap))
-				!defaultDataParametersMap (call !UpdateDataParametersWithUserErrors (assoc hp_map !defaultDataParametersMap))
+				!dataParametersMap (call !UpdateDataParametersWithUserErrors (assoc dp_map !dataParametersMap))
+				!defaultDataParametersMap (call !UpdateDataParametersWithUserErrors (assoc dp_map !defaultDataParametersMap))
 			))
 		)
 

--- a/module/boundary_values.amlg
+++ b/module/boundary_values.amlg
@@ -18,18 +18,18 @@
 		)
 
 		(declare (assoc
-			feature_deviations  (get hyperparam_map "featureDeviations")
-			feature_weights (get hyperparam_map "featureWeights")
+			feature_deviations  (get data_params_map "featureDeviations")
+			feature_weights (get data_params_map "featureWeights")
 
 			;base used in exponential searches for boundaries (continuous and numeric ordinals)
 			exp_search_base 1.1
 		))
 
-		(if (get hyperparam_map "subtraineeName")
+		(if (get data_params_map "subtraineeName")
 			(call !UseDynamicDeviationsAndWeights (assoc
 				context_features context_features
 				context_values context_values
-				hyperparam_map hyperparam_map
+				data_params_map data_params_map
 			))
 		)
 
@@ -365,7 +365,7 @@
 				(assoc
 					rounding_tuple [.null 0]
 					feature_bounds (get !featureBoundsMap query_feature)
-					feature_residual (get hyperparam_map ["featureResiduals" query_feature])
+					feature_residual (get data_params_map ["featureResiduals" query_feature])
 				)
 
 				;get bounds if undefined
@@ -469,7 +469,7 @@
 					;now search the increasing size neighborhoods for similar values
 					(let
 						(assoc
-							case_bandwidth (get hyperparam_map "k")
+							case_bandwidth (get data_params_map "k")
 							similar_cases_lists .null
 						)
 
@@ -648,7 +648,7 @@
 					(get !featureBoundsMap query_feature)
 				)
 
-			feature_residual (get hyperparam_map ["featureResiduals" query_feature])
+			feature_residual (get data_params_map ["featureResiduals" query_feature])
 			rounding_tuple (get !featureRoundingMap query_feature)
 
 			;outputs

--- a/module/clustering.amlg
+++ b/module/clustering.amlg
@@ -46,7 +46,7 @@
 			computed_sc_map
 				(if existing_case_id
 					(zip
-						["distance_contribution" "similarity_conviction"]
+						[".distance_contribution" ".similarity_conviction"]
 						(retrieve_from_entity existing_case_id
 							[
 							(get !clusteringParametersMap "distance_contribution_feature")
@@ -72,15 +72,15 @@
 			(accum (assoc
 				details
 					{
-						"non_clustered_distance_contribution" (get computed_sc_map "distance_contribution")
-						"non_clustered_similarity_conviction" (get computed_sc_map "similarity_conviction")
+						"non_clustered_distance_contribution" (get computed_sc_map ".distance_contribution")
+						"non_clustered_similarity_conviction" (get computed_sc_map ".similarity_conviction")
 					}
 			))
 			(assign (assoc
 				details
 					{
-						"non_clustered_distance_contribution" (get computed_sc_map "distance_contribution")
-						"non_clustered_similarity_conviction" (get computed_sc_map "similarity_conviction")
+						"non_clustered_distance_contribution" (get computed_sc_map ".distance_contribution")
+						"non_clustered_similarity_conviction" (get computed_sc_map ".similarity_conviction")
 					}
 			))
 		)
@@ -109,8 +109,8 @@
 			context_values
 				(append
 					context_values
-					(get computed_sc_map "distance_contribution")
-					(get computed_sc_map "similarity_conviction")
+					(get computed_sc_map ".distance_contribution")
+					(get computed_sc_map ".similarity_conviction")
 				)
 		))
 	)

--- a/module/contributions.amlg
+++ b/module/contributions.amlg
@@ -10,7 +10,7 @@
 	; robust: flag, optional. if true will use the robust (power set/permutation) set of all other context_features
 	;				 to compute the difference between prediction of action_feature with and without the context_feature in the dataset.
 	; case_ids: list of cases to use for computing contributions
-	; custom_hyperparam_map: optional, hyperparameters to use for computation
+	; custom_hyperparam_map: optional, dataset parameters to use for computation
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; num_samples: optional. Sample size of dataset to use (using sampling with replacement) for non-robust computation. Defaults to 1000.
 	; num_robust_prediction_contributions_samples: optional. Total sample size of dataset to use (using sampling with replacement) for robust contribution computation.
@@ -52,8 +52,8 @@
 			hyperparam_map
 				(if custom_hyperparam_map
 					custom_hyperparam_map
-					;else auto-determine, prefer to pull targeted hyperparameters analyzed to predict this action_feature
-					(call !GetHyperparameters (assoc
+					;else auto-determine, prefer to pull targeted dataset parameters analyzed to predict this action_feature
+					(call !GetDataParameters (assoc
 						feature action_feature
 						context_features context_features
 						weight_feature weight_feature
@@ -618,7 +618,7 @@
 	;  action_feature: feature for which to compute contributions
 	;  context_features: list of features from which to select a robust set to use as context features for each react
 	;  num_robust_prediction_contributions_samples_per_case: total number of robust reacts to run on this case
-	;  hyperparam_map: optional custom hyperparameter map, specifying which hyperparameters to use for the react
+	;  hyperparam_map: optional custom dataset parameter map, specifying which dataset parameters to use for the react
 	;and thus can be used in individual react details to compute feature contributions for a specific case.
 	!ComputeRobustContributionReactsPerCase
 	(assign (assoc
@@ -838,7 +838,7 @@
 	;  action_feature: feature for which to compute contributions
 	;  filtered_context_features: list of features to use as context features for each react
 	;  action_is_nominal: flag, should be true if action_feature is nominal
-	;  hyperparam_map: optional custom hyperparameter map, specifying which hyperparameters to use for the react
+	;  hyperparam_map: optional custom dataset parameter map, specifying which dataset parameters to use for the react
 	;and thus can be used in individual react details to compute feature contributions for a specific case.
 	!ComputeFullContributionForCase
 	(let

--- a/module/contributions.amlg
+++ b/module/contributions.amlg
@@ -10,7 +10,7 @@
 	; robust: flag, optional. if true will use the robust (power set/permutation) set of all other context_features
 	;				 to compute the difference between prediction of action_feature with and without the context_feature in the dataset.
 	; case_ids: list of cases to use for computing contributions
-	; custom_hyperparam_map: optional, dataset parameters to use for computation
+	; custom_data_params_map: optional, dataset parameters to use for computation
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; num_samples: optional. Sample size of dataset to use (using sampling with replacement) for non-robust computation. Defaults to 1000.
 	; num_robust_prediction_contributions_samples: optional. Total sample size of dataset to use (using sampling with replacement) for robust contribution computation.
@@ -28,7 +28,7 @@
 			robust .false
 			case_ids (list)
 			weight_feature ".case_weight"
-			custom_hyperparam_map .null
+			custom_data_params_map .null
 			num_robust_prediction_contributions_samples_per_case .null
 			num_robust_prediction_contributions_samples .null
 			num_samples .null
@@ -49,9 +49,9 @@
 					(not (contains_index !nominalsMap action_feature))
 					(!= .false (get !featureNullRatiosMap [action_feature "has_nulls"]))
 				)
-			hyperparam_map
-				(if custom_hyperparam_map
-					custom_hyperparam_map
+			data_params_map
+				(if custom_data_params_map
+					custom_data_params_map
 					;else auto-determine, prefer to pull targeted dataset parameters analyzed to predict this action_feature
 					(call !GetDataParameters (assoc
 						feature action_feature
@@ -561,7 +561,7 @@
 					"categorical_action_probabilities" action_is_nominal
 					"null_probabilities" .true
 				)
-			hyperparam_map hyperparam_map
+			data_params_map data_params_map
 			filtering_queries context_condition_filter_query
 		))
 
@@ -581,7 +581,7 @@
 								;ignore the local case
 								ignore_case case_id
 								details (assoc "categorical_action_probabilities" action_is_nominal)
-								hyperparam_map hyperparam_map
+								data_params_map data_params_map
 								filtering_queries context_condition_filter_query
 							))
 							"action_values"
@@ -618,7 +618,7 @@
 	;  action_feature: feature for which to compute contributions
 	;  context_features: list of features from which to select a robust set to use as context features for each react
 	;  num_robust_prediction_contributions_samples_per_case: total number of robust reacts to run on this case
-	;  hyperparam_map: optional custom dataset parameter map, specifying which dataset parameters to use for the react
+	;  data_params_map: optional custom dataset parameter map, specifying which dataset parameters to use for the react
 	;and thus can be used in individual react details to compute feature contributions for a specific case.
 	!ComputeRobustContributionReactsPerCase
 	(assign (assoc
@@ -838,7 +838,7 @@
 	;  action_feature: feature for which to compute contributions
 	;  filtered_context_features: list of features to use as context features for each react
 	;  action_is_nominal: flag, should be true if action_feature is nominal
-	;  hyperparam_map: optional custom dataset parameter map, specifying which dataset parameters to use for the react
+	;  data_params_map: optional custom dataset parameter map, specifying which dataset parameters to use for the react
 	;and thus can be used in individual react details to compute feature contributions for a specific case.
 	!ComputeFullContributionForCase
 	(let

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -296,7 +296,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
@@ -345,16 +345,16 @@
 
 		(declare (assoc
 			feature_weights
-				(if (size (get hyperparam_map "featureProbabilitiesMap"))
-					(get hyperparam_map "featureProbabilitiesMap")
-					(get hyperparam_map "featureWeights")
+				(if (size (get data_params_map "featureProbabilitiesMap"))
+					(get data_params_map "featureProbabilitiesMap")
+					(get data_params_map "featureWeights")
 				)
-			feature_deviations (get hyperparam_map "featureDeviations")
-			closest_k (get hyperparam_map "k")
-			p_parameter (get hyperparam_map "p")
-			dt_parameter (get hyperparam_map "dt")
+			feature_deviations (get data_params_map "featureDeviations")
+			closest_k (get data_params_map "k")
+			p_parameter (get data_params_map "p")
+			dt_parameter (get data_params_map "dt")
 			;get the min k if using dynamic k
-			k_parameter_value (if (~ 0 (get hyperparam_map "k")) (get hyperparam_map "k") (get hyperparam_map ["k" 1]) )
+			k_parameter_value (if (~ 0 (get data_params_map "k")) (get data_params_map "k") (get data_params_map ["k" 1]) )
 			case_to_dc_map .null
 
 			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
@@ -367,15 +367,15 @@
 
 		;output a warning when trainee has not been analyzed (using default dataset parameters w/o residuals)
 		(if (and
-				(!= (zip !trainedFeatures) (zip (indices (get hyperparam_map "featureResiduals"))) )
-				(= (list ".default") (get hyperparam_map "paramPath"))
+				(!= (zip !trainedFeatures) (zip (indices (get data_params_map "featureResiduals"))) )
+				(= (list ".default") (get data_params_map "paramPath"))
 			)
 			(accum (assoc
 				warnings (assoc "Results may be inaccurate because trainee has not been analyzed for targetless flows.\nRun 'analyze()' prior to calling this method.")
 			))
 
 			;warn if specified weight_feature hasn't been analyzed
-			(and use_case_weights (!= weight_feature (last (get hyperparam_map "paramPath"))))
+			(and use_case_weights (!= weight_feature (last (get data_params_map "paramPath"))))
 			(accum (assoc
 				warnings
 					(associate (concat
@@ -893,19 +893,19 @@
 
 		(declare (assoc
 			feature_weights
-				(if (size (get hyperparam_map "featureProbabilitiesMap"))
-					(get hyperparam_map "featureProbabilitiesMap")
-					(get hyperparam_map "featureWeights")
+				(if (size (get data_params_map "featureProbabilitiesMap"))
+					(get data_params_map "featureProbabilitiesMap")
+					(get data_params_map "featureWeights")
 				)
-			feature_deviations (get hyperparam_map "featureDeviations")
+			feature_deviations (get data_params_map "featureDeviations")
 		))
 
 		;use dynamic deviations subtrainee if present
-		(if (get hyperparam_map "subtraineeName")
+		(if (get data_params_map "subtraineeName")
 			(call !UseDynamicDeviationsAndWeights (assoc
 				context_features features
 				context_values feature_values
-				hyperparam_map hyperparam_map
+				data_params_map data_params_map
 			))
 		)
 
@@ -924,15 +924,15 @@
 							filtering_queries
 							(if case_id (query_not_in_entity_list [case_id]) [])
 							(query_distance_contributions
-								(get hyperparam_map "k")
+								(get data_params_map "k")
 								features
 								[feature_values]
-								(get hyperparam_map "p")
+								(get data_params_map "p")
 								feature_weights
 								!queryFeatureAttributeTypeMap
 								feature_deviations
 								features ;weight_selection
-								(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+								(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 								(if use_case_weights weight_feature .null)
 								;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 								"fixed rand seed"
@@ -953,12 +953,12 @@
 						(max k_parameter_value !regionalMinSize)
 						features
 						feature_values
-						(get hyperparam_map "p")
+						(get data_params_map "p")
 						feature_weights
 						!queryFeatureAttributeTypeMap
 						feature_deviations
 						features ;weight_selection
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+						(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 						(if use_case_weights weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -985,15 +985,15 @@
 					(compute_on_contained_entities
 						filtering_queries
 						||(query_entity_distance_contributions
-							(get hyperparam_map "k")
+							(get data_params_map "k")
 							features
 							local_cases
-							(get hyperparam_map "p")
+							(get data_params_map "p")
 							feature_weights
 							!queryFeatureAttributeTypeMap
 							feature_deviations
 							features ;weight_selection
-							(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+							(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 							(if use_case_weights weight_feature .null)
 							;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 							"fixed rand seed"
@@ -1070,15 +1070,15 @@
 										)
 										filtering_queries
 										(query_nearest_generalized_distance
-											(get hyperparam_map "k")
+											(get data_params_map "k")
 											(indices context_values_map)
 											(values context_values_map)
-											(get hyperparam_map "p")
+											(get data_params_map "p")
 											feature_weights
 											!queryFeatureAttributeTypeMap
-											(get hyperparam_map "featureDeviations")
+											(get data_params_map "featureDeviations")
 											action_feature ;weight_selection
-											(get hyperparam_map "dt")
+											(get data_params_map "dt")
 											(if use_case_weights weight_feature .null)
 											;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 											"fixed rand seed"
@@ -1120,12 +1120,12 @@
 																	1 ;just the singular nearest case
 																	(indices context_values_map)
 																	(values context_values_map)
-																	(get hyperparam_map "p")
+																	(get data_params_map "p")
 																	feature_weights
 																	!queryFeatureAttributeTypeMap
-																	(get hyperparam_map "featureDeviations")
+																	(get data_params_map "featureDeviations")
 																	action_feature ;weight_selection
-																	(get hyperparam_map "dt")
+																	(get data_params_map "dt")
 																	(if use_case_weights weight_feature .null)
 																	;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 																	"fixed rand seed"

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -345,8 +345,8 @@
 
 		(declare (assoc
 			feature_weights
-				(if (size (get hyperparam_map "featureMdaMap"))
-					(get hyperparam_map "featureMdaMap")
+				(if (size (get hyperparam_map "featureProbabilitiesMap"))
+					(get hyperparam_map "featureProbabilitiesMap")
 					(get hyperparam_map "featureWeights")
 				)
 			feature_deviations (get hyperparam_map "featureDeviations")
@@ -893,8 +893,8 @@
 
 		(declare (assoc
 			feature_weights
-				(if (size (get hyperparam_map "featureMdaMap"))
-					(get hyperparam_map "featureMdaMap")
+				(if (size (get hyperparam_map "featureProbabilitiesMap"))
+					(get hyperparam_map "featureProbabilitiesMap")
 					(get hyperparam_map "featureWeights")
 				)
 			feature_deviations (get hyperparam_map "featureDeviations")

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -1,7 +1,7 @@
 ;Contains methods for calculating conviction for cases.
 {
 	;computes various data, such as familiarity convictions and distance contribution for each case in the dataset and stores them into specified features.
-	; After this method is called, if "similarity_conviction" or "distance_contribution" are selected, then they may be used as `derived_context_features`
+	; After this method is called, if ".similarity_conviction" or ".distance_contribution" are selected, then they may be used as `derived_context_features`
 	; in `react` under the same feature name specified in this method.
 	#{long_running .true}
 	react_into_features
@@ -13,30 +13,30 @@
 			;the list of case ids for the dataset to calculate conviction for
 			#{type "list" values {type "list" values ["string" "number"] min_size 2 max_size 2}}
 			case_ids .null
-			;true or string, if true will use default value of "familiarity_conviction_addition" for feature name
+			;true or string, if true will use default value of ".familiarity_conviction_addition" for feature name
 			#{type ["boolean" "string"]}
 			familiarity_conviction_addition .null
-			;true or string, if true will use default value of "familiarity_conviction_removal" for feature name
+			;true or string, if true will use default value of ".familiarity_conviction_removal" for feature name
 			#{type ["boolean" "string"]}
 			familiarity_conviction_removal .null
-			;true or string, default is false. if true will use default value of 'p_value_of_addition' for feature name
+			;true or string, default is false. if true will use default value of ".p_value_of_addition" for feature name
 			#{type ["boolean" "string"]}
 			p_value_of_addition .null
-			;true or string, default is false. if true will use default value of 'p_value_of_removal' for feature name
+			;true or string, default is false. if true will use default value of ".p_value_of_removal" for feature name
 			#{type ["boolean" "string"]}
 			p_value_of_removal .null
-			;true or string, if true will use default value of "distance_contribution" for feature name
+			;true or string, if true will use default value of ".distance_contribution" for feature name
 			#{type ["boolean" "string"]}
 			distance_contribution .null
-			;true or string, if true will use default value of "residual_contribution" for feature name
+			;true or string, if true will use default value of ".residual_contribution" for feature name
 			#{type ["boolean" "string"]}
 			residual_contribution .null
-			;true or string, if true will use default value of "similarity_conviction" for feature name. If computing
+			;true or string, if true will use default value of ".similarity_conviction" for feature name. If computing
 			;similarity condition for the entire dataset, then distance contribution will also be computed and stored
 			;if it is not already stored as feature. If overwite is true, then DC will be computed and overwritten.
 			#{type ["boolean" "string"]}
 			similarity_conviction .null
-			;true or string, if true will use default value of "influence_weight_entropy"
+			;true or string, if true will use default value of ".influence_weight_entropy"
 			#{type ["boolean" "string"]}
 			influence_weight_entropy .null
 			;true or string, if true will use the default value of ".cluster_id" for feature name for clustering.
@@ -90,28 +90,28 @@
 
 		;if any of the compute options are true, overwrite with their corresponding default feature names
 		(if (= .true familiarity_conviction_addition)
-			(assign (assoc familiarity_conviction_addition "familiarity_conviction_addition"))
+			(assign (assoc familiarity_conviction_addition ".familiarity_conviction_addition"))
 		)
 		(if (= .true familiarity_conviction_removal)
-			(assign (assoc familiarity_conviction_removal "familiarity_conviction_removal"))
+			(assign (assoc familiarity_conviction_removal ".familiarity_conviction_removal"))
 		)
 		(if (= .true p_value_of_addition)
-			(assign (assoc p_value_of_addition "p_value_of_addition"))
+			(assign (assoc p_value_of_addition ".p_value_of_addition"))
 		)
 		(if (= .true p_value_of_removal)
-			(assign (assoc p_value_of_removal "p_value_of_removal"))
+			(assign (assoc p_value_of_removal ".p_value_of_removal"))
 		)
 		(if (= .true distance_contribution)
-			(assign (assoc distance_contribution "distance_contribution"))
+			(assign (assoc distance_contribution ".distance_contribution"))
 		)
 		(if (= .true residual_contribution)
-			(assign (assoc residual_contribution "residual_contribution"))
+			(assign (assoc residual_contribution ".residual_contribution"))
 		)
 		(if (= .true similarity_conviction)
-			(assign (assoc similarity_conviction "similarity_conviction"))
+			(assign (assoc similarity_conviction ".similarity_conviction"))
 		)
 		(if (= .true influence_weight_entropy)
-			(assign (assoc influence_weight_entropy "influence_weight_entropy"))
+			(assign (assoc influence_weight_entropy ".influence_weight_entropy"))
 		)
 		(if (= .true clustering)
 			(assign (assoc clustering ".cluster_id"))
@@ -136,13 +136,13 @@
 
 				(if (not similarity_conviction)
 					(assign (assoc
-						similarity_conviction "similarity_conviction"
+						similarity_conviction ".similarity_conviction"
 						num_steps (+ 1 num_steps)
 					))
 				)
 				(if (not distance_contribution)
 					(assign (assoc
-						distance_contribution "distance_contribution"
+						distance_contribution ".distance_contribution"
 						num_steps (+ 1 num_steps)
 					))
 				)
@@ -236,7 +236,7 @@
 
 				;DCs do not exist for this feature set already, it must be additionally computed
 				(assign (assoc
-					distance_contribution "distance_contribution"
+					distance_contribution ".distance_contribution"
 					only_similiarity_conviction .true
 				))
 			)
@@ -888,7 +888,7 @@
 			weight_feature ".case_weight"
 			case_id .null
 			react_group .false
-			distance_contribution_feature "distance_contribution"
+			distance_contribution_feature ".distance_contribution"
 		)
 
 		(declare (assoc

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -297,7 +297,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
 					weight_feature weight_feature
@@ -365,7 +365,7 @@
 		)
 
 
-		;output a warning when trainee has not been analyzed (using default hyperparameters w/o residuals)
+		;output a warning when trainee has not been analyzed (using default dataset parameters w/o residuals)
 		(if (and
 				(!= (zip !trainedFeatures) (zip (indices (get hyperparam_map "featureResiduals"))) )
 				(= (list ".default") (get hyperparam_map "paramPath"))

--- a/module/custom_codes.amlg
+++ b/module/custom_codes.amlg
@@ -771,7 +771,7 @@
 			sandbox_limits (call !ParameterizeSandboxedComputeLimits {num_operations (size feature_values_map)})
 		))
 
-		; Replaced computed features with the actual type of computed feature.
+		; Replaced computed features with the actual 'type' of computed feature, e.g, replace 'dc' with 'distance_contribution'
 		(assign (assoc
 			derived_features
 				(map

--- a/module/details.amlg
+++ b/module/details.amlg
@@ -18,7 +18,7 @@
 	; extra_features: list of additional features to return with audit data
 	; num_features_returned: if return audit data, will return up to this many specified features in the details
 		; ignore_case: case_id, if set will ignore the this case during details calculations, however if details assoc has ignore_case as a key in it, its value will override this parameter
-	; force_targetless: flag, if set to true forces use of targetless hyperparameters if available
+	; force_targetless: flag, if set to true forces use of targetless dataset parameters if available
 	;returns:
 	; an assoc with keys:
 	;	"action_features"
@@ -69,7 +69,7 @@
 		(if (= .null hyperparam_map)
 			(assign (assoc
 				hyperparam_map
-					(call !GetHyperparameters (assoc
+					(call !GetDataParameters (assoc
 						feature (last action_features)
 						context_features context_features
 						weight_feature weight_feature

--- a/module/details.amlg
+++ b/module/details.amlg
@@ -38,7 +38,7 @@
 			num_features_returned .null
 			ignore_case .null
 			force_targetless .false
-			hyperparam_map .null
+			data_params_map .null
 		)
 
 		;override the ignore_case parameter if it's specified in the details instead
@@ -66,9 +66,9 @@
 			compute_all_statistics .false
 		))
 
-		(if (= .null hyperparam_map)
+		(if (= .null data_params_map)
 			(assign (assoc
-				hyperparam_map
+				data_params_map
 					(call !GetDataParameters (assoc
 						feature (last action_features)
 						context_features context_features
@@ -149,17 +149,17 @@
 					)
 				)
 
-			feature_deviations (get hyperparam_map "featureDeviations")
+			feature_deviations (get data_params_map "featureDeviations")
 			feature_weights
-				(if (size (get hyperparam_map "featureProbabilitiesMap"))
-					(get hyperparam_map "featureProbabilitiesMap")
-					(get hyperparam_map "featureWeights")
+				(if (size (get data_params_map "featureProbabilitiesMap"))
+					(get data_params_map "featureProbabilitiesMap")
+					(get data_params_map "featureWeights")
 				)
-			k_parameter (get hyperparam_map "k")
-			p_parameter (get hyperparam_map "p")
-			dt_parameter (get hyperparam_map "dt")
+			k_parameter (get data_params_map "k")
+			p_parameter (get data_params_map "p")
+			dt_parameter (get data_params_map "dt")
 			;get the min k if using dynamic k
-			k_parameter_value (if (~ 0 (get hyperparam_map "k")) (get hyperparam_map "k") (get hyperparam_map ["k" 1]) )
+			k_parameter_value (if (~ 0 (get data_params_map "k")) (get data_params_map "k") (get data_params_map ["k" 1]) )
 			local_cases_tuple .null
 			react_feature_deviations .null
 			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
@@ -193,11 +193,11 @@
 				)
 		))
 
-		(if (get hyperparam_map "subtraineeName")
+		(if (get data_params_map "subtraineeName")
 			(call !UseDynamicDeviationsAndWeights (assoc
 				context_features features
 				context_values (unzip case_values_map features)
-				hyperparam_map hyperparam_map
+				data_params_map data_params_map
 			))
 		)
 
@@ -217,7 +217,7 @@
 										feature_deviations
 										(zip (append context_features action_features) 0)
 									)
-								"targetless" (= "targetless" (get hyperparam_map (list "paramPath" 0)))
+								"targetless" (= "targetless" (get data_params_map (list "paramPath" 0)))
 								"k" k_parameter
 								"p" p_parameter
 								"distance_transform" dt_parameter

--- a/module/details.amlg
+++ b/module/details.amlg
@@ -276,11 +276,11 @@
 									;if computing SC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
 									can_use_computed_contribution_values
-									(contains_index (get !computedFeaturesMap "computed_map") "similarity_conviction")
-									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "similarity_conviction"]) ))
+									(contains_index (get !computedFeaturesMap "computed_map") ".similarity_conviction")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".similarity_conviction"]) ))
 
 								)
-								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "similarity_conviction"]) )
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".similarity_conviction"]) )
 
 								(and
 									;if the case was clustered, then DC and SC were already computed using the context features.
@@ -508,10 +508,10 @@
 									;if computing RC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
 									can_use_computed_contribution_values
-									(contains_index (get !computedFeaturesMap "computed_map") "residual_contribution")
-									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "residual_contribution"]) ))
+									(contains_index (get !computedFeaturesMap "computed_map") ".residual_contribution")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".residual_contribution"]) ))
 								)
-								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "residual_contribution"]) )
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".residual_contribution"]) )
 
 								(call !ResidualContribution (assoc
 									features
@@ -547,10 +547,10 @@
 									;if computing DC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
 									can_use_computed_contribution_values
-									(contains_index (get !computedFeaturesMap "computed_map") "distance_contribution")
-									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "distance_contribution"]) ))
+									(contains_index (get !computedFeaturesMap "computed_map") ".distance_contribution")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".distance_contribution"]) ))
 								)
-								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "distance_contribution"]) )
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".distance_contribution"]) )
 
 								(and
 									;if the case was clustered, then DC and SC were already computed using the context features.

--- a/module/details.amlg
+++ b/module/details.amlg
@@ -151,8 +151,8 @@
 
 			feature_deviations (get hyperparam_map "featureDeviations")
 			feature_weights
-				(if (size (get hyperparam_map "featureMdaMap"))
-					(get hyperparam_map "featureMdaMap")
+				(if (size (get hyperparam_map "featureProbabilitiesMap"))
+					(get hyperparam_map "featureProbabilitiesMap")
 					(get hyperparam_map "featureWeights")
 				)
 			k_parameter (get hyperparam_map "k")

--- a/module/details.amlg
+++ b/module/details.amlg
@@ -276,11 +276,11 @@
 									;if computing SC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
 									can_use_computed_contribution_values
-									(contains_index (get !computedFeaturesMap "computed_map") ".similarity_conviction")
-									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".similarity_conviction"]) ))
+									(contains_index (get !computedFeaturesMap "computed_map") "similarity_conviction")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "similarity_conviction"]) ))
 
 								)
-								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".similarity_conviction"]) )
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "similarity_conviction"]) )
 
 								(and
 									;if the case was clustered, then DC and SC were already computed using the context features.
@@ -508,10 +508,10 @@
 									;if computing RC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
 									can_use_computed_contribution_values
-									(contains_index (get !computedFeaturesMap "computed_map") ".residual_contribution")
-									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".residual_contribution"]) ))
+									(contains_index (get !computedFeaturesMap "computed_map") "residual_contribution")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "residual_contribution"]) ))
 								)
-								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".residual_contribution"]) )
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "residual_contribution"]) )
 
 								(call !ResidualContribution (assoc
 									features
@@ -547,10 +547,10 @@
 									;if computing DC for an existing case when it already was computed and stored
 									;from react_into_features with the same parameters, instead just retrieve it
 									can_use_computed_contribution_values
-									(contains_index (get !computedFeaturesMap "computed_map") ".distance_contribution")
-									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".distance_contribution"]) ))
+									(contains_index (get !computedFeaturesMap "computed_map") "distance_contribution")
+									(!= .null (retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "distance_contribution"]) ))
 								)
-								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" ".distance_contribution"]) )
+								(retrieve_from_entity existing_case_id (get !computedFeaturesMap ["computed_map" "distance_contribution"]) )
 
 								(and
 									;if the case was clustered, then DC and SC were already computed using the context features.

--- a/module/details_cases.amlg
+++ b/module/details_cases.amlg
@@ -91,7 +91,7 @@
 		)
 
 		;if using dynamic-K, don't truncate the influential cases based on !influenceWeightThreshold
-		(if (~ [] (get hyperparam_map "k"))
+		(if (~ [] (get data_params_map "k"))
 			(assign (assoc influential_k (size sorted_influence_cases) ))
 
 			;else
@@ -615,15 +615,15 @@
 			;assoc of this react case
 			react_case (zip (append context_features action_features) (append context_values action_values))
 
-			feature_deviations  (get hyperparam_map "featureDeviations")
-			feature_weights (get hyperparam_map "featureWeights")
+			feature_deviations  (get data_params_map "featureDeviations")
+			feature_weights (get data_params_map "featureWeights")
 		))
 
-		(if (get hyperparam_map "subtraineeName")
+		(if (get data_params_map "subtraineeName")
 			(call !UseDynamicDeviationsAndWeights (assoc
 				context_features context_features
 				context_values context_values
-				hyperparam_map hyperparam_map
+				data_params_map data_params_map
 			))
 		)
 

--- a/module/details_influences.amlg
+++ b/module/details_influences.amlg
@@ -93,7 +93,7 @@
 	(let
 		(assoc
 			;pull targetless dataset parameters because local data will include the action value and therefore is not targeted
-			targetless_hyperparam_map
+			targetless_data_params_map
 				(call !GetDataParameters (assoc
 					context_features context_features
 					feature .null
@@ -106,15 +106,15 @@
 				(contained_entities
 					filtering_queries
 					(query_nearest_generalized_distance
-						(get targetless_hyperparam_map "k")
+						(get targetless_data_params_map "k")
 						features
 						(append context_values action_values)
-						(get targetless_hyperparam_map "p")
-						(get targetless_hyperparam_map "featureWeights")
+						(get targetless_data_params_map "p")
+						(get targetless_data_params_map "featureWeights")
 						!queryFeatureAttributeTypeMap
-						(get targetless_hyperparam_map "featureDeviations")
+						(get targetless_data_params_map "featureDeviations")
 						.null
-						(get targetless_hyperparam_map "dt")
+						(get targetless_data_params_map "dt")
 						(if valid_weight_feature weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -122,7 +122,7 @@
 						!numericalPrecision
 					)
 				)
-			targetless_k (get targetless_hyperparam_map "k")
+			targetless_k (get targetless_data_params_map "k")
 		))
 
 		;for robust computation, increase the number of cases to improve accuracy
@@ -774,7 +774,7 @@
 			all_context_features context_features
 			all_context_features_indices_map (zip context_features (indices context_features))
 			action_is_nominal (contains_index !nominalsMap (first action_features))
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature (first action_features)
 					context_features context_features

--- a/module/details_influences.amlg
+++ b/module/details_influences.amlg
@@ -92,9 +92,9 @@
 	!ComputeFeatureACExPost
 	(let
 		(assoc
-			;pull targetless hyperparameters because local data will include the action value and therefore is not targeted
+			;pull targetless dataset parameters because local data will include the action value and therefore is not targeted
 			targetless_hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					context_features context_features
 					feature .null
 					weight_feature weight_feature
@@ -775,7 +775,7 @@
 			all_context_features_indices_map (zip context_features (indices context_features))
 			action_is_nominal (contains_index !nominalsMap (first action_features))
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature (first action_features)
 					context_features context_features
 					weight_feature weight_feature

--- a/module/details_residuals.amlg
+++ b/module/details_residuals.amlg
@@ -117,7 +117,7 @@
 								robust_residuals robust_residuals
 								compute_all_statistics compute_all_statistics
 								;use the same dataset parameters that were used to make the original prediction
-								custom_hyperparam_map hyperparam_map
+								custom_data_params_map data_params_map
 								compute_null_uncertainties .false
 							))
 					))
@@ -218,7 +218,7 @@
 								regional_data_only .true
 								robust_residuals "deviations"
 								;use the same dataset parameters that were used to make the original prediction
-								custom_hyperparam_map hyperparam_map
+								custom_data_params_map data_params_map
 								compute_null_uncertainties .false
 								weight_feature (if valid_weight_feature weight_feature .null)
 								valid_weight_feature valid_weight_feature
@@ -377,7 +377,7 @@
 						robust_residuals robust_residuals
 						use_case_weights use_case_weights
 						weight_feature weight_feature
-						custom_hyperparam_map hyperparam_map
+						custom_data_params_map data_params_map
 						compute_all_statistics .false
 						context_condition_filter_query context_condition_filter_query
 						strict_case_ids (!= 0 (size action_condition_filter_query))
@@ -411,9 +411,9 @@
 	(declare
 		(assoc
 			feature_weights
-				(if (size (get hyperparam_map "featureProbabilitiesMap"))
-					(get hyperparam_map "featureProbabilitiesMap")
-					(get hyperparam_map "featureWeights")
+				(if (size (get data_params_map "featureProbabilitiesMap"))
+					(get data_params_map "featureProbabilitiesMap")
+					(get data_params_map "featureWeights")
 				)
 		)
 
@@ -729,7 +729,7 @@
 	(declare
 		(assoc
 			action_features_map (keep case_value_map action_features)
-			global_residuals_map (get hyperparam_map "featureResiduals")
+			global_residuals_map (get data_params_map "featureResiduals")
 		)
 
 		(declare (assoc
@@ -877,7 +877,7 @@
 											robust_residuals .false
 											focal_case ignore_case
 											;use the same dataset parameters that were used to make the original prediction
-											custom_hyperparam_map hyperparam_map
+											custom_data_params_map data_params_map
 											compute_null_uncertainties .false
 											null_significance_threshold 0
 											strict_case_ids .true

--- a/module/details_residuals.amlg
+++ b/module/details_residuals.amlg
@@ -116,7 +116,7 @@
 								regional_data_only .true
 								robust_residuals robust_residuals
 								compute_all_statistics compute_all_statistics
-								;use the same hyperparameters that were used to make the original prediction
+								;use the same dataset parameters that were used to make the original prediction
 								custom_hyperparam_map hyperparam_map
 								compute_null_uncertainties .false
 							))
@@ -217,7 +217,7 @@
 								case_ids local_case_ids
 								regional_data_only .true
 								robust_residuals "deviations"
-								;use the same hyperparameters that were used to make the original prediction
+								;use the same dataset parameters that were used to make the original prediction
 								custom_hyperparam_map hyperparam_map
 								compute_null_uncertainties .false
 								weight_feature (if valid_weight_feature weight_feature .null)
@@ -876,7 +876,7 @@
 											regional_data_only .true
 											robust_residuals .false
 											focal_case ignore_case
-											;use the same hyperparameters that were used to make the original prediction
+											;use the same dataset parameters that were used to make the original prediction
 											custom_hyperparam_map hyperparam_map
 											compute_null_uncertainties .false
 											null_significance_threshold 0

--- a/module/details_residuals.amlg
+++ b/module/details_residuals.amlg
@@ -411,8 +411,8 @@
 	(declare
 		(assoc
 			feature_weights
-				(if (size (get hyperparam_map "featureMdaMap"))
-					(get hyperparam_map "featureMdaMap")
+				(if (size (get hyperparam_map "featureProbabilitiesMap"))
+					(get hyperparam_map "featureProbabilitiesMap")
 					(get hyperparam_map "featureWeights")
 				)
 		)

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -267,7 +267,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					context_features features
 					feature (if action_feature action_feature)
@@ -297,13 +297,13 @@
 
 		(declare (assoc
 			feature_weights
-				(if (and action_feature (size (get hyperparam_map "featureProbabilitiesMap")))
-					(get hyperparam_map "featureProbabilitiesMap")
-					(get hyperparam_map "featureWeights")
+				(if (and action_feature (size (get data_params_map "featureProbabilitiesMap")))
+					(get data_params_map "featureProbabilitiesMap")
+					(get data_params_map "featureWeights")
 				)
-			feature_deviations (get hyperparam_map "featureDeviations")
-			p_value (get hyperparam_map "p")
-			in_surprisal_space (= "surprisal_to_prob" (get hyperparam_map "dt"))
+			feature_deviations (get data_params_map "featureDeviations")
+			p_value (get data_params_map "p")
+			in_surprisal_space (= "surprisal_to_prob" (get data_params_map "dt"))
 		))
 
 		;iterate over all the unique session ids and create a map of session id -> session indices map
@@ -517,7 +517,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					context_features features
 					feature (if action_feature action_feature)
@@ -534,11 +534,11 @@
 		(call !UpdateCaseWeightParameters)
 
 		(declare (assoc
-			feature_weights (get hyperparam_map "featureWeights")
-			feature_deviations (get hyperparam_map "featureDeviations")
-			p_value (get hyperparam_map "p")
-			k_value (get hyperparam_map "k")
-			dt_value (get hyperparam_map "dt")
+			feature_weights (get data_params_map "featureWeights")
+			feature_deviations (get data_params_map "featureDeviations")
+			p_value (get data_params_map "p")
+			k_value (get data_params_map "k")
+			dt_value (get data_params_map "dt")
 		))
 
 		(if (> (size case_indices) 1)
@@ -838,7 +838,7 @@
 						p_parameter
 						feature_weights
 						!queryFeatureAttributeTypeMap
-						(if (or use_feature_deviations (= "surprisal_to_prob" dt_parameter)) (get hyperparam_map "featureDeviations") (get hyperparam_map "nullUncertainties"))
+						(if (or use_feature_deviations (= "surprisal_to_prob" dt_parameter)) (get data_params_map "featureDeviations") (get data_params_map "nullUncertainties"))
 						.null
 						;dt = 1 means return computed distance to the case
 						(if (= "surprisal_to_prob" dt_parameter) "surprisal" 1)

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -189,7 +189,7 @@
 			;which features to use when computing pairwise distances. If unspecified uses all features.
 			#{type "list" values "string"}
 			features .null
-			;if specified, uses targeted hyperparameters used to predict this action_feature, otherwise uses targetless hyperparameters.
+			;if specified, uses targeted dataset parameters used to predict this action_feature, otherwise uses targetless dataset parameters.
 			#{type "string"}
 			action_feature .null
 			;list of cases (lists of values), i.e., a 2d-list of values. Either from_values or from_case_indices must be specified, not both.
@@ -268,7 +268,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					context_features features
 					feature (if action_feature action_feature)
 					weight_feature weight_feature
@@ -456,7 +456,7 @@
 			;which features to use when computing case distances. If unspecified uses all features.
 			#{type "list" values "string"}
 			features .null
-			;if specified, uses targeted hyperparameters used to predict this action_feature, otherwise uses targetless hyperparameters.
+			;if specified, uses targeted dataset parameters used to predict this action_feature, otherwise uses targetless dataset parameters.
 			#{type "string"}
 			action_feature .null
 			;list of pair (list) of session id and index, where index is the original 0-based session_training_index of the case as it was
@@ -518,7 +518,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					context_features features
 					feature (if action_feature action_feature)
 					weight_feature weight_feature

--- a/module/distances.amlg
+++ b/module/distances.amlg
@@ -297,8 +297,8 @@
 
 		(declare (assoc
 			feature_weights
-				(if (and action_feature (size (get hyperparam_map "featureMdaMap")))
-					(get hyperparam_map "featureMdaMap")
+				(if (and action_feature (size (get hyperparam_map "featureProbabilitiesMap")))
+					(get hyperparam_map "featureProbabilitiesMap")
 					(get hyperparam_map "featureWeights")
 				)
 			feature_deviations (get hyperparam_map "featureDeviations")

--- a/module/editing.amlg
+++ b/module/editing.amlg
@@ -199,8 +199,8 @@
 					!featureNullRatiosMap (remove !featureNullRatiosMap feature)
 					!queryFeatureAttributeTypeMap (remove !queryFeatureAttributeTypeMap feature)
 
-					;use rewrite to remove all instances of feature in the !hyperparameterMetadataMap
-					!hyperparameterMetadataMap
+					;use rewrite to remove all instances of feature in the !dataParametersMap
+					!dataParametersMap
 						(rewrite
 							(lambda
 								(if (contains_index (current_value) feature)
@@ -208,7 +208,7 @@
 									(current_value)
 								)
 							)
-							!hyperparameterMetadataMap
+							!dataParametersMap
 						)
 
 					!expectedValuesMap
@@ -442,8 +442,8 @@
 				;update hyperparameters and clear the cached residuals flags
 				(assign_to_entities (assoc
 					!inactiveFeaturesNeedCaching .true
-					!hyperparameterMetadataMap (call !UpdateHyperparametersWithNewFeature (assoc hp_map !hyperparameterMetadataMap))
-					!defaultHyperparameters (call !UpdateHyperparametersWithNewFeature (assoc hp_map !defaultHyperparameters))
+					!dataParametersMap (call !UpdateHyperparametersWithNewFeature (assoc hp_map !dataParametersMap))
+					!defaultDataParametersMap (call !UpdateHyperparametersWithNewFeature (assoc hp_map !defaultDataParametersMap))
 
 					!trainedFeatures
 						(if (not (contains_value !trainedFeatures feature_name))

--- a/module/editing.amlg
+++ b/module/editing.amlg
@@ -442,8 +442,8 @@
 				;update dataset parameters and clear the cached residuals flags
 				(assign_to_entities (assoc
 					!inactiveFeaturesNeedCaching .true
-					!dataParametersMap (call !UpdateDataParametersWithNewFeature (assoc hp_map !dataParametersMap))
-					!defaultDataParametersMap (call !UpdateDataParametersWithNewFeature (assoc hp_map !defaultDataParametersMap))
+					!dataParametersMap (call !UpdateDataParametersWithNewFeature (assoc dp_map !dataParametersMap))
+					!defaultDataParametersMap (call !UpdateDataParametersWithNewFeature (assoc dp_map !defaultDataParametersMap))
 
 					!trainedFeatures
 						(if (not (contains_value !trainedFeatures feature_name))

--- a/module/editing.amlg
+++ b/module/editing.amlg
@@ -340,7 +340,7 @@
 			;	case as it was trained. If specified, ignores session and condition parameters.
 			#{ref "CaseIndices"}
 			case_indices .null
-			;flag, if set to true, will not update hyperparameter metadata map
+			;flag, if set to true, will not update dataset parameter metadata map
 			#{type "boolean"}
 			internal_feature .false
 			;assoc of feature specific attributes for this feature. If unspecified and conditions are not specified, will assume feature type as 'continuous'.
@@ -439,11 +439,11 @@
 					)
 				)
 
-				;update hyperparameters and clear the cached residuals flags
+				;update dataset parameters and clear the cached residuals flags
 				(assign_to_entities (assoc
 					!inactiveFeaturesNeedCaching .true
-					!dataParametersMap (call !UpdateHyperparametersWithNewFeature (assoc hp_map !dataParametersMap))
-					!defaultDataParametersMap (call !UpdateHyperparametersWithNewFeature (assoc hp_map !defaultDataParametersMap))
+					!dataParametersMap (call !UpdateDataParametersWithNewFeature (assoc hp_map !dataParametersMap))
+					!defaultDataParametersMap (call !UpdateDataParametersWithNewFeature (assoc hp_map !defaultDataParametersMap))
 
 					!trainedFeatures
 						(if (not (contains_value !trainedFeatures feature_name))

--- a/module/feature_conviction.amlg
+++ b/module/feature_conviction.amlg
@@ -23,15 +23,15 @@
 			entity_dist_contribution_map
 				(compute_on_contained_entities
 					||(query_entity_distance_contributions
-						(get hyperparam_map "k")
+						(get data_params_map "k")
 						features
 						entities ;if null, will compute on full dataset
-						(get hyperparam_map "p")
-						(get hyperparam_map "featureWeights")
+						(get data_params_map "p")
+						(get data_params_map "featureWeights")
 						!queryFeatureAttributeTypeMap
-						(get hyperparam_map "featureDeviations")
+						(get data_params_map "featureDeviations")
 						.null
-						(get hyperparam_map "dt")
+						(get data_params_map "dt")
 						(if valid_weight_feature weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -100,7 +100,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features features

--- a/module/feature_conviction.amlg
+++ b/module/feature_conviction.amlg
@@ -101,7 +101,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
 					weight_feature weight_feature

--- a/module/feature_residuals.amlg
+++ b/module/feature_residuals.amlg
@@ -40,7 +40,7 @@
 		(declare (assoc
 			hyperparam_map
 				(if (= .null custom_hyperparam_map)
-					(call !GetHyperparameters (assoc
+					(call !GetDataParameters (assoc
 						feature hyperparameter_feature
 						context_features context_features
 						weight_feature weight_feature
@@ -65,7 +65,7 @@
 		))
 
 
-		;if there are ordinals but the hyperparameter map doesn't have a featureOrdinalDeviations assoc, initialize it
+		;if there are ordinals but the dataset parameter map doesn't have a featureOrdinalDeviations assoc, initialize it
 		(if (and
 				(size !ordinalFeaturesSet)
 				(= .null (get hyperparam_map "featureOrdinalDeviations"))
@@ -208,11 +208,11 @@
 	; robust_residuals: string, default to .null. when "deviations" calculates accurate local residuals, otherwise computes residuals robust with respect to the set of contexts used
 	;		(across the power set of contexts).  when "robust_mda" will only compute and output MDA using robust residuals. when "missing_information" will compute and average the estimated
 	;		missing information for each feature.
-	; hyperparameter_feature: optional  default .null.  feature whose hyperparameters to use
+	; hyperparameter_feature: optional  default .null.  feature whose dataset parameters to use
 	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
-	; custom_hyperparam_map: optional, hyperparameters to use for residuals computation
+	; custom_hyperparam_map: optional, dataset parameters to use for residuals computation
 	; compute_all_statistics: flag, optional. if set to true will compute other statistics (precision, recall, r^2, rmse, etc.) in addition to MAE
 	; confusion_matrix_min_count: number, optional, default is 10. Applicable only to confusion matrices, the number of predictions a class should have
 	;		(value of a cell in the matrix) for it to remain in the confusion matrix. If the count is less than this value, it will be accumulated

--- a/module/feature_residuals.amlg
+++ b/module/feature_residuals.amlg
@@ -36,7 +36,7 @@
 			(assign (assoc weight_feature ".none"))
 		)
 
-		;set the passed in one as the hyperparam map to use if specified
+		;set the passed in one as the dataparams map to use if specified
 		(declare (assoc
 			data_params_map
 				(if (= .null custom_data_params_map)

--- a/module/feature_residuals.amlg
+++ b/module/feature_residuals.amlg
@@ -1,6 +1,6 @@
 ;Contains methods for computing and storing feature residuals.
 {
-	;Updates the given hyperparam_map and returns it with updated parameters based on computed residuals
+	;Updates the given data_params_map and returns it with updated parameters based on computed residuals
 	;parameters:
 	; see !CalculateFeatureResiduals()
 	!CalculateResidualsAndUpdateParameters
@@ -12,10 +12,10 @@
 			focal_case .null
 			num_samples .null
 			robust_residuals .false
-			hyperparameter_feature .null
+			dataparameters_feature .null
 			use_case_weights .null
 			weight_feature ".case_weight"
-			custom_hyperparam_map .null
+			custom_data_params_map .null
 			confusion_matrix_min_count 15
 			feature_with_nulls .null
 			compute_null_uncertainties .true
@@ -38,29 +38,29 @@
 
 		;set the passed in one as the hyperparam map to use if specified
 		(declare (assoc
-			hyperparam_map
-				(if (= .null custom_hyperparam_map)
+			data_params_map
+				(if (= .null custom_data_params_map)
 					(call !GetDataParameters (assoc
-						feature hyperparameter_feature
+						feature dataparameters_feature
 						context_features context_features
 						weight_feature weight_feature
 					))
 
-					custom_hyperparam_map
+					custom_data_params_map
 				)
 		))
 		(call !UpdateCaseWeightParameters (assoc set_valid_weight_feature .false ))
 		(declare (assoc
 			param_path
 				;if the param_path is missing, create it here
-				(if (= .null (get hyperparam_map "paramPath"))
+				(if (= .null (get data_params_map "paramPath"))
 					(append
-						(if hyperparameter_feature ["targeted" hyperparameter_feature] ["targetless"])
+						(if dataparameters_feature ["targeted" dataparameters_feature] ["targetless"])
 						(call !BuildContextFeaturesKey (assoc context_features features))
 						weight_feature
 					)
 
-					(get hyperparam_map "paramPath")
+					(get data_params_map "paramPath")
 				)
 		))
 
@@ -68,14 +68,14 @@
 		;if there are ordinals but the dataset parameter map doesn't have a featureOrdinalDeviations assoc, initialize it
 		(if (and
 				(size !ordinalFeaturesSet)
-				(= .null (get hyperparam_map "featureOrdinalDeviations"))
+				(= .null (get data_params_map "featureOrdinalDeviations"))
 			)
-			(accum (assoc hyperparam_map (assoc "featureOrdinalDeviations" (assoc))))
+			(accum (assoc data_params_map (assoc "featureOrdinalDeviations" (assoc))))
 		)
 
 		;if storing deviations ensure that featureDeviations is an assoc instead of .null for correct accumulation
-		(if (= .null (get hyperparam_map "featureDeviations" ))
-			(assign (assoc hyperparam_map (modify hyperparam_map "featureDeviations" (assoc))))
+		(if (= .null (get data_params_map "featureDeviations" ))
+			(assign (assoc data_params_map (modify data_params_map "featureDeviations" (assoc))))
 		)
 
 		(declare (assoc
@@ -87,10 +87,10 @@
 					focal_case focal_case
 					num_samples num_samples
 					robust_residuals robust_residuals
-					hyperparameter_feature hyperparameter_feature
+					dataparameters_feature dataparameters_feature
 					use_case_weights use_case_weights
 					weight_feature weight_feature
-					custom_hyperparam_map hyperparam_map
+					custom_data_params_map data_params_map
 					compute_all_statistics compute_all_statistics
 					confusion_matrix_min_count confusion_matrix_min_count
 					compute_null_uncertainties compute_null_uncertainties
@@ -98,14 +98,14 @@
 				))
 		))
 
-		(assign (assoc hyperparam_map (get output_map "hyperparam_map") ))
+		(assign (assoc data_params_map (get output_map "data_params_map") ))
 
-		;update hyperparam_map with null uncertainties if present
+		;update data_params_map with null uncertainties if present
 		(if (size (get output_map "nullUncertainties"))
 			(let
 				(assoc null_uncertainties_map (get output_map "null_uncertainty_map") )
 				(assign
-					"hyperparam_map"
+					"data_params_map"
 					(list "nullUncertainties")
 					(map
 						(lambda
@@ -117,7 +117,7 @@
 				)
 
 				(assign
-					"hyperparam_map"
+					"data_params_map"
 					(list "featureDeviations")
 					(map
 						(lambda
@@ -142,8 +142,8 @@
 								(current_value)
 							)
 						)
-						(if (size (get hyperparam_map "featureDeviations"))
-							(get hyperparam_map "featureDeviations")
+						(if (size (get data_params_map "featureDeviations"))
+							(get data_params_map "featureDeviations")
 							(zip (indices null_uncertainties_map))
 						)
 					)
@@ -152,7 +152,7 @@
 		)
 
 		(assign
-			"hyperparam_map"
+			"data_params_map"
 			(list "featureOrdinalDeviations")
 			(get output_map "ordinal_residuals_map")
 		)
@@ -166,7 +166,7 @@
 				))
 		))
 		(assign
-			"hyperparam_map"
+			"data_params_map"
 			["featureResiduals"]
 			(map
 				(lambda
@@ -188,11 +188,11 @@
 			)
 		)
 
-		hyperparam_map
+		data_params_map
 	)
 
 	;calculate feature residual values, i.e. the mae (mean absolute error of predictions on a sample of the dataset) for each of the specified features
-	;returns an assoc containing feature residuals, feature ordinal residuals and the hyperparam_map used for computations
+	;returns an assoc containing feature residuals, feature ordinal residuals and the data_params_map used for computations
 	;
 	;parameters:
 	; features: optional list of all features to compute residuals for. If not specified will use !trainedFeatures.
@@ -208,11 +208,11 @@
 	; robust_residuals: string, default to .null. when "deviations" calculates accurate local residuals, otherwise computes residuals robust with respect to the set of contexts used
 	;		(across the power set of contexts).  when "robust_mda" will only compute and output MDA using robust residuals. when "missing_information" will compute and average the estimated
 	;		missing information for each feature.
-	; hyperparameter_feature: optional  default .null.  feature whose dataset parameters to use
+	; dataparameters_feature: optional  default .null.  feature whose dataset parameters to use
 	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
-	; custom_hyperparam_map: optional, dataset parameters to use for residuals computation
+	; custom_data_params_map: optional, dataset parameters to use for residuals computation
 	; compute_all_statistics: flag, optional. if set to true will compute other statistics (precision, recall, r^2, rmse, etc.) in addition to MAE
 	; confusion_matrix_min_count: number, optional, default is 10. Applicable only to confusion matrices, the number of predictions a class should have
 	;		(value of a cell in the matrix) for it to remain in the confusion matrix. If the count is less than this value, it will be accumulated
@@ -254,10 +254,10 @@
 			;extra cases with non-null values appended to its list to be able to compute a residual value
 			local_feature_case_id_map .null
 
-			hyperparameter_feature .null
+			dataparameters_feature .null
 			use_case_weights .null
 			weight_feature ".case_weight"
-			custom_hyperparam_map .null
+			custom_data_params_map .null
 			compute_all_statistics .false
 			compute_null_uncertainties .true
 			confusion_matrix_min_count 15
@@ -279,7 +279,7 @@
 			p_parameter .null
 			dt_parameter .null
 			case_features .null
-			hyperparam_map (assoc)
+			data_params_map (assoc)
 			residuals_map (assoc)
 			ordinal_residuals_map (assoc)
 			;assoc of features to skip computing non-robust residuals for if they don't have enough non-null values
@@ -546,7 +546,7 @@
 					))
 				)
 
-				;compute null deviations and update hyperparam_map with them
+				;compute null deviations and update data_params_map with them
 				(if (or (size features_with_nulls) (size features_with_insignificant_non_nulls))
 					(call !ComputeNullUncertainties (assoc
 						features_with_nulls features_with_nulls
@@ -793,7 +793,7 @@
 		(assoc
 			"residual_map" residuals_map
 			"ordinal_residual_map" ordinal_residuals_map
-			"hyperparam_map" hyperparam_map
+			"data_params_map" data_params_map
 			"prediction_stats" prediction_stats
 			"null_uncertainty_map" null_uncertainties_map
 			"null_accuracy_map" null_accuracies_map
@@ -878,7 +878,7 @@
 										)
 
 										;else if there were no values for this feature, return global feature residual
-										(get hyperparam_map (list "featureResiduals" (get continuous_features (current_index 1))))
+										(get data_params_map (list "featureResiduals" (get continuous_features (current_index 1))))
 									)
 								)
 							)
@@ -904,7 +904,7 @@
 										(generalized_mean (map (lambda (first (current_value))) (current_value 1)) )
 
 										;else if there were no values for this feature, return global feature residual
-										(get hyperparam_map [ "featureResiduals" feature ] )
+										(get data_params_map [ "featureResiduals" feature ] )
 									)
 								;must have 30 or more nulls for null residuals to be statistically significant
 								null_residual
@@ -1142,7 +1142,7 @@
 							(generalized_mean (map (lambda (first (current_value))) (current_value)) )
 
 							;else if there were no values for this feature, return global feature residual
-							(modify (get hyperparam_map (list "featureResiduals" (modify (get nominal_features (current_index 1))))))
+							(modify (get data_params_map (list "featureResiduals" (modify (get nominal_features (current_index 1))))))
 						))
 						(unzip feature_residuals_lists nominal_indices)
 					)
@@ -1426,7 +1426,7 @@
 		))
 
 		(if (= .null param_path)
-			(declare (assoc param_path (get hyperparam_map "paramPath")))
+			(declare (assoc param_path (get data_params_map "paramPath")))
 		)
 
 		;wrap each confusion matrix in an assoc
@@ -1540,7 +1540,7 @@
 
 		(assoc
 			".robust" (and robust_residuals (!= "deviations" robust_residuals))
-			".hyperparam_path"
+			".dataparams_path"
 				(if (and use_case_weights (= param_path (list ".default")) )
 					;intentionally storing which case weight feature is used for retrieval
 					(list ".default" .null .null weight_feature)
@@ -1699,11 +1699,11 @@
 									]
 
 									(contains_index !nominalsMap feature)
-									[(get hyperparam_map ["featureResiduals" feature ]) 0 ]
+									[(get data_params_map ["featureResiduals" feature ]) 0 ]
 
 									;else continuous outputs a pair of default values
 									[
-										(get hyperparam_map ["featureResiduals" feature ])
+										(get data_params_map ["featureResiduals" feature ])
 										(/
 											1
 											(+ 1 (or (get !featureNullRatiosMap [feature "num_nulls"])) )
@@ -1739,7 +1739,7 @@
 											)
 
 											;else if there were no values for this feature, return global feature residual
-											(get hyperparam_map ["featureResiduals" (get features (current_index 1)) ])
+											(get data_params_map ["featureResiduals" (get features (current_index 1)) ])
 										)
 									)
 								)

--- a/module/get_cases.amlg
+++ b/module/get_cases.amlg
@@ -84,7 +84,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature ""
 					weight_feature (if valid_weight_feature weight_feature)
 				))
@@ -658,7 +658,7 @@
 				(assign (assoc
 					num_cases
 						(get
-							(call !GetHyperparameters (assoc
+							(call !GetDataParameters (assoc
 								feature .null
 								weight_feature ".none"
 							))
@@ -755,7 +755,7 @@
 					;list of features where the condition is a range or null
 					other_features (list)
 					hyperparam_map
-						(call !GetHyperparameters (assoc
+						(call !GetDataParameters (assoc
 							feature .null
 							weight_feature ".none"
 						))

--- a/module/get_cases.amlg
+++ b/module/get_cases.amlg
@@ -83,7 +83,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature ""
 					weight_feature (if valid_weight_feature weight_feature)
@@ -94,8 +94,8 @@
 
 		;setting up variables to use goal_feature influence code correctly
 		(declare (assoc
-			feature_weights (get hyperparam_map "featureWeights")
-			dt_parameter (get hyperparam_map "dt")
+			feature_weights (get data_params_map "featureWeights")
+			dt_parameter (get data_params_map "dt")
 			all_context_features (append features goal_dependent_features)
 		))
 
@@ -174,13 +174,13 @@
 		(query_exists !internalLabelSession)
 		custom_extra_filtering_queries
 		(query_nearest_generalized_distance
-			(get hyperparam_map "k")
+			(get data_params_map "k")
 			context_features
 			context_values
-			(get hyperparam_map "p")
+			(get data_params_map "p")
 			feature_weights
 			!queryFeatureAttributeTypeMap
-			(get hyperparam_map "featureDeviations")
+			(get data_params_map "featureDeviations")
 			.null
 			dt_parameter
 			(if valid_weight_feature weight_feature .null)
@@ -754,7 +754,7 @@
 					equals_features (list)
 					;list of features where the condition is a range or null
 					other_features (list)
-					hyperparam_map
+					data_params_map
 						(call !GetDataParameters (assoc
 							feature .null
 							weight_feature ".none"
@@ -817,12 +817,12 @@
 							num_cases
 							equals_features
 							equals_features_values
-							(get hyperparam_map "p")
-							(get hyperparam_map "featureWeights")
+							(get data_params_map "p")
+							(get data_params_map "featureWeights")
 							!queryFeatureAttributeTypeMap
-							(get hyperparam_map "featureDeviations")
+							(get data_params_map "featureDeviations")
 							.null
-							(get hyperparam_map "dt")
+							(get data_params_map "dt")
 							.null ;weight
 							;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 							"fixed rand seed"

--- a/module/hyperparameters.amlg
+++ b/module/hyperparameters.amlg
@@ -3,17 +3,17 @@
 	; contains, p, k, dt, gridSearchError, etc
 	!BackupAnalyzedDataParameters
 	(assign (assoc
-		previous_analyzed_hp_map analyzed_hp_map
-		baseline_data_parameters_map analyzed_hp_map
+		previous_analyzed_dp_map analyzed_dp_map
+		baseline_data_parameters_map analyzed_dp_map
 	))
 
 	;updates baseline_data_parameters_map
 	!KeepOrRevertDataParameters
-	(if (<= (get previous_analyzed_hp_map "gridSearchError") (get analyzed_hp_map "gridSearchError"))
-		(assign (assoc baseline_data_parameters_map previous_analyzed_hp_map))
+	(if (<= (get previous_analyzed_dp_map "gridSearchError") (get analyzed_dp_map "gridSearchError"))
+		(assign (assoc baseline_data_parameters_map previous_analyzed_dp_map))
 
 		;else update with analyzed
-		(assign (assoc baseline_data_parameters_map analyzed_hp_map))
+		(assign (assoc baseline_data_parameters_map analyzed_dp_map))
 	)
 
 	;updates baseline_data_parameters_map
@@ -278,7 +278,7 @@
 		)
 
 		(if (= (get baseline_data_parameters_map ["paramPath" 0]) ".default")
-			;updating default hyperparam set with featuredeviations
+			;updating default dataparams set with featuredeviations
 			(assign_to_entities (assoc !defaultDataParametersMap baseline_data_parameters_map ))
 
 			;update the appropriate dataset parameter set
@@ -291,7 +291,7 @@
 
 	;updates baseline_data_parameters_map
 	;uses provided baseline_data_parameters_map to compute the dataset MAE (!gridSerachError), if computed error is less than current/y stored error,
-	;updates baseline_data_parameters_map with the new error value, otherwise reverts it back to previous_analyzed_hp_map
+	;updates baseline_data_parameters_map with the new error value, otherwise reverts it back to previous_analyzed_dp_map
 	!TestAccuracyAndKeepOrRevertDataParameters
 	(seq
 		;re-set the defined random seed to run gridsearch the same way as it was run above
@@ -304,14 +304,14 @@
 
 		;if previous pass did better than this pass, revert baseline_data_parameters_map
 		(if (>= dataset_mae (get baseline_data_parameters_map "gridSearchError"))
-			(assign (assoc baseline_data_parameters_map previous_analyzed_hp_map))
+			(assign (assoc baseline_data_parameters_map previous_analyzed_dp_map))
 
-			;else keep update current hyperparams with new error value and back them up
+			;else keep update current data params with new error value and back them up
 			(seq
 				(assign (assoc
 					baseline_data_parameters_map (modify baseline_data_parameters_map "gridSearchError" dataset_mae)
 				))
-				(assign (assoc previous_analyzed_hp_map baseline_data_parameters_map))
+				(assign (assoc previous_analyzed_dp_map baseline_data_parameters_map))
 			)
 		)
 	)
@@ -319,7 +319,7 @@
 	;update all deviations in hyperparemeters with user specified errors
 	!UpdateDataParametersWithUserErrors
 	(declare
-		(assoc hp_map (assoc) )
+		(assoc dp_map (assoc) )
 
 		(rewrite
 			;if this is a hp assoc, modify it
@@ -371,17 +371,17 @@
 					(current_value)
 				)
 			)
-			hp_map
+			dp_map
 		)
 	)
 
 	;update dataset parameter map for newly added feature
-	; hp_map: the hp map to be updated, should be either !defaultDataParametersMap or !dataParametersMap
+	; dp_map: the hp map to be updated, should be either !defaultDataParametersMap or !dataParametersMap
 	; feature_name: the name of the new feature
 	; using_default_value: a flag indicating if all cases got a single value for the new feature (making it inactive)
 	!UpdateDataParametersWithNewFeature
 	(declare
-		(assoc hp_map (assoc) )
+		(assoc dp_map (assoc) )
 
 		(declare (assoc num_cases (call !GetNumTrainingCases) ))
 
@@ -455,7 +455,7 @@
 					(current_value)
 				)
 			)
-			hp_map
+			dp_map
 		)
 	)
 
@@ -515,7 +515,7 @@
 					(if (contains_index !dataParametersMap "targetless")
 						["targetless"]
 
-						;else just use one of the targeted analyzed hyperparam sets
+						;else just use one of the targeted analyzed dataparams sets
 						["targeted" (first (indices (get !dataParametersMap "targeted")))]
 					)
 

--- a/module/hyperparameters.amlg
+++ b/module/hyperparameters.amlg
@@ -209,7 +209,7 @@
 		(accum (assoc baseline_hyperparameter_map attribute_map ))
 	)
 
-	;write baseline_hyperparameter_map out to the trainee's !hyperparameterMetadataMap
+	;write baseline_hyperparameter_map out to the trainee's !dataParametersMap
 	;null action feature assumes targetless hyperparameters
 	!SetHyperparameters
 	(seq
@@ -227,7 +227,7 @@
 			context_key_index (if action_feature 2 1)
 		))
 
-		(if (not (contains_value !hyperparameterParamPaths (append target_mode context_features_key weight_feature) ) )
+		(if (not (contains_value !dataParametersPaths (append target_mode context_features_key weight_feature) ) )
 			(let
 				(assoc
 					;check if any hyperparameters exist that also match this action_feature and weight_feature
@@ -235,11 +235,11 @@
 					old_params_key_to_remove
 						(first (filter
 							(lambda (and
-								(get !hyperparameterMetadataMap (append (current_value) "derivedAutoAnalyzed"))
+								(get !dataParametersMap (append (current_value) "derivedAutoAnalyzed"))
 								;check if it matches with removed context key
 								(= (remove (current_value) context_key_index) (append target_mode weight_feature) )
 							))
-							!hyperparameterParamPaths
+							!dataParametersPaths
 						))
 				)
 
@@ -247,24 +247,24 @@
 				(if (size old_params_key_to_remove)
 					(seq
 						(assign_to_entities (assoc
-							!hyperparameterParamPaths (filter old_params_key_to_remove !hyperparameterParamPaths .false)
+							!dataParametersPaths (filter old_params_key_to_remove !dataParametersPaths .false)
 						))
 
 						;remove the old context features set
 						(assign_to_entities (assoc
-							!hyperparameterMetadataMap
+							!dataParametersMap
 								(modify
-									!hyperparameterMetadataMap
+									!dataParametersMap
 									target_mode
-									(remove (get !hyperparameterMetadataMap target_mode) (get old_params_key_to_remove context_key_index))
+									(remove (get !dataParametersMap target_mode) (get old_params_key_to_remove context_key_index))
 								)
-							!hyperparameterParamPaths (list (append target_mode context_features_key weight_feature))
+							!dataParametersPaths (list (append target_mode context_features_key weight_feature))
 						))
 					)
 
 					;else add the new path
 					(accum_to_entities (assoc
-						!hyperparameterParamPaths (list (append target_mode context_features_key weight_feature))
+						!dataParametersPaths (list (append target_mode context_features_key weight_feature))
 					))
 				)
 			)
@@ -279,11 +279,11 @@
 
 		(if (= (get baseline_hyperparameter_map ["paramPath" 0]) ".default")
 			;updating default hyperparam set with featuredeviations
-			(assign_to_entities (assoc !defaultHyperparameters baseline_hyperparameter_map ))
+			(assign_to_entities (assoc !defaultDataParametersMap baseline_hyperparameter_map ))
 
 			;update the appropriate hyperparameter set
 			(assign_to_entities (assoc
-				!hyperparameterMetadataMap (modify !hyperparameterMetadataMap (get baseline_hyperparameter_map "paramPath") baseline_hyperparameter_map)
+				!dataParametersMap (modify !dataParametersMap (get baseline_hyperparameter_map "paramPath") baseline_hyperparameter_map)
 			))
 		)
 		(accum_to_entities (assoc !revision 1))
@@ -376,7 +376,7 @@
 	)
 
 	;update hyperparameter map for newly added feature
-	; hp_map: the hp map to be updated, should be either !defaultHyperparameters or !hyperparameterMetadataMap
+	; hp_map: the hp map to be updated, should be either !defaultDataParametersMap or !dataParametersMap
 	; feature_name: the name of the new feature
 	; using_default_value: a flag indicating if all cases got a single value for the new feature (making it inactive)
 	!UpdateHyperparametersWithNewFeature
@@ -391,7 +391,7 @@
 					(let
 						(assoc
 							feature_weights_map (get (current_value 1) "featureWeights")
-							feature_mda_map (get (current_value 1) "featureMdaMap")
+							feature_mda_map (get (current_value 1) "featureProbabilitiesMap")
 							feature_deviations_map (get (current_value 1) "featureDeviations")
 						)
 
@@ -447,7 +447,7 @@
 						(append (current_value) (assoc
 							"featureWeights" feature_weights_map
 							"featureDeviations" feature_deviations_map
-							"featureMdaMap" feature_mda_map
+							"featureProbabilitiesMap" feature_mda_map
 						))
 					)
 
@@ -465,10 +465,10 @@
 		(assoc weight_feature ".none")
 
 		;if only one set of analyzed params, return them
-		(if (= 1 (size !hyperparameterParamPaths))
-			(conclude (get !hyperparameterMetadataMap (first !hyperparameterParamPaths)))
+		(if (= 1 (size !dataParametersPaths))
+			(conclude (get !dataParametersMap (first !dataParametersPaths)))
 
-			(= 0 (size !hyperparameterParamPaths))
+			(= 0 (size !dataParametersPaths))
 			(seq
 				(if (and
 						(not !autoAnalyzeEnabled )
@@ -493,7 +493,7 @@
 					))
 				)
 				;if no params, use defaults
-				(conclude !defaultHyperparameters)
+				(conclude !defaultDataParametersMap)
 			)
 		)
 
@@ -511,12 +511,12 @@
 		;if feature is specified as "", this will default to ["targetless"] since "" can't be a targeted action feature
 		(declare (assoc
 			target_mode
-				(if (or (= .null feature) (not (contains_index !hyperparameterMetadataMap ["targeted" feature])) )
-					(if (contains_index !hyperparameterMetadataMap "targetless")
+				(if (or (= .null feature) (not (contains_index !dataParametersMap ["targeted" feature])) )
+					(if (contains_index !dataParametersMap "targetless")
 						["targetless"]
 
 						;else just use one of the targeted analyzed hyperparam sets
-						["targeted" (first (indices (get !hyperparameterMetadataMap "targeted")))]
+						["targeted" (first (indices (get !dataParametersMap "targeted")))]
 					)
 
 					["targeted" feature]
@@ -525,8 +525,8 @@
 
 
 		;if we have completely correct HPs, return them
-		(if (contains_index !hyperparameterMetadataMap (append target_mode context_key weight_feature))
-			(conclude (get !hyperparameterMetadataMap (append target_mode context_key weight_feature)) )
+		(if (contains_index !dataParametersMap (append target_mode context_key weight_feature))
+			(conclude (get !dataParametersMap (append target_mode context_key weight_feature)) )
 		)
 
 		;we don't have the exact HPs, determine best context_key
@@ -536,7 +536,7 @@
 				context_key_options
 					(sort
 						(lambda (< (size (current_value)) (size (current_value 1))))
-						(indices (get !hyperparameterMetadataMap target_mode) )
+						(indices (get !dataParametersMap target_mode) )
 					)
 			)
 
@@ -547,27 +547,27 @@
 			(while (< (current_index) (size context_key_options))
 				(assign (assoc candidate_context_key (get context_key_options (current_index 1)) ))
 
-				(if (contains_index !hyperparameterMetadataMap (append target_mode candidate_context_key weight_feature))
+				(if (contains_index !dataParametersMap (append target_mode candidate_context_key weight_feature))
 					(conclude
 						(assign (assoc context_key candidate_context_key))
 					)
 
-					(contains_index !hyperparameterMetadataMap (append target_mode candidate_context_key ".none"))
+					(contains_index !dataParametersMap (append target_mode candidate_context_key ".none"))
 					(assign (assoc context_key candidate_context_key ))
 				)
 			)
 		)
 
 		;if we have the correct weight for the action and context, return it
-		(if (contains_index !hyperparameterMetadataMap (append target_mode context_key weight_feature))
-			(get !hyperparameterMetadataMap (append target_mode context_key weight_feature))
+		(if (contains_index !dataParametersMap (append target_mode context_key weight_feature))
+			(get !dataParametersMap (append target_mode context_key weight_feature))
 
 			;no case weight
-			(contains_index !hyperparameterMetadataMap (append target_mode context_key ".none"))
-			(get !hyperparameterMetadataMap (append target_mode context_key ".none"))
+			(contains_index !dataParametersMap (append target_mode context_key ".none"))
+			(get !dataParametersMap (append target_mode context_key ".none"))
 
 			;else the case_weight and ".none" isn't in the map, return the default params
-			!defaultHyperparameters
+			!defaultDataParametersMap
 		)
 	)
 
@@ -613,7 +613,7 @@
 				(assoc
 					"hyperparameter_map"
 						(if (= .null action_feature context_features weight_feature)
-							!hyperparameterMetadataMap
+							!dataParametersMap
 
 							;else one of these parameters were specified
 							(call !GetHyperparameters
@@ -629,7 +629,7 @@
 							)
 						)
 
-					"default_hyperparameter_map" !defaultHyperparameters
+					"default_hyperparameter_map" !defaultDataParametersMap
 					"numerical_precision" (if !numericalPrecisionFastest "fastest" !numericalPrecision)
 				)
 		))
@@ -689,7 +689,7 @@
 		(if (!= .null default_hyperparameter_map)
 			(seq
 				(accum (assoc default_hyperparameter_map {"paramPath" [".default"]} ))
-				(assign_to_entities (assoc !defaultHyperparameters default_hyperparameter_map) )
+				(assign_to_entities (assoc !defaultDataParametersMap default_hyperparameter_map) )
 			)
 		)
 
@@ -706,8 +706,8 @@
 				(call !RecursivelyAccumulateParamPaths)
 
 				(assign_to_entities (assoc
-					!hyperparameterMetadataMap hyperparameter_map
-					!hyperparameterParamPaths param_paths
+					!dataParametersMap hyperparameter_map
+					!dataParametersPaths param_paths
 				))
 			)
 		)
@@ -764,13 +764,13 @@
 		(map
 			(lambda (let
 				(assoc
-					subtrainee (get !hyperparameterMetadataMap (append (current_value 1) "subtraineeName"))
+					subtrainee (get !dataParametersMap (append (current_value 1) "subtraineeName"))
 				)
 				(if subtrainee
 					(call delete_subtrainee (assoc path [subtrainee] ))
 				)
 			))
-			!hyperparameterParamPaths
+			!dataParametersPaths
 		)
 
 		(assign_to_entities (assoc
@@ -779,8 +779,8 @@
 			!autoAnalyzeGrowthFactorAmount 7.3890561
 			!numericalPrecision .null
 			!numericalPrecisionFastest .false
-			!hyperparameterMetadataMap (assoc)
-			!defaultHyperparameters
+			!dataParametersMap (assoc)
+			!defaultDataParametersMap
 				(assoc
 					"k" 8
 					"p" 0.1

--- a/module/hyperparameters.amlg
+++ b/module/hyperparameters.amlg
@@ -4,19 +4,19 @@
 	!BackupAnalyzedDataParameters
 	(assign (assoc
 		previous_analyzed_hp_map analyzed_hp_map
-		baseline_hyperparameter_map analyzed_hp_map
+		baseline_data_parameters_map analyzed_hp_map
 	))
 
-	;updates baseline_hyperparameter_map
+	;updates baseline_data_parameters_map
 	!KeepOrRevertDataParameters
 	(if (<= (get previous_analyzed_hp_map "gridSearchError") (get analyzed_hp_map "gridSearchError"))
-		(assign (assoc baseline_hyperparameter_map previous_analyzed_hp_map))
+		(assign (assoc baseline_data_parameters_map previous_analyzed_hp_map))
 
 		;else update with analyzed
-		(assign (assoc baseline_hyperparameter_map analyzed_hp_map))
+		(assign (assoc baseline_data_parameters_map analyzed_hp_map))
 	)
 
-	;updates baseline_hyperparameter_map
+	;updates baseline_data_parameters_map
 	!UpdateDataParameters
 	(declare
 		(assoc
@@ -206,15 +206,15 @@
 				)
 		))
 
-		(accum (assoc baseline_hyperparameter_map attribute_map ))
+		(accum (assoc baseline_data_parameters_map attribute_map ))
 	)
 
-	;write baseline_hyperparameter_map out to the trainee's !dataParametersMap
+	;write baseline_data_parameters_map out to the trainee's !dataParametersMap
 	;null action feature assumes targetless dataset parameters
 	!SetDataParameters
 	(seq
 		(if derived_auto_analyzed
-			(accum (assoc baseline_hyperparameter_map (assoc "derivedAutoAnalyzed" .true) ))
+			(accum (assoc baseline_data_parameters_map (assoc "derivedAutoAnalyzed" .true) ))
 		)
 
 		(declare (assoc
@@ -273,25 +273,25 @@
 		;add subtrainee ID
 		(if deviation_subtrainee_name
 			(assign (assoc
-				baseline_hyperparameter_map (append baseline_hyperparameter_map {"subtraineeName" deviation_subtrainee_name})
+				baseline_data_parameters_map (append baseline_data_parameters_map {"subtraineeName" deviation_subtrainee_name})
 			))
 		)
 
-		(if (= (get baseline_hyperparameter_map ["paramPath" 0]) ".default")
+		(if (= (get baseline_data_parameters_map ["paramPath" 0]) ".default")
 			;updating default hyperparam set with featuredeviations
-			(assign_to_entities (assoc !defaultDataParametersMap baseline_hyperparameter_map ))
+			(assign_to_entities (assoc !defaultDataParametersMap baseline_data_parameters_map ))
 
 			;update the appropriate dataset parameter set
 			(assign_to_entities (assoc
-				!dataParametersMap (modify !dataParametersMap (get baseline_hyperparameter_map "paramPath") baseline_hyperparameter_map)
+				!dataParametersMap (modify !dataParametersMap (get baseline_data_parameters_map "paramPath") baseline_data_parameters_map)
 			))
 		)
 		(accum_to_entities (assoc !revision 1))
 	)
 
-	;updates baseline_hyperparameter_map
-	;uses provided baseline_hyperparameter_map to compute the dataset MAE (!gridSerachError), if computed error is less than current/y stored error,
-	;updates baseline_hyperparameter_map with the new error value, otherwise reverts it back to previous_analyzed_hp_map
+	;updates baseline_data_parameters_map
+	;uses provided baseline_data_parameters_map to compute the dataset MAE (!gridSerachError), if computed error is less than current/y stored error,
+	;updates baseline_data_parameters_map with the new error value, otherwise reverts it back to previous_analyzed_hp_map
 	!TestAccuracyAndKeepOrRevertDataParameters
 	(seq
 		;re-set the defined random seed to run gridsearch the same way as it was run above
@@ -302,16 +302,16 @@
 			dataset_mae (call !ComputeResidualForParameters)
 		))
 
-		;if previous pass did better than this pass, revert baseline_hyperparameter_map
-		(if (>= dataset_mae (get baseline_hyperparameter_map "gridSearchError"))
-			(assign (assoc baseline_hyperparameter_map previous_analyzed_hp_map))
+		;if previous pass did better than this pass, revert baseline_data_parameters_map
+		(if (>= dataset_mae (get baseline_data_parameters_map "gridSearchError"))
+			(assign (assoc baseline_data_parameters_map previous_analyzed_hp_map))
 
 			;else keep update current hyperparams with new error value and back them up
 			(seq
 				(assign (assoc
-					baseline_hyperparameter_map (modify baseline_hyperparameter_map "gridSearchError" dataset_mae)
+					baseline_data_parameters_map (modify baseline_data_parameters_map "gridSearchError" dataset_mae)
 				))
-				(assign (assoc previous_analyzed_hp_map baseline_hyperparameter_map))
+				(assign (assoc previous_analyzed_hp_map baseline_data_parameters_map))
 			)
 		)
 	)
@@ -585,8 +585,8 @@
 		# 	type "assoc"
 		#	additional_indices .false
 		# 	indices {
-		# 		"hyperparameter_map" {any_of [{ref "DataParametersMap"} {ref "DataParametersMapFull"}] description "The full map of dataset parameters or a specific map of dataset parameters if any parameters were given"}
-		# 		"default_hyperparameter_map" {ref "DataParametersMap" description "The map of default dataset parameters"}
+		# 		"data_parameters_map" {any_of [{ref "DataParametersMap"} {ref "DataParametersMapFull"}] description "The full map of dataset parameters or a specific map of dataset parameters if any parameters were given"}
+		# 		"default_data_parameters_map" {ref "DataParametersMap" description "The map of default dataset parameters"}
 		# 		"auto_analyze_enabled" {type "boolean" description "Flag indicating of auto-analysis is enabled."}
 		# 		"analyze_threshold" {type "number" description "The number of cases at which the auto-analysis is triggered."}
 		# 		"analyze_growth_factor" {type "number" description "The scalar rate at which the number of cases to trigger an auto-analysis grows with each iteration"}
@@ -611,7 +611,7 @@
 		(declare (assoc
 			internal_parameters_map
 				(assoc
-					"hyperparameter_map"
+					"data_parameters_map"
 						(if (= .null action_feature context_features weight_feature)
 							!dataParametersMap
 
@@ -629,7 +629,7 @@
 							)
 						)
 
-					"default_hyperparameter_map" !defaultDataParametersMap
+					"default_data_parameters_map" !defaultDataParametersMap
 					"numerical_precision" (if !numericalPrecisionFastest "fastest" !numericalPrecision)
 				)
 		))
@@ -661,10 +661,10 @@
 			;			...
 			;	}
 			#{ref "DataParametersMapFull"}
-			hyperparameter_map .null
+			data_parameters_map .null
 			;an assoc of dataset parameters to use when no others are available must contain k, p, and dt.
 			#{ref "DataParametersMap"}
-			default_hyperparameter_map .null
+			default_data_parameters_map .null
 			;flag, default is false. when true, returns when it's time for dataset to be analyzed again.
 			#{type "boolean"}
 			auto_analyze_enabled .null
@@ -686,27 +686,27 @@
 		(call !ValidateParameters)
 
 
-		(if (!= .null default_hyperparameter_map)
+		(if (!= .null default_data_parameters_map)
 			(seq
-				(accum (assoc default_hyperparameter_map {"paramPath" [".default"]} ))
-				(assign_to_entities (assoc !defaultDataParametersMap default_hyperparameter_map) )
+				(accum (assoc default_data_parameters_map {"paramPath" [".default"]} ))
+				(assign_to_entities (assoc !defaultDataParametersMap default_data_parameters_map) )
 			)
 		)
 
 		;the passed in dataset parameters must at least have the basic attributes defined correctly
 		;iterate over action features
-		(if (!= .null hyperparameter_map)
+		(if (!= .null data_parameters_map)
 			(let
 				(assoc
 					param_paths []
 					keys []
 				)
 
-				;populate all provided param_paths from the specified hyperparameter_map by appending all the indices recursively
+				;populate all provided param_paths from the specified data_parameters_map by appending all the indices recursively
 				(call !RecursivelyAccumulateParamPaths)
 
 				(assign_to_entities (assoc
-					!dataParametersMap hyperparameter_map
+					!dataParametersMap data_parameters_map
 					!dataParametersPaths param_paths
 				))
 			)
@@ -736,7 +736,7 @@
 		(call !Return)
 	)
 
-	;populate all provided param_paths from the specified hyperparameter_map by appending all the indices recursively
+	;populate all provided param_paths from the specified data_parameters_map by appending all the indices recursively
 	!RecursivelyAccumulateParamPaths
 	(map
 		(lambda
@@ -749,11 +749,11 @@
 
 				(call !RecursivelyAccumulateParamPaths (assoc
 					keys (append keys (current_index 1))
-					hyperparameter_map (current_value 1)
+					data_parameters_map (current_value 1)
 				))
 			)
 		)
-		hyperparameter_map
+		data_parameters_map
 	)
 
 	;resets all dataset parameters and thresholds back to original values, while leaving feature definitions alone

--- a/module/hyperparameters.amlg
+++ b/module/hyperparameters.amlg
@@ -1,14 +1,14 @@
-;Contains helper methods for hyperparameter maintenance.
+;Contains helper methods for dataset parameter maintenance.
 {
 	; contains, p, k, dt, gridSearchError, etc
-	!BackupAnalyzedHyperparameters
+	!BackupAnalyzedDataParameters
 	(assign (assoc
 		previous_analyzed_hp_map analyzed_hp_map
 		baseline_hyperparameter_map analyzed_hp_map
 	))
 
 	;updates baseline_hyperparameter_map
-	!KeepOrRevertHyperparameters
+	!KeepOrRevertDataParameters
 	(if (<= (get previous_analyzed_hp_map "gridSearchError") (get analyzed_hp_map "gridSearchError"))
 		(assign (assoc baseline_hyperparameter_map previous_analyzed_hp_map))
 
@@ -17,7 +17,7 @@
 	)
 
 	;updates baseline_hyperparameter_map
-	!UpdateHyperparameters
+	!UpdateDataParameters
 	(declare
 		(assoc
 			use_weights .null
@@ -210,8 +210,8 @@
 	)
 
 	;write baseline_hyperparameter_map out to the trainee's !dataParametersMap
-	;null action feature assumes targetless hyperparameters
-	!SetHyperparameters
+	;null action feature assumes targetless dataset parameters
+	!SetDataParameters
 	(seq
 		(if derived_auto_analyzed
 			(accum (assoc baseline_hyperparameter_map (assoc "derivedAutoAnalyzed" .true) ))
@@ -230,8 +230,8 @@
 		(if (not (contains_value !dataParametersPaths (append target_mode context_features_key weight_feature) ) )
 			(let
 				(assoc
-					;check if any hyperparameters exist that also match this action_feature and weight_feature
-					;if any exist that were derived_auto_analyzed, remove them because that means these new hyperparameters supercede them
+					;check if any dataset parameters exist that also match this action_feature and weight_feature
+					;if any exist that were derived_auto_analyzed, remove them because that means these new dataset parameters supercede them
 					old_params_key_to_remove
 						(first (filter
 							(lambda (and
@@ -281,7 +281,7 @@
 			;updating default hyperparam set with featuredeviations
 			(assign_to_entities (assoc !defaultDataParametersMap baseline_hyperparameter_map ))
 
-			;update the appropriate hyperparameter set
+			;update the appropriate dataset parameter set
 			(assign_to_entities (assoc
 				!dataParametersMap (modify !dataParametersMap (get baseline_hyperparameter_map "paramPath") baseline_hyperparameter_map)
 			))
@@ -292,7 +292,7 @@
 	;updates baseline_hyperparameter_map
 	;uses provided baseline_hyperparameter_map to compute the dataset MAE (!gridSerachError), if computed error is less than current/y stored error,
 	;updates baseline_hyperparameter_map with the new error value, otherwise reverts it back to previous_analyzed_hp_map
-	!TestAccuracyAndKeepOrRevertHyperparameters
+	!TestAccuracyAndKeepOrRevertDataParameters
 	(seq
 		;re-set the defined random seed to run gridsearch the same way as it was run above
 		(set_rand_seed sampling_random_seed)
@@ -317,7 +317,7 @@
 	)
 
 	;update all deviations in hyperparemeters with user specified errors
-	!UpdateHyperparametersWithUserErrors
+	!UpdateDataParametersWithUserErrors
 	(declare
 		(assoc hp_map (assoc) )
 
@@ -375,11 +375,11 @@
 		)
 	)
 
-	;update hyperparameter map for newly added feature
+	;update dataset parameter map for newly added feature
 	; hp_map: the hp map to be updated, should be either !defaultDataParametersMap or !dataParametersMap
 	; feature_name: the name of the new feature
 	; using_default_value: a flag indicating if all cases got a single value for the new feature (making it inactive)
-	!UpdateHyperparametersWithNewFeature
+	!UpdateDataParametersWithNewFeature
 	(declare
 		(assoc hp_map (assoc) )
 
@@ -460,7 +460,7 @@
 	)
 
 
-	!GetHyperparameters
+	!GetDataParameters
 	(declare
 		(assoc weight_feature ".none")
 
@@ -477,8 +477,8 @@
 						(not (contains_index
 							warnings
 								(concat
-									"There are no cached hyperparameters in this trainee. "
-									"This operation was executed using a set of predefined default hyperparameters. "
+									"There are no cached dataset parameters in this trainee. "
+									"This operation was executed using a set of predefined default dataset parameters. "
 									"Please run `analyze` or enable auto-analysis with `set_auto_analyze_params`."
 								)
 						))
@@ -486,8 +486,8 @@
 					(accum (assoc
 						warnings
 							(associate (concat
-								"There are no cached hyperparameters in this trainee. "
-								"This operation was executed using a set of predefined default hyperparameters. "
+								"There are no cached dataset parameters in this trainee. "
+								"This operation was executed using a set of predefined default dataset parameters. "
 								"Please run `analyze` or enable auto-analysis with `set_auto_analyze_params`."
 							))
 					))
@@ -577,7 +577,7 @@
 
 
 	;return the full internal parameters map if no parameters are specified.
-	;if any of the parameters are specified, then GetHyperparameters is called, which uses the specified parameters to find the most suitable set of hyperparameters to return
+	;if any of the parameters are specified, then GetDataParameters is called, which uses the specified parameters to find the most suitable set of dataset parameters to return
 	#{read_only .true idempotent .true}
 	get_params
 	(declare
@@ -585,8 +585,8 @@
 		# 	type "assoc"
 		#	additional_indices .false
 		# 	indices {
-		# 		"hyperparameter_map" {any_of [{ref "HyperparameterMap"} {ref "HyperparameterMapFull"}] description "The full map of hyperparameters or a specific map of hyperparameters if any parameters were given"}
-		# 		"default_hyperparameter_map" {ref "HyperparameterMap" description "The map of default hyperparameters"}
+		# 		"hyperparameter_map" {any_of [{ref "DataParametersMap"} {ref "DataParametersMapFull"}] description "The full map of dataset parameters or a specific map of dataset parameters if any parameters were given"}
+		# 		"default_hyperparameter_map" {ref "DataParametersMap" description "The map of default dataset parameters"}
 		# 		"auto_analyze_enabled" {type "boolean" description "Flag indicating of auto-analysis is enabled."}
 		# 		"analyze_threshold" {type "number" description "The number of cases at which the auto-analysis is triggered."}
 		# 		"analyze_growth_factor" {type "number" description "The scalar rate at which the number of cases to trigger an auto-analysis grows with each iteration"}
@@ -594,15 +594,15 @@
 		# 	}
 		# }
 		(assoc
-			;the target feature of the desired hyperparameters, when specified as a feature name, outputs the matching "targeted" hyperparameters.
-			;	When empty string "" will output "targetless" hyperparameters. When unspecified defaults to whatever hyperparameters were analyzed,
-			;	prioritizing "targetless" hyperparameters if multiple parameters exist.
+			;the target feature of the desired dataset parameters, when specified as a feature name, outputs the matching "targeted" dataset parameters.
+			;	When empty string "" will output "targetless" dataset parameters. When unspecified defaults to whatever dataset parameters were analyzed,
+			;	prioritizing "targetless" dataset parameters if multiple parameters exist.
 			#{type "string"}
 			action_feature .null
-			;the set of context features used for the desired hyperparameters
+			;the set of context features used for the desired dataset parameters
 			#{type "list" values "string"}
 			context_features .null
-			;the weight feature used in the calculation of the desired hyperparameters
+			;the weight feature used in the calculation of the desired dataset parameters
 			#{type "string"}
 			weight_feature .null
 		)
@@ -616,14 +616,14 @@
 							!dataParametersMap
 
 							;else one of these parameters were specified
-							(call !GetHyperparameters
+							(call !GetDataParameters
 								(append
 									(assoc
 										feature action_feature
 										context_features context_features
 									)
 									;don't pass weight_feature in if it wasn't specified,
-									;allowing GetHyperparameters to use its defaults
+									;allowing GetDataParameters to use its defaults
 									(if weight_feature (assoc weight_feature weight_feature) {})
 								)
 							)
@@ -648,7 +648,7 @@
 		(call !Return (assoc payload internal_parameters_map))
 	)
 
-	;sets internal hyperparameters
+	;sets internal dataset parameters
 	#{idempotent .true}
 	set_params
 	(declare
@@ -660,10 +660,10 @@
 			;		"targeted" : { "featureA" : { "featureB.featureC.": { ".none" : { "k" : number, "p" : number, "dt": number }}}},
 			;			...
 			;	}
-			#{ref "HyperparameterMapFull"}
+			#{ref "DataParametersMapFull"}
 			hyperparameter_map .null
-			;an assoc of hyperparameters to use when no others are available must contain k, p, and dt.
-			#{ref "HyperparameterMap"}
+			;an assoc of dataset parameters to use when no others are available must contain k, p, and dt.
+			#{ref "DataParametersMap"}
 			default_hyperparameter_map .null
 			;flag, default is false. when true, returns when it's time for dataset to be analyzed again.
 			#{type "boolean"}
@@ -693,7 +693,7 @@
 			)
 		)
 
-		;the passed in hyperparameters must at least have the basic attributes defined correctly
+		;the passed in dataset parameters must at least have the basic attributes defined correctly
 		;iterate over action features
 		(if (!= .null hyperparameter_map)
 			(let
@@ -756,7 +756,7 @@
 		hyperparameter_map
 	)
 
-	;resets all hyperparameters and thresholds back to original values, while leaving feature definitions alone
+	;resets all dataset parameters and thresholds back to original values, while leaving feature definitions alone
 	#{idempotent .true}
 	reset_params
 	(seq
@@ -848,9 +848,9 @@
 			#{type "list" values ["number" "string"]}
 			dt_values .null
 			;enumeration, default is "single_targeted"
-			;   "single_targeted" = analyze hyperparameters for the specified action_features
-			;   "omni_targeted" = analyze hyperparameters for each action feature, using all other features as context_features. if action_features aren't specified, uses all context_features.
-			;   "targetless" = analyze hyperparameters for all context features as possible action features, ignores action_features parameter
+			;   "single_targeted" = analyze dataset parameters for the specified action_features
+			;   "omni_targeted" = analyze dataset parameters for each action feature, using all other features as context_features. if action_features aren't specified, uses all context_features.
+			;   "targetless" = analyze dataset parameters for all context features as possible action features, ignores action_features parameter
 			#{type "string" enum ["single_targeted" "omni_targeted" "targetless"]}
 			targeted_model "single_targeted"
 			;name of feature whose values to use as case weights

--- a/module/hypotheticals.amlg
+++ b/module/hypotheticals.amlg
@@ -359,7 +359,7 @@
 		(if (= (size hyperparam_map 0))
 			(assign (assoc
 				hyperparam_map
-					(call !GetHyperparameters (assoc
+					(call !GetDataParameters (assoc
 						context_features context_features
 						weight_feature (if use_case_weights weight_feature)
 					))

--- a/module/hypotheticals.amlg
+++ b/module/hypotheticals.amlg
@@ -53,7 +53,7 @@
 									(get react_feature_deviations [(current_index 2) 0])
 									;use global value if the local one is null, pull deviation stored in featureResiduals because
 									;it'll be a single value whereas featureDeviations may or may not be a tuple
-									(get hyperparam_map ["featureResiduals" (current_index 2)])
+									(get data_params_map ["featureResiduals" (current_index 2)])
 								)
 						)
 
@@ -254,7 +254,7 @@
 									(get react_feature_deviations [feature 0])
 									;use global value if the local one is null, pull deviation stored in featureResiduals because
 									;it'll be a single value whereas featureDeviations may or may not be a tuple
-									(get hyperparam_map ["featureResiduals" feature])
+									(get data_params_map ["featureResiduals" feature])
 								)
 						)
 
@@ -352,13 +352,13 @@
 			features []
 			use_case_weights .false
 			weight_feature .null
-			hyperparam_map (assoc)
+			data_params_map (assoc)
 			context_condition_filter_query (list)
 		)
 
-		(if (= (size hyperparam_map 0))
+		(if (= (size data_params_map 0))
 			(assign (assoc
-				hyperparam_map
+				data_params_map
 					(call !GetDataParameters (assoc
 						context_features context_features
 						weight_feature (if use_case_weights weight_feature)
@@ -416,15 +416,15 @@
 															context_condition_filter_query
 															(query_not_in_entity_list [(current_value 2)])
 															(query_nearest_generalized_distance
-																(get hyperparam_map "k")
+																(get data_params_map "k")
 																remaining_context_features
 																(unzip (get cases_context_values (current_index 1)) remaining_context_indices)
-																(get hyperparam_map "p")
-																(get hyperparam_map "featureWeights")
+																(get data_params_map "p")
+																(get data_params_map "featureWeights")
 																!queryFeatureAttributeTypeMap
-																(get hyperparam_map "featureDeviations")
+																(get data_params_map "featureDeviations")
 																feature
-																(get hyperparam_map "dt")
+																(get data_params_map "dt")
 																(if use_case_weights weight_feature .null)
 																;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 																"fixed rand seed"
@@ -504,15 +504,15 @@
 														context_condition_filter_query
 														(query_not_in_entity_list [(current_value 2)])
 														(query_nearest_generalized_distance
-															(get hyperparam_map "k")
+															(get data_params_map "k")
 															remaining_context_features
 															(unzip (get cases_context_values (current_index 1)) remaining_context_indices)
-															(get hyperparam_map "p")
-															(get hyperparam_map "featureWeights")
+															(get data_params_map "p")
+															(get data_params_map "featureWeights")
 															!queryFeatureAttributeTypeMap
-															(get hyperparam_map "featureDeviations")
+															(get data_params_map "featureDeviations")
 															feature
-															(get hyperparam_map "dt")
+															(get data_params_map "dt")
 															(if use_case_weights weight_feature .null)
 															;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 															"fixed rand seed"

--- a/module/influences.amlg
+++ b/module/influences.amlg
@@ -87,7 +87,7 @@
 			(assign (assoc
 				hyperparam_map
 					(if (= 1 (size action_features))
-						(call !GetHyperparameters (assoc
+						(call !GetDataParameters (assoc
 							context_features context_features
 							feature (first action_features)
 							weight_feature weight_feature
@@ -250,7 +250,7 @@
 			(assign (assoc
 				hyperparam_map
 					(if (= 1 (size action_features))
-						(call !GetHyperparameters (assoc
+						(call !GetDataParameters (assoc
 							context_features context_features
 							feature (first action_features)
 							weight_feature weight_feature
@@ -383,7 +383,7 @@
 	;			predictions, high uses categorical action probabilities for both correct and incorrect predictions
 	; ignore_exact_cases: flag, if set to true will call !ReactDiscriminative with the case ids so that perfect matches will be ignored
 	; robust_residuals: flag, default to false. when true calculates residuals robust with respect to the set of contexts used (across the power set of contexts)
-	; custom_hyperparam_map: optional assoc of hyperparameters to use (instead of system-determined ones) when calculating MAE
+	; custom_hyperparam_map: optional assoc of dataset parameters to use (instead of system-determined ones) when calculating MAE
 	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights

--- a/module/influences.amlg
+++ b/module/influences.amlg
@@ -31,7 +31,7 @@
 			robust .false
 			weight_feature ".case_weight"
 			use_case_weights .null
-			hyperparam_map .null
+			data_params_map .null
 			context_condition_filter_query (list)
 			regional_data_only .false
 			features_to_derive []
@@ -50,7 +50,7 @@
 							features (values (append context_features action_features) .true)
 							robust_residuals "robust_mda"
 							case_ids case_ids
-							custom_hyperparam_map hyperparam_map
+							custom_data_params_map data_params_map
 							features_to_derive features_to_derive
 							output_raw_mda .true
 							compute_null_uncertainties .false
@@ -83,9 +83,9 @@
 			)
 		)
 
-		(if (= .null hyperparam_map)
+		(if (= .null data_params_map)
 			(assign (assoc
-				hyperparam_map
+				data_params_map
 					(if (= 1 (size action_features))
 						(call !GetDataParameters (assoc
 							context_features context_features
@@ -141,7 +141,7 @@
 					context_features context_features
 					robust_residuals .false
 					case_ids case_ids
-					custom_hyperparam_map hyperparam_map
+					custom_data_params_map data_params_map
 					features_to_derive features_to_derive
 					compute_null_uncertainties .false
 					regional_data_only regional_data_only
@@ -178,7 +178,7 @@
 							context_features (filter feature context_features .false)
 							robust_residuals .false
 							case_ids case_ids
-							custom_hyperparam_map hyperparam_map
+							custom_data_params_map data_params_map
 							features_to_derive features_to_derive
 							compute_null_uncertainties .false
 							regional_data_only regional_data_only
@@ -240,15 +240,15 @@
 			robust .false
 			weight_feature ".case_weight"
 			use_case_weights .null
-			hyperparam_map .null
+			data_params_map .null
 			context_condition_filter_query (list)
 			regional_data_only .false
 			features_to_derive []
 		)
 
-		(if (= .null hyperparam_map)
+		(if (= .null data_params_map)
 			(assign (assoc
-				hyperparam_map
+				data_params_map
 					(if (= 1 (size action_features))
 						(call !GetDataParameters (assoc
 							context_features context_features
@@ -292,7 +292,7 @@
 					ignore_exact_cases .true
 					classification_precision classification_precision
 					robust_residuals robust
-					custom_hyperparam_map hyperparam_map
+					custom_data_params_map data_params_map
 					use_case_weights use_case_weights
 					weight_feature weight_feature
 					context_condition_filter_query context_condition_filter_query
@@ -326,7 +326,7 @@
 									ignore_exact_cases .true
 									classification_precision classification_precision
 									robust_residuals robust
-									custom_hyperparam_map hyperparam_map
+									custom_data_params_map data_params_map
 									use_case_weights use_case_weights
 									weight_feature weight_feature
 									context_condition_filter_query context_condition_filter_query
@@ -383,7 +383,7 @@
 	;			predictions, high uses categorical action probabilities for both correct and incorrect predictions
 	; ignore_exact_cases: flag, if set to true will call !ReactDiscriminative with the case ids so that perfect matches will be ignored
 	; robust_residuals: flag, default to false. when true calculates residuals robust with respect to the set of contexts used (across the power set of contexts)
-	; custom_hyperparam_map: optional assoc of dataset parameters to use (instead of system-determined ones) when calculating MAE
+	; custom_data_params_map: optional assoc of dataset parameters to use (instead of system-determined ones) when calculating MAE
 	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
@@ -404,7 +404,7 @@
 			;default to medium precision
 			classification_precision 1
 			robust_residuals .false
-			custom_hyperparam_map .null
+			custom_data_params_map .null
 			use_case_weights .null
 			weight_feature ".case_weight"
 			context_condition_filter_query (list)
@@ -889,7 +889,7 @@
 			details (assoc "categorical_action_probabilities" .true "ignore_case" .null)
 			ignore_case (if ignore_exact_cases case_id .null)
 			substitute_output .false
-			hyperparam_map custom_hyperparam_map
+			data_params_map custom_data_params_map
 			weight_feature weight_feature
 			use_case_weights use_case_weights
 			;disable usage of dependent features for resdiual computation to prevent recursive behaviour in reacts
@@ -935,7 +935,7 @@
 															details (assoc "categorical_action_probabilities" .true "ignore_case" .null)
 															ignore_case (if ignore_exact_cases case_id .null)
 															substitute_output .false
-															hyperparam_map custom_hyperparam_map
+															data_params_map custom_data_params_map
 															weight_feature weight_feature
 															use_case_weights use_case_weights
 															;disable usage of dependent features for resdiual computation to prevent recursive behaviour in reacts
@@ -974,7 +974,7 @@
 										details (assoc "categorical_action_probabilities" .true "ignore_case" .null)
 										ignore_case (if ignore_exact_cases case_id .null)
 										substitute_output .false
-										hyperparam_map custom_hyperparam_map
+										data_params_map custom_data_params_map
 										weight_feature weight_feature
 										use_case_weights use_case_weights
 										;disable usage of dependent features for resdiual computation to prevent recursive behaviour in reacts

--- a/module/mda_weight.amlg
+++ b/module/mda_weight.amlg
@@ -57,7 +57,7 @@
 							num_test_cases
 							(max 50 (/ 10000 (size features)))
 						)
-					hyperparam_map (modify hyperparam_map "featureMdaMap" custom_mda_map)
+					hyperparam_map (modify hyperparam_map "featureProbabilitiesMap" custom_mda_map)
 				))
 
 				(if custom_residuals_map
@@ -264,7 +264,7 @@
 														)
 													feature_weights
 														(if per_feature_weights
-															(get hyperparam_map ["featureMdaMap" feature])
+															(get hyperparam_map ["featureProbabilitiesMap" feature])
 															(get hyperparam_map "featureWeights")
 														)
 												)
@@ -1194,7 +1194,7 @@
 					num_test_cases
 					(max 50 (/ 10000 (size features)))
 				)
-			hyperparam_map (modify hyperparam_map "featureMdaMap" custom_mda_map)
+			hyperparam_map (modify hyperparam_map "featureProbabilitiesMap" custom_mda_map)
 			;assoc of feature -> minimum null residual, for features with nulls
 			min_null_residual_map
 				(filter (map
@@ -1371,7 +1371,7 @@
 										superfull_candidate_cases_lists
 											(call !MissingInformationQuery (assoc
 												query_context_features superfull_context_features
-												feature_weights (get hyperparam_map ["featureMdaMap"])
+												feature_weights (get hyperparam_map ["featureProbabilitiesMap"])
 											))
 									))
 
@@ -1400,7 +1400,7 @@
 										full_candidate_cases_lists
 											(call !MissingInformationQuery (assoc
 												query_context_features full_context_features
-												feature_weights (get orig_hyperparam_map ["featureMdaMap"])
+												feature_weights (get orig_hyperparam_map ["featureProbabilitiesMap"])
 											))
 									))
 
@@ -1562,7 +1562,7 @@
 															candidate_cases_lists
 																(call !MissingInformationQuery (assoc
 																	query_context_features full_context_features
-																	feature_weights (get orig_hyperparam_map ["featureMdaMap"])
+																	feature_weights (get orig_hyperparam_map ["featureProbabilitiesMap"])
 																	context_condition_filter_query
 																		(if (size context_condition_filter_query)
 																			(append context_condition_filter_query (query_not_equals feature .null) )
@@ -1581,7 +1581,7 @@
 															candidate_cases_lists
 																(call !MissingInformationQuery (assoc
 																	query_context_features superfull_context_features
-																	feature_weights (get hyperparam_map ["featureMdaMap"])
+																	feature_weights (get hyperparam_map ["featureProbabilitiesMap"])
 																	context_condition_filter_query
 																		(if (size context_condition_filter_query)
 																			(append context_condition_filter_query (query_not_equals feature .null) )

--- a/module/mda_weight.amlg
+++ b/module/mda_weight.amlg
@@ -1067,7 +1067,7 @@
 						(min
 							;use the first value out of [value residual, null residual] pair
 							(first (current_value 1))
-							;compare with originally computed residuals by doubling the half-sized ones that are stored in hyperparameters
+							;compare with originally computed residuals by doubling the half-sized ones that are stored in dataset parameters
 							(* 2 (get updated_estimated_residuals_map ["hyperparam_map" "featureResiduals" (current_index 2)]))
 						)
 				)

--- a/module/mda_weight.amlg
+++ b/module/mda_weight.amlg
@@ -57,14 +57,14 @@
 							num_test_cases
 							(max 50 (/ 10000 (size features)))
 						)
-					hyperparam_map (modify hyperparam_map "featureProbabilitiesMap" custom_mda_map)
+					data_params_map (modify data_params_map "featureProbabilitiesMap" custom_mda_map)
 				))
 
 				(if custom_residuals_map
 					(assign (assoc
-						hyperparam_map
-							(modify hyperparam_map "featureDeviations"
-								(append (get hyperparam_map "featureDeviations") custom_residuals_map)
+						data_params_map
+							(modify data_params_map "featureDeviations"
+								(append (get data_params_map "featureDeviations") custom_residuals_map)
 							)
 					))
 				)
@@ -148,9 +148,9 @@
 												context_features
 												(unzip case_values_map context_features)
 												p_parameter
-												(get hyperparam_map "featureWeights")
+												(get data_params_map "featureWeights")
 												!queryFeatureAttributeTypeMap
-												(get hyperparam_map "featureDeviations")
+												(get data_params_map "featureDeviations")
 												.null
 												dt_parameter
 												(if valid_weight_feature weight_feature .null)
@@ -264,8 +264,8 @@
 														)
 													feature_weights
 														(if per_feature_weights
-															(get hyperparam_map ["featureProbabilitiesMap" feature])
-															(get hyperparam_map "featureWeights")
+															(get data_params_map ["featureProbabilitiesMap" feature])
+															(get data_params_map "featureWeights")
 														)
 												)
 
@@ -309,7 +309,7 @@
 														p_parameter
 														feature_weights
 														!queryFeatureAttributeTypeMap
-														(get hyperparam_map "featureDeviations")
+														(get data_params_map "featureDeviations")
 														.null
 														dt_parameter
 														(if valid_weight_feature weight_feature .null)
@@ -778,7 +778,7 @@
 			smallest_probability (/ 1 (+ 0.5 num_training_cases) (size features))
 
 			;baseline isn't specified, declare it on the stack here
-			baseline_hyperparameter_map hyperparam_map
+			baseline_data_parameters_map data_params_map
 		))
 
 		;iterate over an assoc of MDA maps per feature and convert to a normalized probability feature mda matrix
@@ -789,7 +789,7 @@
 					(assoc
 						target_feature (current_value 1)
 						feature_index (current_index 1)
-						target_feature_residual (get baseline_hyperparameter_map ["featureResiduals" (current_value 2)])
+						target_feature_residual (get baseline_data_parameters_map ["featureResiduals" (current_value 2)])
 						;the second value is the nullness
 						target_null_residual (get null_residual_map (current_value 1))
 					)
@@ -1068,7 +1068,7 @@
 							;use the first value out of [value residual, null residual] pair
 							(first (current_value 1))
 							;compare with originally computed residuals by doubling the half-sized ones that are stored in dataset parameters
-							(* 2 (get updated_estimated_residuals_map ["hyperparam_map" "featureResiduals" (current_index 2)]))
+							(* 2 (get updated_estimated_residuals_map ["data_params_map" "featureResiduals" (current_index 2)]))
 						)
 				)
 
@@ -1146,7 +1146,7 @@
 					(if (size (get residuals_map "residual_map" ))
 						(get residuals_map "residual_map" )
 						;output global robust residuals if new ones were not computed
-						(get hyperparam_map "featureRobustResiduals")
+						(get data_params_map "featureRobustResiduals")
 					)
 				)
 		}
@@ -1183,8 +1183,8 @@
 		))
 
 		(declare (assoc
-			orig_hyperparam_map hyperparam_map
-			feature_deviations (get hyperparam_map "featureDeviations")
+			orig_data_params_map data_params_map
+			feature_deviations (get data_params_map "featureDeviations")
 		))
 
 		(assign (assoc
@@ -1194,7 +1194,7 @@
 					num_test_cases
 					(max 50 (/ 10000 (size features)))
 				)
-			hyperparam_map (modify hyperparam_map "featureProbabilitiesMap" custom_mda_map)
+			data_params_map (modify data_params_map "featureProbabilitiesMap" custom_mda_map)
 			;assoc of feature -> minimum null residual, for features with nulls
 			min_null_residual_map
 				(filter (map
@@ -1371,7 +1371,7 @@
 										superfull_candidate_cases_lists
 											(call !MissingInformationQuery (assoc
 												query_context_features superfull_context_features
-												feature_weights (get hyperparam_map ["featureProbabilitiesMap"])
+												feature_weights (get data_params_map ["featureProbabilitiesMap"])
 											))
 									))
 
@@ -1400,7 +1400,7 @@
 										full_candidate_cases_lists
 											(call !MissingInformationQuery (assoc
 												query_context_features full_context_features
-												feature_weights (get orig_hyperparam_map ["featureProbabilitiesMap"])
+												feature_weights (get orig_data_params_map ["featureProbabilitiesMap"])
 											))
 									))
 
@@ -1473,7 +1473,7 @@
 														allow_nulls .true
 														feature_has_continuous_nulls (contains_index continuous_with_nulls_map feature)
 													))
-												feature_deviation (get orig_hyperparam_map ["featureResiduals" feature]) ;;;TODO: 25242 replace with full deviation?
+												feature_deviation (get orig_data_params_map ["featureResiduals" feature]) ;;;TODO: 25242 replace with full deviation?
 											))
 
 											;there are nulls in the local data if either full_caps_map or categorical_action_probabilities_map has values
@@ -1562,7 +1562,7 @@
 															candidate_cases_lists
 																(call !MissingInformationQuery (assoc
 																	query_context_features full_context_features
-																	feature_weights (get orig_hyperparam_map ["featureProbabilitiesMap"])
+																	feature_weights (get orig_data_params_map ["featureProbabilitiesMap"])
 																	context_condition_filter_query
 																		(if (size context_condition_filter_query)
 																			(append context_condition_filter_query (query_not_equals feature .null) )
@@ -1581,7 +1581,7 @@
 															candidate_cases_lists
 																(call !MissingInformationQuery (assoc
 																	query_context_features superfull_context_features
-																	feature_weights (get hyperparam_map ["featureProbabilitiesMap"])
+																	feature_weights (get data_params_map ["featureProbabilitiesMap"])
 																	context_condition_filter_query
 																		(if (size context_condition_filter_query)
 																			(append context_condition_filter_query (query_not_equals feature .null) )

--- a/module/react.amlg
+++ b/module/react.amlg
@@ -519,7 +519,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature (if (= 1 (size action_features)) (first action_features) )
 					context_features context_features
@@ -928,7 +928,7 @@
 		(call !CheckForIncompletePreservedActionFeatures)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature (if (= 1 (size action_features)) (first action_features) )
 					context_features context_features
@@ -1351,7 +1351,7 @@
 						)
 
 						(declare (assoc
-							hyperparam_map
+							data_params_map
 								(call !GetDataParameters (assoc
 									feature .null
 									context_features context_features
@@ -1387,7 +1387,7 @@
 									extra_features extra_features
 									force_targetless .true
 									ignore_case .null
-									hyperparam_map hyperparam_map
+									data_params_map data_params_map
 									custom_extra_filtering_queries holdout_queries
 								))
 						))
@@ -1523,12 +1523,12 @@
 					))
 					(list)
 				)
-			k_parameter (get hyperparam_map "k")
-			feature_deviations (get hyperparam_map "featureDeviations")
+			k_parameter (get data_params_map "k")
+			feature_deviations (get data_params_map "featureDeviations")
 			feature_weights
-				(if (= .null (get hyperparam_map "featureProbabilitiesMap"))
-					(get hyperparam_map "featureWeights")
-					(get hyperparam_map "featureProbabilitiesMap")
+				(if (= .null (get data_params_map "featureProbabilitiesMap"))
+					(get data_params_map "featureWeights")
+					(get data_params_map "featureProbabilitiesMap")
 				)
 
 			;check if action_feature has nulls, if not, the no need to filter them out since they don't exist
@@ -1577,11 +1577,11 @@
 		)
 
 		;use dynamic deviations subtrainee if present
-		(if (get hyperparam_map "subtraineeName")
+		(if (get data_params_map "subtraineeName")
 			(call !UseDynamicDeviationsAndWeights (assoc
 				context_features context_features
 				context_values context_values
-				hyperparam_map hyperparam_map
+				data_params_map data_params_map
 			))
 		)
 
@@ -1622,7 +1622,7 @@
 						context_features context_features
 						context_values context_values
 						custom_extra_filtering_queries custom_extra_filtering_queries
-						dt_parameter (get hyperparam_map "dt")
+						dt_parameter (get data_params_map "dt")
 						query_label "!ReactionQuery"
 					))
 			))
@@ -1727,12 +1727,12 @@
 			k_parameter
 			context_features
 			context_values
-			(get hyperparam_map "p")
+			(get data_params_map "p")
 			feature_weights
 			!queryFeatureAttributeTypeMap
 			feature_deviations
 			(first action_features) ;used to select the feature weights
-			(get hyperparam_map "dt")
+			(get data_params_map "dt")
 			(if valid_weight_feature weight_feature .null)
 			tie_break_random_seed
 			.null ;radius
@@ -1743,7 +1743,7 @@
 
 	;helper method for React calls that checks marginal, expected value, and residuals caches
 	;requires the following vars on the stack:
-	; hyperparam_map, desired_conviction, weight_feature, use_case_weights
+	; data_params_map, desired_conviction, weight_feature, use_case_weights
 	; These should be ready if !GetDataParameters and !UpdateCaseWeightParameters are called beforehand
 	!PreReactCacheChecks
 	(seq
@@ -1752,7 +1752,7 @@
 		;they are needed regardless of which residual mode is being used
 		(if (and
 				(!= desired_conviction .null)
-				(= 0 (size (get hyperparam_map "featureResiduals")))
+				(= 0 (size (get data_params_map "featureResiduals")))
 				(>= (call !GetNumTrainingCases) 2)
 			)
 			(seq
@@ -1763,14 +1763,14 @@
 					params { "total" 2 }
 				))
 				(assign (assoc
-					hyperparam_map
+					data_params_map
 						(call !CalculateResidualsAndUpdateParameters (assoc
 							context_features !trainedFeatures
-							custom_hyperparam_map hyperparam_map
+							custom_data_params_map data_params_map
 							num_samples 1000
 							;robust with respect to the set of contexts used (across the power set of contexts)
 							robust_residuals (!= 1 (size action_features))
-							hyperparameter_feature
+							dataparameters_feature
 								(if (= 1 (size action_features))
 									(first action_features)
 								)
@@ -1781,12 +1781,12 @@
 						))
 				))
 				(call !ProgressClear)
-				(if (= (first (get hyperparam_map "paramPath")) ".default")
+				(if (= (first (get data_params_map "paramPath")) ".default")
 					;updating default hyperparam set with featuredeviations
-					(assign_to_entities (assoc !defaultDataParametersMap hyperparam_map) )
+					(assign_to_entities (assoc !defaultDataParametersMap data_params_map) )
 
 					;update the appropriate dataset parameter set
-					(assign_to_entities (assoc !dataParametersMap (modify !dataParametersMap (get hyperparam_map "paramPath") hyperparam_map)) )
+					(assign_to_entities (assoc !dataParametersMap (modify !dataParametersMap (get data_params_map "paramPath") data_params_map)) )
 				)
 			)
 		)
@@ -1823,7 +1823,7 @@
 
 	;update "minimum_time_bound" which is the stored minimum time value that can be used as an upper bound
 	;in queries when the time feature is universal
-	;needs "hyperparam_map"
+	;needs "data_params_map"
 	!UpdateMinimumTimeBound
 	(assign_to_entities (assoc
 		!tsFeaturesMap
@@ -1836,9 +1836,9 @@
 							(query_exists !tsTimeFeature)
 							(query_min
 								!tsTimeFeature
-								(if (~ 0 (get hyperparam_map "k"))
-									(get hyperparam_map "k")
-									(get hyperparam_map ["k" 1])
+								(if (~ 0 (get data_params_map "k"))
+									(get data_params_map "k")
+									(get data_params_map ["k" 1])
 								)
 							)
 						)

--- a/module/react.amlg
+++ b/module/react.amlg
@@ -24,7 +24,7 @@
 			;	Must be different than context_features. May include similarity conviction and distance contribution features,
 			;	however, if either of those features are requested, then `react_into_features` must be called first with those features
 			; 	selected. For those features, the name must match the name specified when calling `react_into_features`. If not specified
-			;	in `react_into_features`, then they default to "similarity_conviction" and "distance_contribution".
+			;	in `react_into_features`, then they default to ".similarity_conviction" and ".distance_contribution".
 			#{type "list" values "string"}
 			derived_context_features (list)
 			;list of action features whose values should be computed from the resulting action prior to output, in the specified

--- a/module/react.amlg
+++ b/module/react.amlg
@@ -520,7 +520,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature (if (= 1 (size action_features)) (first action_features) )
 					context_features context_features
 					weight_feature weight_feature
@@ -929,7 +929,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature (if (= 1 (size action_features)) (first action_features) )
 					context_features context_features
 					weight_feature weight_feature
@@ -1352,7 +1352,7 @@
 
 						(declare (assoc
 							hyperparam_map
-								(call !GetHyperparameters (assoc
+								(call !GetDataParameters (assoc
 									feature .null
 									context_features context_features
 									weight_feature weight_feature
@@ -1476,7 +1476,7 @@
 	; ignore_case: case_id, if set will query for K+1 cases and ignore the perfect matching case during the reaction
 	; tie_break_random_seed: the random number seed to use to break ties for equal distances
 	; allow_nulls: flag, if set to true will allow interpolate to return null values if there are nulls in the local data for the action features
-	; force_targetless: flag, if set to true forces use of targetless hyperparameters if available
+	; force_targetless: flag, if set to true forces use of targetless dataset parameters if available
 	; use_case_weights: flag, if set to true will scale influence weights by each case's .case_weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
 	; custom_extra_filtering_queries: optional list of filtering queries to reduce the search space
@@ -1744,7 +1744,7 @@
 	;helper method for React calls that checks marginal, expected value, and residuals caches
 	;requires the following vars on the stack:
 	; hyperparam_map, desired_conviction, weight_feature, use_case_weights
-	; These should be ready if !GetHyperparameters and !UpdateCaseWeightParameters are called beforehand
+	; These should be ready if !GetDataParameters and !UpdateCaseWeightParameters are called beforehand
 	!PreReactCacheChecks
 	(seq
 		;if doing a generative react and global residuals have have not been calculated yet,
@@ -1785,7 +1785,7 @@
 					;updating default hyperparam set with featuredeviations
 					(assign_to_entities (assoc !defaultDataParametersMap hyperparam_map) )
 
-					;update the appropriate hyperparameter set
+					;update the appropriate dataset parameter set
 					(assign_to_entities (assoc !dataParametersMap (modify !dataParametersMap (get hyperparam_map "paramPath") hyperparam_map)) )
 				)
 			)

--- a/module/react.amlg
+++ b/module/react.amlg
@@ -1782,7 +1782,7 @@
 				))
 				(call !ProgressClear)
 				(if (= (first (get data_params_map "paramPath")) ".default")
-					;updating default hyperparam set with featuredeviations
+					;updating default dataparams set with featuredeviations
 					(assign_to_entities (assoc !defaultDataParametersMap data_params_map) )
 
 					;update the appropriate dataset parameter set

--- a/module/react.amlg
+++ b/module/react.amlg
@@ -1526,9 +1526,9 @@
 			k_parameter (get hyperparam_map "k")
 			feature_deviations (get hyperparam_map "featureDeviations")
 			feature_weights
-				(if (= .null (get hyperparam_map "featureMdaMap"))
+				(if (= .null (get hyperparam_map "featureProbabilitiesMap"))
 					(get hyperparam_map "featureWeights")
-					(get hyperparam_map "featureMdaMap")
+					(get hyperparam_map "featureProbabilitiesMap")
 				)
 
 			;check if action_feature has nulls, if not, the no need to filter them out since they don't exist
@@ -1783,10 +1783,10 @@
 				(call !ProgressClear)
 				(if (= (first (get hyperparam_map "paramPath")) ".default")
 					;updating default hyperparam set with featuredeviations
-					(assign_to_entities (assoc !defaultHyperparameters hyperparam_map) )
+					(assign_to_entities (assoc !defaultDataParametersMap hyperparam_map) )
 
 					;update the appropriate hyperparameter set
-					(assign_to_entities (assoc !hyperparameterMetadataMap (modify !hyperparameterMetadataMap (get hyperparam_map "paramPath") hyperparam_map)) )
+					(assign_to_entities (assoc !dataParametersMap (modify !dataParametersMap (get hyperparam_map "paramPath") hyperparam_map)) )
 				)
 			)
 		)

--- a/module/react_aggregate.amlg
+++ b/module/react_aggregate.amlg
@@ -53,18 +53,18 @@
 			;of the originally sampled case.
 			#{type "list" values "string"}
 			goal_dependent_features (list)
-			;full path for hyperparameters to use for computation.
+			;full path for dataset parameters to use for computation.
 			;	If specified for any residual computations, takes precendence over prediction_stats_action_feature and feature_influences_action_feature
-			;	parameters for hyperparameter selection.
+			;	parameters for dataset parameter selection.
 			#{type "list" values "string"}
 			hyperparameter_param_path .null
 			;if specified will calculate only on a sub trainee of the specified size from the full trainee.
 			;	Applicable only to datasets > 1000 cases.
 			#{type "number" min 0}
 			sub_model_size .null
-			;When calculating residuals and prediction stats, uses this target features's hyperparameters. The trainee should have been analyzed
+			;When calculating residuals and prediction stats, uses this target features's dataset parameters. The trainee should have been analyzed
 			;   with this feature as the action feature first. If "prediction_stats_action_feature" is not provided, residuals and prediction
-			;	stats uses "targetless" hyperparameters.
+			;	stats uses "targetless" dataset parameters.
 			#{type "string"}
 			prediction_stats_action_feature .null
 			;When computing feature influences such as prediction contributions or accuracy contributions, use this feature as the action feature.
@@ -74,7 +74,7 @@
 			;Only continuous and nominal features can be evaluated in this manner.
 			#{type "any"}
 			forecast_window_length .null
-			;flag, optional. if specified, will attempt to return stats that were computed using hyperparameters with the
+			;flag, optional. if specified, will attempt to return stats that were computed using dataset parameters with the
 			;	specified robust or non-robust type.
 			#{type "boolean"}
 			robust_hyperparameters .null
@@ -286,13 +286,13 @@
 				(assoc hp_map (get (retrieve_from_entity "!dataParametersMap") hyperparameter_param_path) )
 				(if (= .null hp_map)
 					(conclude (conclude
-						(call !Return (assoc errors (list "Invalid hyperparameter param path provided. Please call 'get_params' for list of available param paths.")))
+						(call !Return (assoc errors (list "Invalid dataset parameter param path provided. Please call 'get_params' for list of available param paths.")))
 					))
 				)
 			)
 		)
 
-		;use "targetless" hyperparameters by setting prediction_stats_action_feature to null
+		;use "targetless" dataset parameters by setting prediction_stats_action_feature to null
 		(if (= "" prediction_stats_action_feature)
 			(assign (assoc prediction_stats_action_feature .null ))
 		)
@@ -1369,17 +1369,17 @@
 	(let
 		(assoc
 			expected_hp_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature action_feature
 					context_features (filter action_feature context_features .false)
 					weight_feature weight_feature
 				))
 			param_path (list)
 		)
-		;hyperparameter path tuple
+		;dataset parameter path tuple
 		(assign (assoc param_path (get expected_hp_map "paramPath") ))
 
-		;if pulled hyperparameters don't match requested, display warning
+		;if pulled dataset parameters don't match requested, display warning
 		(if (!= weight_feature (last param_path))
 			(accum (assoc
 				warnings

--- a/module/react_aggregate.amlg
+++ b/module/react_aggregate.amlg
@@ -57,7 +57,7 @@
 			;	If specified for any residual computations, takes precendence over prediction_stats_action_feature and feature_influences_action_feature
 			;	parameters for dataset parameter selection.
 			#{type "list" values "string"}
-			hyperparameter_param_path .null
+			dataparameters_param_path .null
 			;if specified will calculate only on a sub trainee of the specified size from the full trainee.
 			;	Applicable only to datasets > 1000 cases.
 			#{type "number" min 0}
@@ -281,9 +281,9 @@
 			warnings (assoc)
 		))
 
-		(if hyperparameter_param_path
+		(if dataparameters_param_path
 			(let
-				(assoc hp_map (get (retrieve_from_entity "!dataParametersMap") hyperparameter_param_path) )
+				(assoc hp_map (get (retrieve_from_entity "!dataParametersMap") dataparameters_param_path) )
 				(if (= .null hp_map)
 					(conclude (conclude
 						(call !Return (assoc errors (list "Invalid dataset parameter param path provided. Please call 'get_params' for list of available param paths.")))
@@ -522,10 +522,10 @@
 		)
 
 		(declare (assoc
-			;set the custom hp map if specified a hyperparameter_param_path
-			custom_hyperparam_map
-				(if hyperparameter_param_path
-					(get !dataParametersMap hyperparameter_param_path)
+			;set the custom hp map if specified a dataparameters_param_path
+			custom_data_params_map
+				(if dataparameters_param_path
+					(get !dataParametersMap dataparameters_param_path)
 				)
 			;initialize conditional queries
 			action_condition_filter_query
@@ -879,10 +879,10 @@
 							features action_features
 							context_features context_features
 							robust_residuals .false
-							hyperparameter_feature prediction_stats_action_feature
+							dataparameters_feature prediction_stats_action_feature
 							use_case_weights use_case_weights
 							weight_feature weight_feature
-							custom_hyperparam_map custom_hyperparam_map
+							custom_data_params_map custom_data_params_map
 							compute_all_statistics .true
 							confusion_matrix_min_count confusion_matrix_min_count
 							context_condition_filter_query context_condition_filter_query
@@ -899,7 +899,7 @@
 						(append
 							(filter
 								(lambda (contains_value selected_prediction_stats (current_index)))
-								(remove (get prediction_stats_map "prediction_stats") [".robust" ".hyperparam_path"])
+								(remove (get prediction_stats_map "prediction_stats") [".robust" ".dataparams_path"])
 							)
 							(if (contains_value selected_prediction_stats "mae")
 								(assoc "mae" (get prediction_stats_map "residual_map"))
@@ -944,10 +944,10 @@
 										context_features context_features
 										case_ids case_ids
 										robust_residuals .false
-										hyperparameter_feature prediction_stats_action_feature
+										dataparameters_feature prediction_stats_action_feature
 										use_case_weights use_case_weights
 										weight_feature weight_feature
-										custom_hyperparam_map custom_hyperparam_map
+										custom_data_params_map custom_data_params_map
 										compute_all_statistics .false
 										confusion_matrix_min_count confusion_matrix_min_count
 										context_condition_filter_query context_condition_filter_query
@@ -980,10 +980,10 @@
 											context_features context_features
 											case_ids robust_residual_case_ids
 											robust_residuals .true
-											hyperparameter_feature prediction_stats_action_feature
+											dataparameters_feature prediction_stats_action_feature
 											use_case_weights use_case_weights
 											weight_feature weight_feature
-											custom_hyperparam_map custom_hyperparam_map
+											custom_data_params_map custom_data_params_map
 											compute_all_statistics .false
 											confusion_matrix_min_count confusion_matrix_min_count
 											context_condition_filter_query context_condition_filter_query
@@ -1012,7 +1012,7 @@
 												context_features context_features
 												case_ids case_ids
 												robust_residuals "deviations"
-												custom_hyperparam_map custom_hyperparam_map
+												custom_data_params_map custom_data_params_map
 												compute_all_statistics .false
 												confusion_matrix_min_count confusion_matrix_min_count
 												context_condition_filter_query context_condition_filter_query
@@ -1055,7 +1055,7 @@
 
 							use_case_weights use_case_weights
 							weight_feature weight_feature
-							hyperparam_map custom_hyperparam_map
+							data_params_map custom_data_params_map
 							context_condition_filter_query context_condition_filter_query
 							convergence_threshold convergence_threshold
 							convergence_samples_growth_rate convergence_samples_growth_rate
@@ -1121,7 +1121,7 @@
 								robust .false
 								case_ids case_ids
 								weight_feature weight_feature
-								custom_hyperparam_map custom_hyperparam_map
+								custom_data_params_map custom_data_params_map
 								context_condition_filter_query context_condition_filter_query
 								num_samples num_samples
 								derive_action_feature (contains_value features_to_derive feature_influences_action_feature)
@@ -1138,7 +1138,7 @@
 								robust .true
 								case_ids robust_prediction_contributions_case_ids
 								weight_feature weight_feature
-								custom_hyperparam_map custom_hyperparam_map
+								custom_data_params_map custom_data_params_map
 								num_robust_prediction_contributions_samples num_robust_prediction_contributions_samples
 								num_robust_prediction_contributions_samples_per_case num_robust_prediction_contributions_samples_per_case
 								context_condition_filter_query context_condition_filter_query
@@ -1175,7 +1175,7 @@
 										case_ids case_ids
 										use_case_weights use_case_weights
 										weight_feature weight_feature
-										hyperparam_map custom_hyperparam_map
+										data_params_map custom_data_params_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
 									))
@@ -1199,7 +1199,7 @@
 									case_ids robust_accuracy_contributions_samples
 									use_case_weights use_case_weights
 									weight_feature weight_feature
-									hyperparam_map custom_hyperparam_map
+									data_params_map custom_data_params_map
 									context_condition_filter_query context_condition_filter_query
 									features_to_derive features_to_derive
 									convergence_threshold convergence_threshold
@@ -1236,7 +1236,7 @@
 										case_ids case_ids
 										use_case_weights use_case_weights
 										weight_feature weight_feature
-										hyperparam_map custom_hyperparam_map
+										data_params_map custom_data_params_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
 									))
@@ -1257,7 +1257,7 @@
 										case_ids robust_accuracy_contributions_permutation_samples
 										use_case_weights use_case_weights
 										weight_feature weight_feature
-										hyperparam_map custom_hyperparam_map
+										data_params_map custom_data_params_map
 										context_condition_filter_query context_condition_filter_query
 										features_to_derive features_to_derive
 									))
@@ -1284,7 +1284,7 @@
 										)
 									use_case_weights use_case_weights
 									weight_feature weight_feature
-									hyperparam_map custom_hyperparam_map
+									data_params_map custom_data_params_map
 									context_condition_filter_query context_condition_filter_query
 								))
 						)
@@ -1309,7 +1309,7 @@
 									features context_features
 									use_case_weights use_case_weights
 									weight_feature weight_feature
-									hyperparam_map custom_hyperparam_map
+									data_params_map custom_data_params_map
 									context_condition_filter_query context_condition_filter_query
 									action_feature value_robust_contributions_action_feature
 									value_robust_contributions_features value_robust_contributions_features
@@ -1341,7 +1341,7 @@
 									features context_features
 									use_case_weights use_case_weights
 									weight_feature weight_feature
-									hyperparam_map custom_hyperparam_map
+									data_params_map custom_data_params_map
 									context_condition_filter_query context_condition_filter_query
 									action_feature value_robust_contributions_action_feature
 									value_robust_contributions_features value_robust_contributions_features

--- a/module/react_aggregate.amlg
+++ b/module/react_aggregate.amlg
@@ -74,10 +74,6 @@
 			;Only continuous and nominal features can be evaluated in this manner.
 			#{type "any"}
 			forecast_window_length .null
-			;flag, optional. if specified, will attempt to return stats that were computed using dataset parameters with the
-			;	specified robust or non-robust type.
-			#{type "boolean"}
-			robust_dataparamseters .null
 			;Total sample size of dataset to use (using sampling with replacement) for feature_robust_residuals.
 			;	Defaults to the smaller of 150000 or (6321 * num_context_features).
 			;	'num_robust_accuracy_contributions_samples' will be used instead if 'feature_robust_accuracy_contributions' is true.

--- a/module/react_aggregate.amlg
+++ b/module/react_aggregate.amlg
@@ -77,7 +77,7 @@
 			;flag, optional. if specified, will attempt to return stats that were computed using dataset parameters with the
 			;	specified robust or non-robust type.
 			#{type "boolean"}
-			robust_hyperparameters .null
+			robust_dataparamseters .null
 			;Total sample size of dataset to use (using sampling with replacement) for feature_robust_residuals.
 			;	Defaults to the smaller of 150000 or (6321 * num_context_features).
 			;	'num_robust_accuracy_contributions_samples' will be used instead if 'feature_robust_accuracy_contributions' is true.
@@ -283,8 +283,8 @@
 
 		(if dataparameters_param_path
 			(let
-				(assoc hp_map (get (retrieve_from_entity "!dataParametersMap") dataparameters_param_path) )
-				(if (= .null hp_map)
+				(assoc dp_map (get (retrieve_from_entity "!dataParametersMap") dataparameters_param_path) )
+				(if (= .null dp_map)
 					(conclude (conclude
 						(call !Return (assoc errors (list "Invalid dataset parameter param path provided. Please call 'get_params' for list of available param paths.")))
 					))
@@ -1368,7 +1368,7 @@
 	!ReactAggregateMismatchedParametersWarning
 	(let
 		(assoc
-			expected_hp_map
+			expected_dp_map
 				(call !GetDataParameters (assoc
 					feature action_feature
 					context_features (filter action_feature context_features .false)
@@ -1377,7 +1377,7 @@
 			param_path (list)
 		)
 		;dataset parameter path tuple
-		(assign (assoc param_path (get expected_hp_map "paramPath") ))
+		(assign (assoc param_path (get expected_dp_map "paramPath") ))
 
 		;if pulled dataset parameters don't match requested, display warning
 		(if (!= weight_feature (last param_path))

--- a/module/react_aggregate.amlg
+++ b/module/react_aggregate.amlg
@@ -283,7 +283,7 @@
 
 		(if hyperparameter_param_path
 			(let
-				(assoc hp_map (get (retrieve_from_entity "!hyperparameterMetadataMap") hyperparameter_param_path) )
+				(assoc hp_map (get (retrieve_from_entity "!dataParametersMap") hyperparameter_param_path) )
 				(if (= .null hp_map)
 					(conclude (conclude
 						(call !Return (assoc errors (list "Invalid hyperparameter param path provided. Please call 'get_params' for list of available param paths.")))
@@ -363,7 +363,7 @@
 							".none"
 							(map
 								(lambda (last (current_value)))
-								!hyperparameterParamPaths
+								!dataParametersPaths
 							)
 							.false
 						)
@@ -525,7 +525,7 @@
 			;set the custom hp map if specified a hyperparameter_param_path
 			custom_hyperparam_map
 				(if hyperparameter_param_path
-					(get !hyperparameterMetadataMap hyperparameter_param_path)
+					(get !dataParametersMap hyperparameter_param_path)
 				)
 			;initialize conditional queries
 			action_condition_filter_query

--- a/module/react_discriminative.amlg
+++ b/module/react_discriminative.amlg
@@ -35,7 +35,7 @@
 	;
 	; return_action_values_only: if set to true and details is not specified, output will be just the raw list of action values
 	; force_targetless: flag, if set to true forces use of targetless dataset parameters if available
-	; hyperparam_map: optional assoc of dataset parameters to use (instead of system-determined ones)
+	; data_params_map: optional assoc of dataset parameters to use (instead of system-determined ones)
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
@@ -67,7 +67,7 @@
 			allow_nulls .false
 			return_action_values_only .false
 			force_targetless .false
-			hyperparam_map .null
+			data_params_map .null
 			weight_feature ".case_weight"
 			use_case_weights .null
 			case_indices .null
@@ -254,9 +254,9 @@
 			(assign (assoc weight_feature ".none"))
 		)
 
-		(if (= .null hyperparam_map)
+		(if (= .null data_params_map)
 			(assign (assoc
-				hyperparam_map
+				data_params_map
 					(call !GetDataParameters (assoc
 						feature (first action_features)
 						context_features context_features
@@ -268,7 +268,7 @@
 		(call !UpdateCaseWeightParameters)
 
 		;warn if specified weight_feature hasn't been analyzed
-		(if (and use_case_weights (!= weight_feature (last (get hyperparam_map "paramPath"))))
+		(if (and use_case_weights (!= weight_feature (last (get data_params_map "paramPath"))))
 			(accum (assoc
 				warnings
 					(associate (concat
@@ -338,7 +338,7 @@
 						context_features context_features
 						context_values context_values
 						use_differential_privacy use_differential_privacy
-						hyperparam_map hyperparam_map
+						data_params_map data_params_map
 					))
 
 					(assign (assoc action_feature_is_dependent .true))
@@ -416,7 +416,7 @@
 											context_features context_features_param
 											context_values context_values_param
 											use_differential_privacy use_differential_privacy
-											hyperparam_map hyperparam_map
+											data_params_map data_params_map
 										))
 
 										(assign (assoc action_feature_is_dependent .true ))
@@ -433,7 +433,7 @@
 						action_feature (get ordered_action_features (current_index 1))
 
 						;get dataset parameters for the action feature if available
-						hyperparam_map
+						data_params_map
 							(call !GetDataParameters (assoc
 								feature (get ordered_action_features (current_index 2))
 								context_features context_features_param
@@ -520,7 +520,7 @@
 				extra_features extra_features
 				ignore_case ignore_case
 				force_targetless force_targetless
-				hyperparam_map hyperparam_map
+				data_params_map data_params_map
 			))
 
 			;output only the action values

--- a/module/react_discriminative.amlg
+++ b/module/react_discriminative.amlg
@@ -34,8 +34,8 @@
 	; impute_react: optional flag, if true will not ignore future data for time series reacts
 	;
 	; return_action_values_only: if set to true and details is not specified, output will be just the raw list of action values
-	; force_targetless: flag, if set to true forces use of targetless hyperparameters if available
-	; hyperparam_map: optional assoc of hyperparameters to use (instead of system-determined ones)
+	; force_targetless: flag, if set to true forces use of targetless dataset parameters if available
+	; hyperparam_map: optional assoc of dataset parameters to use (instead of system-determined ones)
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; use_case_weights: flag, if set to true will scale influence weights by each case's weight_feature weight. If unspecified,
 	;   			case weights will be used if the trainee has them.
@@ -257,7 +257,7 @@
 		(if (= .null hyperparam_map)
 			(assign (assoc
 				hyperparam_map
-					(call !GetHyperparameters (assoc
+					(call !GetDataParameters (assoc
 						feature (first action_features)
 						context_features context_features
 						weight_feature weight_feature
@@ -432,9 +432,9 @@
 					(assign (assoc
 						action_feature (get ordered_action_features (current_index 1))
 
-						;get hyperparameters for the action feature if available
+						;get dataset parameters for the action feature if available
 						hyperparam_map
-							(call !GetHyperparameters (assoc
+							(call !GetDataParameters (assoc
 								feature (get ordered_action_features (current_index 2))
 								context_features context_features_param
 								weight_feature weight_feature

--- a/module/react_group.amlg
+++ b/module/react_group.amlg
@@ -285,7 +285,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
 					weight_feature weight_feature

--- a/module/react_group.amlg
+++ b/module/react_group.amlg
@@ -284,7 +284,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
@@ -314,14 +314,14 @@
 		(declare (assoc
 			feature_weights
 				;only overwrite with inactive features if feature weights already exist
-				(if (and (size !inactiveFeaturesMap) (size (get hyperparam_map "featureWeights")))
+				(if (and (size !inactiveFeaturesMap) (size (get data_params_map "featureWeights")))
 					(append
-						(get hyperparam_map "featureWeights")
+						(get data_params_map "featureWeights")
 						(map 1 !inactiveFeaturesMap)
 					)
 				)
-			feature_deviations (get hyperparam_map "featureDeviations")
-			closest_k (get hyperparam_map "k")
+			feature_deviations (get data_params_map "featureDeviations")
+			closest_k (get data_params_map "k")
 			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
 			max_lag_index_value .null
 		))
@@ -668,12 +668,12 @@
 						closest_k
 						features
 						.null
-						(get hyperparam_map "p")
+						(get data_params_map "p")
 						feature_weights
 						!queryFeatureAttributeTypeMap
 						feature_deviations
 						.null
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+						(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 						(if valid_weight_feature weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -698,12 +698,12 @@
 						closest_k
 						features
 						.null
-						(get hyperparam_map "p")
+						(get data_params_map "p")
 						feature_weights
 						!queryFeatureAttributeTypeMap
 						feature_deviations
 						.null
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+						(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 						(if valid_weight_feature weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -729,12 +729,12 @@
 						closest_k
 						features
 						.null
-						(get hyperparam_map "p")
+						(get data_params_map "p")
 						feature_weights
 						!queryFeatureAttributeTypeMap
 						feature_deviations
 						.null
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+						(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 						(if valid_weight_feature weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -759,12 +759,12 @@
 						closest_k
 						features
 						.null
-						(get hyperparam_map "p")
+						(get data_params_map "p")
 						feature_weights
 						!queryFeatureAttributeTypeMap
 						feature_deviations
 						.null
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+						(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 						(if valid_weight_feature weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -813,12 +813,12 @@
 						closest_k
 						features
 						case_ids
-						(get hyperparam_map "p")
+						(get data_params_map "p")
 						feature_weights
 						!queryFeatureAttributeTypeMap
 						feature_deviations
 						.null
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+						(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 						(if valid_weight_feature weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -857,12 +857,12 @@
 						closest_k
 						features
 						case_ids
-						(get hyperparam_map "p")
+						(get data_params_map "p")
 						feature_weights
 						!queryFeatureAttributeTypeMap
 						feature_deviations
 						.null
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+						(if (= (get data_params_map "dt") "surprisal_to_prob") "surprisal" (get data_params_map "dt") )
 						(if valid_weight_feature weight_feature .null)
 						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 						"fixed rand seed"
@@ -1200,10 +1200,10 @@
 																			(compute_on_contained_entities
 																				(query_in_entity_list (trunc
 																					(current_value)
-																					(if (~ 0 (get hyperparam_map "k"))
-																						(get hyperparam_map "k")
+																					(if (~ 0 (get data_params_map "k"))
+																						(get data_params_map "k")
 																						;else get the min value from dynamic k
-																						(get hyperparam_map ["k" 1])
+																						(get data_params_map ["k" 1])
 																					)
 																				))
 																				(query_max_difference action_feature (get !cyclicFeaturesMap action_feature))

--- a/module/react_series.amlg
+++ b/module/react_series.amlg
@@ -269,7 +269,7 @@
 
 		(declare (assoc
 			output_features action_features
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features series_context_features
@@ -666,7 +666,7 @@
 			post_process_needed_features_map .null
 			initial_features (list)
 			initial_values (list)
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features series_context_features

--- a/module/react_series.amlg
+++ b/module/react_series.amlg
@@ -270,7 +270,7 @@
 		(declare (assoc
 			output_features action_features
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features series_context_features
 					weight_feature weight_feature
@@ -667,7 +667,7 @@
 			initial_features (list)
 			initial_values (list)
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features series_context_features
 					weight_feature weight_feature

--- a/module/react_series_stationary.amlg
+++ b/module/react_series_stationary.amlg
@@ -130,7 +130,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features context_features
 					weight_feature (if use_case_weights weight_feature)

--- a/module/react_series_stationary.amlg
+++ b/module/react_series_stationary.amlg
@@ -129,7 +129,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features context_features

--- a/module/react_series_utilities.amlg
+++ b/module/react_series_utilities.amlg
@@ -368,7 +368,7 @@
 			dbl_precision_epsilon
 				;similar to !ComputePrecisionEpsilon but streamlined for use in react series
 				(if (!= "no" generate_new_cases)
-					(if (= "surprisal_to_prob" (get hyperparam_map "dt"))
+					(if (= "surprisal_to_prob" (get data_params_map "dt"))
 						(let
 							(assoc output_features_set (zip output_features_no_ids))
 							(*

--- a/module/react_utilities.amlg
+++ b/module/react_utilities.amlg
@@ -942,7 +942,7 @@
 				)
 		))
 
-		;if hyperparams are using deviations, overwrite feature_deviations with dynamic deviations
+		;if data params are using deviations, overwrite feature_deviations with dynamic deviations
 		(if (get data_params_map "featureDeviations")
 			(assign (assoc
 				feature_deviations

--- a/module/react_utilities.amlg
+++ b/module/react_utilities.amlg
@@ -815,7 +815,7 @@
 	)
 
 	;helper method that updates the stack's values of use_case_weights, weight_feature, and optionally valid_weight_feature
-	;according to the user inputs and selected hyperparameters. No value is returned.
+	;according to the user inputs and selected dataset parameters. No value is returned.
 	; accesses variables: use_case_weights, hyperparam_map
 	; assigns to variables: use_case_weights, weight_feature, optionally valid_weight_feature
 	;parameters:
@@ -861,7 +861,7 @@
 	;params:
 	;  context_features: list of feature names to compute dynamic deviations for (also to query the subtrainee with)
 	;  context_values: list of values corresponding to context_features
-	;  hyperparam_map: the hyperparameters selected for the query
+	;  hyperparam_map: the dataset parameters selected for the query
 	;
 	;assigns to:
 	;	feature_weights: the feature weights to be used in a query, only assigns if HPs are targetless

--- a/module/react_utilities.amlg
+++ b/module/react_utilities.amlg
@@ -544,7 +544,7 @@
 			context_features (list)
 			context_values (list)
 			use_differential_privacy .false
-			hyperparam_map (assoc)
+			data_params_map (assoc)
 		)
 
 		(declare (assoc
@@ -567,19 +567,19 @@
 		;when using approximated max-gap residuals, local_k will always be a number
 		(declare (assoc
 			local_k
-				(if (~ 0 (get hyperparam_map "k"))
+				(if (~ 0 (get data_params_map "k"))
 					(if use_differential_privacy
 						;get max of e*k and 30, needed to approximate with max gaps
-						(max (* 2.718281828459045 (get hyperparam_map "k")) 30)
+						(max (* 2.718281828459045 (get data_params_map "k")) 30)
 						;else use max of k or 30
-						(max (get hyperparam_map "k")  30)
+						(max (get data_params_map "k")  30)
 					)
 
 					(if use_differential_privacy
 						;get max of e*k and 30, needed to approximate with max gaps
-						(max (* 2.718281828459045 (get hyperparam_map ["k" 1])) 30)
+						(max (* 2.718281828459045 (get data_params_map ["k" 1])) 30)
 						;else use standard k parameter
-						(get hyperparam_map ["k"])
+						(get data_params_map ["k"])
 					)
 				)
 		))
@@ -597,12 +597,12 @@
 						local_k
 						context_features
 						context_values
-						(get hyperparam_map "p")
-						(get hyperparam_map "featureWeights")
+						(get data_params_map "p")
+						(get data_params_map "featureWeights")
 						!queryFeatureAttributeTypeMap
-						(get hyperparam_map "featureDeviations")
+						(get data_params_map "featureDeviations")
 						.null
-						(get hyperparam_map "dt")
+						(get data_params_map "dt")
 						(if valid_weight_feature weight_feature .null)
 						(rand)
 						.null ;radius
@@ -816,7 +816,7 @@
 
 	;helper method that updates the stack's values of use_case_weights, weight_feature, and optionally valid_weight_feature
 	;according to the user inputs and selected dataset parameters. No value is returned.
-	; accesses variables: use_case_weights, hyperparam_map
+	; accesses variables: use_case_weights, data_params_map
 	; assigns to variables: use_case_weights, weight_feature, optionally valid_weight_feature
 	;parameters:
 	;  set_valid_weight_feature: flag, if true will assign to valid_weight_feature appropriately
@@ -826,7 +826,7 @@
 			set_valid_weight_feature .true
 		)
 		(if (= .null use_case_weights)
-			(if (or (= (get hyperparam_map "paramPath") [".default"]) (= (get hyperparam_map "paramPath") .null))
+			(if (or (= (get data_params_map "paramPath") [".default"]) (= (get data_params_map "paramPath") .null))
 				;if default params, no case weights
 				(assign (assoc
 					use_case_weights .false
@@ -837,14 +837,14 @@
 				(let
 					(assoc
 						param_path_weight_index
-							(if (= "targetless" (get hyperparam_map ["paramPath" 0]))
+							(if (= "targetless" (get data_params_map ["paramPath" 0]))
 								2
 								3
 							)
 					)
 					(assign (assoc
-						use_case_weights (!= (get hyperparam_map ["paramPath" param_path_weight_index]) ".none")
-						weight_feature (get hyperparam_map ["paramPath" param_path_weight_index])
+						use_case_weights (!= (get data_params_map ["paramPath" param_path_weight_index]) ".none")
+						weight_feature (get data_params_map ["paramPath" param_path_weight_index])
 					))
 				)
 			)
@@ -861,7 +861,7 @@
 	;params:
 	;  context_features: list of feature names to compute dynamic deviations for (also to query the subtrainee with)
 	;  context_values: list of values corresponding to context_features
-	;  hyperparam_map: the dataset parameters selected for the query
+	;  data_params_map: the dataset parameters selected for the query
 	;
 	;assigns to:
 	;	feature_weights: the feature weights to be used in a query, only assigns if HPs are targetless
@@ -871,7 +871,7 @@
 		(assoc
 			context_features []
 			context_values []
-			hyperparam_map .null
+			data_params_map .null
 
 			;not param
 			local_deviations .null
@@ -892,7 +892,7 @@
 					(assoc
 						inf_cases
 							(get
-								(call_entity [!traineeContainer (get hyperparam_map "subtraineeName")] "single_react" (assoc
+								(call_entity [!traineeContainer (get data_params_map "subtraineeName")] "single_react" (assoc
 									context_features context_features
 									context_values context_values
 									extra_features (map (lambda (concat "." (current_value) "_residual") ) continuous_context_features)
@@ -943,7 +943,7 @@
 		))
 
 		;if hyperparams are using deviations, overwrite feature_deviations with dynamic deviations
-		(if (get hyperparam_map "featureDeviations")
+		(if (get data_params_map "featureDeviations")
 			(assign (assoc
 				feature_deviations
 					(map

--- a/module/residuals.amlg
+++ b/module/residuals.amlg
@@ -955,9 +955,9 @@
 							feature_is_non_string_edit_distance .false
 							feature_deviations (get hyperparam_map "featureDeviations")
 							feature_weights
-								(if (= .null (get hyperparam_map "featureMdaMap"))
+								(if (= .null (get hyperparam_map "featureProbabilitiesMap"))
 									(get hyperparam_map "featureWeights")
-									(get hyperparam_map "featureMdaMap")
+									(get hyperparam_map "featureProbabilitiesMap")
 								)
 							needed_features (append context_features (get_value (current_value 1)) (if !tsTimeFeature [".series_index"] []) )
 							feature_is_dependent (contains_index !dependentFeatureMap (current_value 1))

--- a/module/residuals.amlg
+++ b/module/residuals.amlg
@@ -467,19 +467,19 @@
 		)
 
 		;set the passed in one as the hyperparam map to use if specified
-		(assign (assoc hyperparam_map custom_hyperparam_map))
+		(assign (assoc data_params_map custom_data_params_map))
 
 		;if not using case weights, change weight_feature to '.none'
 		(if (= .false use_case_weights)
 			(assign (assoc weight_feature ".none"))
 		)
 
-		(if (= .null hyperparam_map)
+		(if (= .null data_params_map)
 			(assign (assoc
-				hyperparam_map
+				data_params_map
 					(call !GetDataParameters (assoc
 						context_features features
-						feature hyperparameter_feature
+						feature dataparameters_feature
 						weight_feature weight_feature
 					))
 			))
@@ -488,9 +488,9 @@
 		(call !UpdateCaseWeightParameters)
 
 		(assign (assoc
-			k_parameter (get hyperparam_map "k")
-			p_parameter (get hyperparam_map "p")
-			dt_parameter (get hyperparam_map "dt")
+			k_parameter (get data_params_map "k")
+			p_parameter (get data_params_map "p")
+			dt_parameter (get data_params_map "dt")
 
 			;flag to track if all cases are being used as the sample
 			using_all_cases .false
@@ -552,9 +552,9 @@
 				(assoc
 					"residual_map" .null
 					"ordinal_residual_map" .null
-					"hyperparam_map"
+					"data_params_map"
 						(accum (assoc
-							hyperparam_map
+							data_params_map
 								(assoc
 									"featureDeviations"
 									(call !ComputeMaxResiduals (assoc
@@ -647,7 +647,7 @@
 			feature_deviations
 				(if custom_residuals_map
 					custom_residuals_map
-					(get hyperparam_map "featureDeviations")
+					(get data_params_map "featureDeviations")
 				)
 			;list, length of case_ids, each item will be a list of residual values, one per feature
 			case_residuals_lists (list)
@@ -674,7 +674,7 @@
 							;map of feature -> value for all the case values
 							case_values_map (zip case_features (retrieve_from_entity (current_value 1) case_features) )
 							time_series_filter_query (list)
-							feature_weights (get hyperparam_map "featureWeights")
+							feature_weights (get data_params_map "featureWeights")
 							context_features context_features
 							dependent_queries_list .null
 							fanout_features_queries .null
@@ -735,11 +735,11 @@
 						)
 
 						;use dynamic deviations subtrainee if present
-						(if (get hyperparam_map "subtraineeName")
+						(if (get data_params_map "subtraineeName")
 							(call !UseDynamicDeviationsAndWeights (assoc
 								context_features react_context_features
 								context_values (unzip case_values_map react_context_features)
-								hyperparam_map hyperparam_map
+								data_params_map data_params_map
 							))
 						)
 
@@ -953,11 +953,11 @@
 							react_context_features (filter (current_value 1) context_features .false)
 							feature_is_edit_distance (contains_index !editDistanceFeatureTypesMap (current_value 1))
 							feature_is_non_string_edit_distance .false
-							feature_deviations (get hyperparam_map "featureDeviations")
+							feature_deviations (get data_params_map "featureDeviations")
 							feature_weights
-								(if (= .null (get hyperparam_map "featureProbabilitiesMap"))
-									(get hyperparam_map "featureWeights")
-									(get hyperparam_map "featureProbabilitiesMap")
+								(if (= .null (get data_params_map "featureProbabilitiesMap"))
+									(get data_params_map "featureWeights")
+									(get data_params_map "featureProbabilitiesMap")
 								)
 							needed_features (append context_features (get_value (current_value 1)) (if !tsTimeFeature [".series_index"] []) )
 							feature_is_dependent (contains_index !dependentFeatureMap (current_value 1))
@@ -1033,11 +1033,11 @@
 
 
 									;use dynamic deviations subtrainee if present
-									(if (get hyperparam_map "subtraineeName")
+									(if (get data_params_map "subtraineeName")
 										(call !UseDynamicDeviationsAndWeights (assoc
 											context_features react_context_features
 											context_values (unzip case_values_map react_context_features)
-											hyperparam_map hyperparam_map
+											data_params_map data_params_map
 										))
 									)
 
@@ -1563,15 +1563,15 @@
 											(or time_series_filter_query [])
 											fanout_features_queries
 											(query_nearest_generalized_distance
-												(get hyperparam_map "k")
+												(get data_params_map "k")
 												react_context_features
 												(unzip case_values_map react_context_features)
-												(get hyperparam_map "p")
-												(get hyperparam_map "featureWeights")
+												(get data_params_map "p")
+												(get data_params_map "featureWeights")
 												!queryFeatureAttributeTypeMap
-												(get hyperparam_map "featureDeviations")
+												(get data_params_map "featureDeviations")
 												.null
-												(get hyperparam_map "dt")
+												(get data_params_map "dt")
 												(if valid_weight_feature weight_feature .null)
 												tie_break_random_seed
 												.null ;radius

--- a/module/residuals.amlg
+++ b/module/residuals.amlg
@@ -477,7 +477,7 @@
 		(if (= .null hyperparam_map)
 			(assign (assoc
 				hyperparam_map
-					(call !GetHyperparameters (assoc
+					(call !GetDataParameters (assoc
 						context_features features
 						feature hyperparameter_feature
 						weight_feature weight_feature

--- a/module/residuals.amlg
+++ b/module/residuals.amlg
@@ -466,7 +466,7 @@
 			))
 		)
 
-		;set the passed in one as the hyperparam map to use if specified
+		;set the passed in one as the dataparams map to use if specified
 		(assign (assoc data_params_map custom_data_params_map))
 
 		;if not using case weights, change weight_feature to '.none'

--- a/module/scale.amlg
+++ b/module/scale.amlg
@@ -520,7 +520,7 @@
 					(and
 						(>= (+ num_cases (size cases)) !autoAblationMaxNumCases)
 						(not skip_reduce_data)
-						(size !hyperparameterMetadataMap)
+						(size !dataParametersMap)
 					)
 					(call reduce_data (assoc
 						skip_auto_analyze skip_auto_analyze

--- a/module/scale.amlg
+++ b/module/scale.amlg
@@ -196,7 +196,7 @@
 			(seq
 				(declare (assoc
 					hyperparam_map
-						(call !GetHyperparameters (assoc
+						(call !GetDataParameters (assoc
 							feature .null
 							context_features features
 							weight_feature accumulate_weight_feature

--- a/module/scale.amlg
+++ b/module/scale.amlg
@@ -195,7 +195,7 @@
 		(if (or train_weights_only (size ablated_indices_list))
 			(seq
 				(declare (assoc
-					hyperparam_map
+					data_params_map
 						(call !GetDataParameters (assoc
 							feature .null
 							context_features features
@@ -203,7 +203,7 @@
 						))
 					context_features (filter accumulate_weight_feature features .false)
 				))
-				(declare (assoc k_param (get hyperparam_map "k") ))
+				(declare (assoc k_param (get data_params_map "k") ))
 				;if k_param is a dynamic k tuple, use the max k value to compute the larger possible max_influence_entropy
 				(declare (assoc k_value (if (~ 0 k_param) k_param (last k_param)) ))
 

--- a/module/synthesis.amlg
+++ b/module/synthesis.amlg
@@ -675,7 +675,7 @@
 							action_is_in_context
 								(and
 									(= "surprisal_to_prob" (get hyperparam_map "dt"))
-									(= 0 (get hyperparam_map ["featureMdaMap" feature feature]))
+									(= 0 (get hyperparam_map ["featureProbabilitiesMap" feature feature]))
 								)
 							react_map (assoc)
 						))

--- a/module/synthesis.amlg
+++ b/module/synthesis.amlg
@@ -71,7 +71,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature (if (= 1 (size action_features)) (first action_features))
 					context_features context_features
@@ -82,7 +82,7 @@
 
 		(call !UpdateCaseWeightParameters)
 
-		(declare (assoc cached_residuals_map (get hyperparam_map "featureResiduals") ))
+		(declare (assoc cached_residuals_map (get data_params_map "featureResiduals") ))
 
 		;if for some reason expected values haven't been cached, do that here
 		(if (= 0 (size !expectedValuesMap))
@@ -158,8 +158,8 @@
 			;to account for missing data by dividing mad by this value: ( 1 - cutoff_percent )
 			mad_scaler
 				(if (not use_differential_privacy)
-					(if (!~ 0 (get hyperparam_map "k"))
-						(- 1 (get hyperparam_map ["k" 0]))
+					(if (!~ 0 (get data_params_map "k"))
+						(- 1 (get data_params_map ["k" 0]))
 						1
 					)
 					1
@@ -172,7 +172,7 @@
 				context_features context_features
 				context_values context_values
 				use_differential_privacy use_differential_privacy
-				hyperparam_map hyperparam_map
+				data_params_map data_params_map
 			))
 		)
 
@@ -621,7 +621,7 @@
 					context_values context_values
 					action_feature feature
 					allow_nulls allow_nulls
-					hyperparam_map hyperparam_map
+					data_params_map data_params_map
 					weight_feature weight_feature
 					valid_weight_feature valid_weight_feature
 					feature_is_nominal feature_is_nominal
@@ -664,7 +664,7 @@
 							context_values regional_context_values
 							action_feature feature
 							allow_nulls allow_nulls
-							hyperparam_map hyperparam_map
+							data_params_map data_params_map
 							weight_feature weight_feature
 							valid_weight_feature valid_weight_feature
 							feature_is_nominal feature_is_nominal
@@ -674,8 +674,8 @@
 							custom_extra_filtering_queries custom_extra_filtering_queries
 							action_is_in_context
 								(and
-									(= "surprisal_to_prob" (get hyperparam_map "dt"))
-									(= 0 (get hyperparam_map ["featureProbabilitiesMap" feature feature]))
+									(= "surprisal_to_prob" (get data_params_map "dt"))
+									(= 0 (get data_params_map ["featureProbabilitiesMap" feature feature]))
 								)
 							react_map (assoc)
 						))
@@ -729,7 +729,7 @@
 					context_values regional_context_values
 					action_feature feature
 					allow_nulls allow_nulls
-					hyperparam_map hyperparam_map
+					data_params_map data_params_map
 					weight_feature weight_feature
 					valid_weight_feature valid_weight_feature
 					feature_is_nominal feature_is_nominal
@@ -868,7 +868,7 @@
 				ordinal_residual
 					(if use_differential_privacy
 						;use global ordinal residual
-						(get hyperparam_map (list "featureOrdinalDeviations" feature))
+						(get data_params_map (list "featureOrdinalDeviations" feature))
 
 						;else compute it from the MAD residual
 						(/ feature_residual (get !ordinalFeaturesRangesMap feature))

--- a/module/synthesis.amlg
+++ b/module/synthesis.amlg
@@ -72,7 +72,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature (if (= 1 (size action_features)) (first action_features))
 					context_features context_features
 					weight_feature weight_feature

--- a/module/synthesis_utilities.amlg
+++ b/module/synthesis_utilities.amlg
@@ -340,7 +340,7 @@
 				;use domain probabilities with a 1 / num_classes if the dataset is too small or using same probability WRT feature_residual
 				(if (or
 						(< (rand) (max nominal_selection_probability (/ feature_residual desired_conviction)))
-						(< num_cases (max 30 (get hyperparam_map "k")))
+						(< num_cases (max 30 (get data_params_map "k")))
 					)
 					(assign (assoc
 						local_class_probabilities_map
@@ -540,12 +540,12 @@
 			)
 			context_features
 			context_values
-			(get hyperparam_map "p")
+			(get data_params_map "p")
 			feature_weights
 			!queryFeatureAttributeTypeMap
 			feature_deviations
 			action_feature ;weight selection feature
-			(get hyperparam_map "dt")
+			(get data_params_map "dt")
 			(if valid_weight_feature weight_feature .null)
 			(rand)
 			.null ;radius
@@ -565,7 +565,7 @@
 	; context_values : list of context values to use in the react
 	; feature_is_nominal : flag, set to true if action_feature is nominal
 	; allow_nulls : flag, if set to true, cases where the action_feature is null will be considered
-	; hyperparam_map: optional assoc of dataset parameters to use (instead of system-determined ones)
+	; data_params_map: optional assoc of dataset parameters to use (instead of system-determined ones)
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; valid_weight_feature : flag, set to true if the provided weight_feature should be used to scale the results
 	; approximate_residual : flag, set to true if approximating RMR and action feature is continuous
@@ -580,16 +580,16 @@
 			feature_is_nominal .false
 			allow_nulls .true
 			weight_feature ".case_weight"
-			hyperparam_map .null
+			data_params_map .null
 			valid_weight_feature .false
 			approximate_residual .true
 			ignore_case .null
 			action_is_in_context .false
 		)
 
-		(if (= .null hyperparam_map)
+		(if (= .null data_params_map)
 			(assign (assoc
-				hyperparam_map
+				data_params_map
 					(call !GetDataParameters (assoc
 						feature action_feature
 						context_features context_features
@@ -599,7 +599,7 @@
 		)
 
 		(declare (assoc
-			local_k (get hyperparam_map "k")
+			local_k (get data_params_map "k")
 			local_case_ids (list)
 			regional_case_ids (list)
 			dependent_queries_list
@@ -627,28 +627,28 @@
 			local_case_values_map (assoc)
 
 			feature_weights
-				(if (= .null (get hyperparam_map "featureProbabilitiesMap"))
-					(get hyperparam_map "featureWeights")
+				(if (= .null (get data_params_map "featureProbabilitiesMap"))
+					(get data_params_map "featureWeights")
 
 					(if action_is_in_context
 						(modify
-							(get hyperparam_map ["featureProbabilitiesMap" action_feature])
+							(get data_params_map ["featureProbabilitiesMap" action_feature])
 							action_feature
-							(/ 1 (size (get hyperparam_map ["featureProbabilitiesMap" action_feature])) )
+							(/ 1 (size (get data_params_map ["featureProbabilitiesMap" action_feature])) )
 						)
-						(get hyperparam_map "featureProbabilitiesMap")
+						(get data_params_map "featureProbabilitiesMap")
 					)
 				)
 
-			feature_deviations (get hyperparam_map "featureDeviations")
+			feature_deviations (get data_params_map "featureDeviations")
 		))
 
 		;use dynamic deviations subtrainee if present
-		(if (get hyperparam_map "subtraineeName")
+		(if (get data_params_map "subtraineeName")
 			(call !UseDynamicDeviationsAndWeights (assoc
 				context_features context_features
 				context_values context_values
-				hyperparam_map hyperparam_map
+				data_params_map data_params_map
 			))
 		)
 
@@ -679,7 +679,7 @@
 						context_features context_features
 						context_values context_values
 						custom_extra_filtering_queries custom_extra_filtering_queries
-						dt_parameter (get hyperparam_map "dt")
+						dt_parameter (get data_params_map "dt")
 						query_label "!NearestRegionalCasesQuery"
 					))
 			))
@@ -1080,7 +1080,7 @@
 
 
 
-		(if (= "surprisal_to_prob" (get hyperparam_map "dt") )
+		(if (= "surprisal_to_prob" (get data_params_map "dt") )
 
 			(*
 				;multiply by 2 to account for the precision uncertainty around both computed values

--- a/module/synthesis_utilities.amlg
+++ b/module/synthesis_utilities.amlg
@@ -565,7 +565,7 @@
 	; context_values : list of context values to use in the react
 	; feature_is_nominal : flag, set to true if action_feature is nominal
 	; allow_nulls : flag, if set to true, cases where the action_feature is null will be considered
-	; hyperparam_map: optional assoc of hyperparameters to use (instead of system-determined ones)
+	; hyperparam_map: optional assoc of dataset parameters to use (instead of system-determined ones)
 	; weight_feature: optional, default '.case_weight'.  name of feature whose values to use as case weights
 	; valid_weight_feature : flag, set to true if the provided weight_feature should be used to scale the results
 	; approximate_residual : flag, set to true if approximating RMR and action feature is continuous
@@ -590,7 +590,7 @@
 		(if (= .null hyperparam_map)
 			(assign (assoc
 				hyperparam_map
-					(call !GetHyperparameters (assoc
+					(call !GetDataParameters (assoc
 						feature action_feature
 						context_features context_features
 						weight_feature weight_feature

--- a/module/synthesis_utilities.amlg
+++ b/module/synthesis_utilities.amlg
@@ -627,16 +627,16 @@
 			local_case_values_map (assoc)
 
 			feature_weights
-				(if (= .null (get hyperparam_map "featureMdaMap"))
+				(if (= .null (get hyperparam_map "featureProbabilitiesMap"))
 					(get hyperparam_map "featureWeights")
 
 					(if action_is_in_context
 						(modify
-							(get hyperparam_map ["featureMdaMap" action_feature])
+							(get hyperparam_map ["featureProbabilitiesMap" action_feature])
 							action_feature
-							(/ 1 (size (get hyperparam_map ["featureMdaMap" action_feature])) )
+							(/ 1 (size (get hyperparam_map ["featureProbabilitiesMap" action_feature])) )
 						)
-						(get hyperparam_map "featureMdaMap")
+						(get hyperparam_map "featureProbabilitiesMap")
 					)
 				)
 

--- a/module/synthesis_validation.amlg
+++ b/module/synthesis_validation.amlg
@@ -16,7 +16,7 @@
 			context_numeric_values (list)
 			non_novel_context_values .null
 			non_novel_context_features .null
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features context_features
@@ -39,16 +39,16 @@
 			null_count_fraction (/ min_diff_num_features (floor (+ 1 (pow (log (size context_features)) 2)) ) )
 			feature_weights
 				(if (size !inactiveFeaturesMap)
-					(append (or (get hyperparam_map "featureWeights") {}) (map 0 !inactiveFeaturesMap))
-					(get hyperparam_map "featureWeights")
+					(append (or (get data_params_map "featureWeights") {}) (map 0 !inactiveFeaturesMap))
+					(get data_params_map "featureWeights")
 				)
-			feature_deviations (get hyperparam_map "featureDeviations")
-			p_parameter (get hyperparam_map "p")
-			dt_parameter (get hyperparam_map "dt")
-			k_parameter (get hyperparam_map "k")
+			feature_deviations (get data_params_map "featureDeviations")
+			p_parameter (get data_params_map "p")
+			dt_parameter (get data_params_map "dt")
+			k_parameter (get data_params_map "k")
 			;override global residuals with calculated residuals per feature
 			threshold_feature_residuals_map
-				(append (get hyperparam_map "featureDeviations") (zip rand_ordered_features threshold_feature_residuals))
+				(append (get data_params_map "featureDeviations") (zip rand_ordered_features threshold_feature_residuals))
 		))
 
 		;check if an exact duplicate already exists in the dataset and if so re-try up to 2 times to re-generate a novel case
@@ -443,7 +443,7 @@
 	!CheckIsDuplicateSeries
 	(let
 		(assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					weight_feature weight_feature
@@ -453,15 +453,15 @@
 		(declare (assoc
 			feature_weights
 				(if (size !inactiveFeaturesMap)
-					(append (or (get hyperparam_map "featureWeights") {}) (map 0 !inactiveFeaturesMap))
-					(get hyperparam_map "featureWeights")
+					(append (or (get data_params_map "featureWeights") {}) (map 0 !inactiveFeaturesMap))
+					(get data_params_map "featureWeights")
 				)
-			feature_deviations (get hyperparam_map "featureDeviations")
-			p_parameter (get hyperparam_map "p")
+			feature_deviations (get data_params_map "featureDeviations")
+			p_parameter (get data_params_map "p")
 			non_novel_context_features .null
 			has_novel_substitions (and exclude_novel_nominals_from_uniqueness_check (size !novelSubstitionFeatureSet))
-			dt_parameter (get hyperparam_map "dt")
-			k_parameter (get hyperparam_map "k")
+			dt_parameter (get data_params_map "dt")
+			k_parameter (get data_params_map "k")
 		))
 
 		;find the closest cases using the same code as generate case, set generate_attempt to 2 so that it

--- a/module/synthesis_validation.amlg
+++ b/module/synthesis_validation.amlg
@@ -17,7 +17,7 @@
 			non_novel_context_values .null
 			non_novel_context_features .null
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features context_features
 					weight_feature weight_feature
@@ -444,7 +444,7 @@
 	(let
 		(assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					weight_feature weight_feature
 				))

--- a/module/train.amlg
+++ b/module/train.amlg
@@ -782,7 +782,7 @@
 
 			;Only compute prediction stats for ablation if thresholds are enabled, we're
 			; not skipping ablation, and we have hyperparameters to use for the computation.
-			(if (and thresholds_enabled (not skip_ablation) (size !hyperparameterMetadataMap))
+			(if (and thresholds_enabled (not skip_ablation) (size !dataParametersMap))
 				(seq
 					(assign (assoc
 						prev_prediction_stats_map new_prediction_stats_map
@@ -863,7 +863,7 @@
 				(and
 					(not skip_reduce_data)
 					(>= (call !GetNumTrainingCases) !autoAblationMaxNumCases)
-					(size !hyperparameterMetadataMap)
+					(size !dataParametersMap)
 				)
 				(seq
 					;clear progress from auto analyze if there was one
@@ -943,7 +943,7 @@
 				; just train all of the cases in this batch.
 				(if (or
 						thresholds_satisfied
-						(not (size !hyperparameterMetadataMap))
+						(not (size !dataParametersMap))
 					)
 					(indices cases)
 					;Otherwise, do the normal ablation filtering.

--- a/module/train.amlg
+++ b/module/train.amlg
@@ -764,7 +764,7 @@
 
 		(declare  (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					context_features features
 					weight_feature weight_feature
 				))
@@ -781,7 +781,7 @@
 		(while (< input_case_index (size cases))
 
 			;Only compute prediction stats for ablation if thresholds are enabled, we're
-			; not skipping ablation, and we have hyperparameters to use for the computation.
+			; not skipping ablation, and we have dataset parameters to use for the computation.
 			(if (and thresholds_enabled (not skip_ablation) (size !dataParametersMap))
 				(seq
 					(assign (assoc

--- a/module/train.amlg
+++ b/module/train.amlg
@@ -763,18 +763,18 @@
 		)
 
 		(declare  (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					context_features features
 					weight_feature weight_feature
 				))
 		))
 		(declare (assoc
-			closest_k (get hyperparam_map "k")
-			p_parameter (get hyperparam_map "p")
-			dt_parameter (get hyperparam_map "dt")
-			feature_weights (get hyperparam_map "featureWeights")
-			feature_deviations (get hyperparam_map "featureDeviations")
+			closest_k (get data_params_map "k")
+			p_parameter (get data_params_map "p")
+			dt_parameter (get data_params_map "dt")
+			feature_weights (get data_params_map "featureWeights")
+			feature_deviations (get data_params_map "featureDeviations")
 		))
 
 		;split by batches of cases until next analyze

--- a/module/train_utilities.amlg
+++ b/module/train_utilities.amlg
@@ -48,7 +48,7 @@
 		)
 
 		(declare (assoc
-			updated_hp_maps
+			updated_dp_maps
 				(map
 					(lambda
 						(rewrite
@@ -118,8 +118,8 @@
 		))
 
 		(assign_to_entities (assoc
-			!defaultDataParametersMap (first updated_hp_maps)
-			!dataParametersMap (last updated_hp_maps)
+			!defaultDataParametersMap (first updated_dp_maps)
+			!dataParametersMap (last updated_dp_maps)
 		))
 	)
 

--- a/module/train_utilities.amlg
+++ b/module/train_utilities.amlg
@@ -35,7 +35,7 @@
 		)
 	)
 
-	;set specified feature weights for inactive features in all hyperparameter maps (!defaultHyperparameters and !hyperparameterMetadataMap)
+	;set specified feature weights for inactive features in all hyperparameter maps (!defaultDataParametersMap and !dataParametersMap)
 	;If weights haven't been defined yet, set them to 0 for invacitves and 1 for actives
 	;If already defined, will overwrite the weight of the specified features in feature_weights_map
 	;
@@ -63,12 +63,12 @@
 											num_features (size !trainedFeatures)
 										)
 
-										;if there is a featureMdaMap specified, temporarily set the weight of activated features to be 1/num_features
+										;if there is a featureProbabilitiesMap specified, temporarily set the weight of activated features to be 1/num_features
 										;if features_weights_map value is 1, so that they can be used in queries until the dataset is reanalyzed
 										;otherwise set it to 0
 										(declare (assoc
 											scaled_features_weights_map
-												(if (size (get (current_value 1) "featureMdaMap"))
+												(if (size (get (current_value 1) "featureProbabilitiesMap"))
 													(map
 														(lambda (/ (current_value) num_features) )
 														features_weights_map
@@ -87,10 +87,10 @@
 
 											(if scaled_features_weights_map
 												(assoc
-													"featureMdaMap"
+													"featureProbabilitiesMap"
 														(map
 															(lambda (append (current_value) scaled_features_weights_map))
-															(get (current_value 1) "featureMdaMap")
+															(get (current_value 1) "featureProbabilitiesMap")
 														)
 													;temporarily set the deviations of activated features to be initial values
 													;so that they can be used in queries until the dataset is reanalyzed
@@ -113,13 +113,13 @@
 							(current_value)
 						)
 					)
-					(list !defaultHyperparameters !hyperparameterMetadataMap)
+					(list !defaultDataParametersMap !dataParametersMap)
 				)
 		))
 
 		(assign_to_entities (assoc
-			!defaultHyperparameters (first updated_hp_maps)
-			!hyperparameterMetadataMap (last updated_hp_maps)
+			!defaultDataParametersMap (first updated_hp_maps)
+			!dataParametersMap (last updated_hp_maps)
 		))
 	)
 

--- a/module/train_utilities.amlg
+++ b/module/train_utilities.amlg
@@ -35,12 +35,12 @@
 		)
 	)
 
-	;set specified feature weights for inactive features in all hyperparameter maps (!defaultDataParametersMap and !dataParametersMap)
+	;set specified feature weights for inactive features in all dataset parameter maps (!defaultDataParametersMap and !dataParametersMap)
 	;If weights haven't been defined yet, set them to 0 for invacitves and 1 for actives
 	;If already defined, will overwrite the weight of the specified features in feature_weights_map
 	;
 	;parameters:
-	; features_weights_map: assoc of feature -> weight to overwrite in all hyperparameter sets
+	; features_weights_map: assoc of feature -> weight to overwrite in all dataset parameter sets
 	!SetInactiveFeatureWeights
 	(declare
 		(assoc
@@ -169,7 +169,7 @@
 	;parameters:
 	; editing_existing_cases: boolean, default false. If true this method is being called from cases
 	;		being edited and thus !inactiveFeaturesMap may be being added to or removed from and
-	;		all the features are already defined in hyperparameters.
+	;		all the features are already defined in dataset parameters.
 	!UpdateInactiveFeatures
 	(declare
 		(assoc editing_existing_cases .false )
@@ -279,7 +279,7 @@
 	(let
 		(assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					context_features features
 					weight_feature (if !autoAblationEnabled !autoAblationWeightFeature ".case_weight")
 				))
@@ -430,7 +430,7 @@
 	(let
 		(assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					context_features features
 					weight_feature
 						(or

--- a/module/train_utilities.amlg
+++ b/module/train_utilities.amlg
@@ -278,7 +278,7 @@
 	!ComputeRebalanceCaseWeights
 	(let
 		(assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					context_features features
 					weight_feature (if !autoAblationEnabled !autoAblationWeightFeature ".case_weight")
@@ -287,11 +287,11 @@
 		(declare (assoc
 			dataset_size (call !GetNumTrainingCases)
 			weight_feature (if !autoAblationEnabled !autoAblationWeightFeature ".case_weight")
-			feature_weights (get hyperparam_map "featureWeights")
-			feature_deviations  (get hyperparam_map "featureDeviations")
-			dt_parameter (get hyperparam_map "dt")
-			p_parameter (get hyperparam_map "p")
-			query_closest_k (get hyperparam_map "k")
+			feature_weights (get data_params_map "featureWeights")
+			feature_deviations  (get data_params_map "featureDeviations")
+			dt_parameter (get data_params_map "dt")
+			p_parameter (get data_params_map "p")
+			query_closest_k (get data_params_map "k")
 			rebalance_feature_indices  (unzip (zip features (indices features)) !continuousRebalanceFeatures)
 			continuous_rebalance_features !continuousRebalanceFeatures
 			nominal_rebalance_features !nominalRebalanceFeatures
@@ -429,7 +429,7 @@
 	!ComputeFeaturesDuringTrain
 	(let
 		(assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					context_features features
 					weight_feature
@@ -448,11 +448,11 @@
 					(get !computedFeaturesMap "weight_feature")
 					(if !autoAblationEnabled !autoAblationWeightFeature ".none")
 				)
-			feature_weights (get hyperparam_map "featureWeights")
-			feature_deviations  (get hyperparam_map "featureDeviations")
-			dt_parameter (get hyperparam_map "dt")
-			p_parameter (get hyperparam_map "p")
-			query_closest_k (get hyperparam_map "k")
+			feature_weights (get data_params_map "featureWeights")
+			feature_deviations  (get data_params_map "featureDeviations")
+			dt_parameter (get data_params_map "dt")
+			p_parameter (get data_params_map "p")
+			query_closest_k (get data_params_map "k")
 		))
 
 		(declare (assoc

--- a/module/trainee.amlg
+++ b/module/trainee.amlg
@@ -548,14 +548,14 @@
 		;map of parameters used when analyze was called on this dataset
 		!savedAnalyzeParameterMap .null
 
-		;hyperparameters stored in nested assocs, where full paths are
+		;dataset parameters stored in nested assocs, where full paths are
 		; [ targeted/targetless [action_feature] context_features case_weight_feature/.none)
 		!dataParametersMap (assoc)
 
-		;list of param paths to Hyperparameter assocs in !dataParametersMap
+		;list of param paths to dataset parameter assocs in !dataParametersMap
 		!dataParametersPaths (list)
 
-		;default hyperparameters, these are used when there are no cached hyperparameters
+		;default dataset parameters, these are used when there are no cached dataset parameters
 		!defaultDataParametersMap
 			(assoc
 				"k" 8

--- a/module/trainee.amlg
+++ b/module/trainee.amlg
@@ -550,13 +550,13 @@
 
 		;hyperparameters stored in nested assocs, where full paths are
 		; [ targeted/targetless [action_feature] context_features case_weight_feature/.none)
-		!hyperparameterMetadataMap (assoc)
+		!dataParametersMap (assoc)
 
-		;list of param paths to Hyperparameter assocs in !hyperparameterMetadataMap
-		!hyperparameterParamPaths (list)
+		;list of param paths to Hyperparameter assocs in !dataParametersMap
+		!dataParametersPaths (list)
 
 		;default hyperparameters, these are used when there are no cached hyperparameters
-		!defaultHyperparameters
+		!defaultDataParametersMap
 			(assoc
 				"k" 8
 				"p" 0.1

--- a/module/types.amlg
+++ b/module/types.amlg
@@ -937,7 +937,7 @@
 								additional_indices "number"
 								description "Map of features to their computed robust feature residuals."
 							)
-						featureMdaMap
+						featureProbabilitiesMap
 							(assoc
 								type "assoc"
 								description "Map of each feature's map of feature weights."

--- a/module/types.amlg
+++ b/module/types.amlg
@@ -846,7 +846,7 @@
 					)
 				description "A map defining any feature bounds, allowed values, and constraints."
 			)
-		HyperparameterMap
+		DataParametersMap
 			(assoc
 				type "assoc"
 				indices
@@ -894,7 +894,7 @@
 							(assoc
 								type "list"
 								values "string"
-								description "The list of strings that make up the path to the set of hyperparameters within the larger hyperparameter map."
+								description "The list of strings that make up the path to the set of dataset parameters within the larger dataset parameter map."
 							)
 						useDeviations
 							(assoc
@@ -943,27 +943,27 @@
 								description "Map of each feature's map of feature weights."
 							)
 					)
-				description "The base hyperparameter map containing all the individual parameter values."
+				description "The base dataset parameter map containing all the individual parameter values."
 			)
-		HyperparameterMapFull
+		DataParametersMapFull
 			(assoc
 				type "assoc"
 				additional_indices .false
 				indices
 					(assoc
 						targetless
-							(assoc ref "HyperparameterMapTree")
+							(assoc ref "DataParametersMapTree")
 						targeted
 							(assoc
 								type "assoc"
 								;action_features
 								additional_indices
-									(assoc ref "HyperparameterMapTree")
+									(assoc ref "DataParametersMapTree")
 							)
 					)
-				description "The full map containing all analyzed targetless and targeted hyperparameters."
+				description "The full map containing all analyzed targetless and targeted dataset parameters."
 			)
-		HyperparameterMapTree
+		DataParametersMapTree
 			(assoc
 				type "assoc"
 				;context_features key
@@ -972,9 +972,9 @@
 							;weight feature
 							type "assoc"
 							additional_indices
-								(assoc ref "HyperparameterMap")
+								(assoc ref "DataParametersMap")
 						)
-				description "The subtree of a the full hyperparameter map starting with the nodes containing analyzed context_features."
+				description "The subtree of a the full dataset parameter map starting with the nodes containing analyzed context_features."
 			)
 		NewCaseThreshold (assoc type "string" enum (list "min" "max" "most_similar") description "The privacy distance criteria for generated new cases.")
 		ReactDetails

--- a/module/update_cases.amlg
+++ b/module/update_cases.amlg
@@ -68,7 +68,7 @@
 
 			;local variable, not a parameter
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					weight_feature ".none"
 				))
@@ -589,7 +589,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
 					weight_feature accumulate_weight_feature
@@ -835,7 +835,7 @@
 
 		(declare (assoc
 			hyperparam_map
-				(call !GetHyperparameters (assoc
+				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
 					weight_feature ".none"

--- a/module/update_cases.amlg
+++ b/module/update_cases.amlg
@@ -67,14 +67,14 @@
 			features (list)
 
 			;local variable, not a parameter
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					weight_feature ".none"
 				))
 		)
 		(declare (assoc
-			feature_deviations (get hyperparam_map "featureDeviations")
+			feature_deviations (get data_params_map "featureDeviations")
 		))
 
 		(if (= 0 (size features)) (assign (assoc features !trainedFeatures)))
@@ -92,7 +92,7 @@
 									0.0
 									features
 									(current_value 2)
-									(get hyperparam_map "p")
+									(get data_params_map "p")
 									;weights can always be null since only looking for distances of 0
 									.null
 									!queryFeatureAttributeTypeMap
@@ -588,7 +588,7 @@
 		)
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
@@ -608,7 +608,7 @@
 			entropy_weights []
 			rebalance_case_weights .null
 		))
-		(declare (assoc k_param (get hyperparam_map "k") ))
+		(declare (assoc k_param (get data_params_map "k") ))
 		;if k_param is a dynamic k tuple, use the max k value to compute the larger possible max_influence_entropy
 		(declare (assoc k_value (if (~ 0 k_param) k_param (last k_param)) ))
 		(declare (assoc
@@ -785,12 +785,12 @@
 							k_param
 							context_features
 							(unzip (zip features (current_value 1)) context_features)
-							(get hyperparam_map "p")
-							(get hyperparam_map "featureWeights")
+							(get data_params_map "p")
+							(get data_params_map "featureWeights")
 							!queryFeatureAttributeTypeMap
-							(get hyperparam_map "featureDeviations")
+							(get data_params_map "featureDeviations")
 							.null
-							(get hyperparam_map "dt")
+							(get data_params_map "dt")
 							(if (!= accumulate_weight_feature ".none") accumulate_weight_feature)
 							;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
 							"fixed rand seed"
@@ -834,7 +834,7 @@
 		(if has_rebalance_features (assign (assoc distribute_weight_feature !internalLabelProbabilityMass)) )
 
 		(declare (assoc
-			hyperparam_map
+			data_params_map
 				(call !GetDataParameters (assoc
 					feature .null
 					context_features features
@@ -861,16 +861,16 @@
 									;don't consider cases whose weights should be distributed, since they are all about to be removed
 									(query_not_in_entity_list case_ids)
 									(query_nearest_generalized_distance
-										(get hyperparam_map "k")
+										(get data_params_map "k")
 										features
 										;case id
 										(current_index 1)
-										(get hyperparam_map "p")
-										(get hyperparam_map "featureWeights")
+										(get data_params_map "p")
+										(get data_params_map "featureWeights")
 										!queryFeatureAttributeTypeMap
-										(get hyperparam_map "featureDeviations")
+										(get data_params_map "featureDeviations")
 										.null
-										(get hyperparam_map "dt")
+										(get data_params_map "dt")
 										;do not use case weights for distribution to prevent over distributing to cases that already have more mass
 										;and rather distribute by surprisal/similarity only
 										.null

--- a/module/value_contributions.amlg
+++ b/module/value_contributions.amlg
@@ -6,7 +6,7 @@
 		(if (= .null hyperparam_map)
 			(assign (assoc
 				hyperparam_map
-					(call !GetHyperparameters (assoc
+					(call !GetDataParameters (assoc
 						context_features features
 						weight_feature weight_feature
 						use_case_weights use_case_weights

--- a/module/value_contributions.amlg
+++ b/module/value_contributions.amlg
@@ -134,9 +134,9 @@
 			;used by pc to do feature weight rebalancing
 			all_feature_weights
 				(if compute_pc
-					(if (= .null (get hyperparam_map "featureMdaMap"))
+					(if (= .null (get hyperparam_map "featureProbabilitiesMap"))
 						(get hyperparam_map "featureWeights")
-						(get hyperparam_map "featureMdaMap")
+						(get hyperparam_map "featureProbabilitiesMap")
 					)
 				)
 

--- a/module/value_contributions.amlg
+++ b/module/value_contributions.amlg
@@ -3,9 +3,9 @@
 	;helper method to initialize common value used in value contribution decomposition flows
 	!InitValueContributions
 	(seq
-		(if (= .null hyperparam_map)
+		(if (= .null data_params_map)
 			(assign (assoc
-				hyperparam_map
+				data_params_map
 					(call !GetDataParameters (assoc
 						context_features features
 						weight_feature weight_feature
@@ -125,18 +125,18 @@
 		(call !InitValueContributions)
 
 		(assign (assoc
-			k_parameter (get hyperparam_map "k")
-			p_parameter (get hyperparam_map "p")
-			dt_parameter (get hyperparam_map "dt")
-			feature_deviations (get hyperparam_map "featureDeviations")
-			feature_weights (get hyperparam_map "featureWeights")
+			k_parameter (get data_params_map "k")
+			p_parameter (get data_params_map "p")
+			dt_parameter (get data_params_map "dt")
+			feature_deviations (get data_params_map "featureDeviations")
+			feature_weights (get data_params_map "featureWeights")
 
 			;used by pc to do feature weight rebalancing
 			all_feature_weights
 				(if compute_pc
-					(if (= .null (get hyperparam_map "featureProbabilitiesMap"))
-						(get hyperparam_map "featureWeights")
-						(get hyperparam_map "featureProbabilitiesMap")
+					(if (= .null (get data_params_map "featureProbabilitiesMap"))
+						(get data_params_map "featureWeights")
+						(get data_params_map "featureProbabilitiesMap")
 					)
 				)
 
@@ -229,11 +229,11 @@
 						)
 
 						;use dynamic deviations subtrainee if present
-						(if (get hyperparam_map "subtraineeName")
+						(if (get data_params_map "subtraineeName")
 							(call !UseDynamicDeviationsAndWeights (assoc
 								context_features react_context_features
 								context_values (unzip case_values_map react_context_features)
-								hyperparam_map hyperparam_map
+								data_params_map data_params_map
 							))
 						)
 
@@ -377,11 +377,11 @@
 						)
 
 						;use dynamic deviations subtrainee if present
-						(if (get hyperparam_map "subtraineeName")
+						(if (get data_params_map "subtraineeName")
 							(call !UseDynamicDeviationsAndWeights (assoc
 								context_features react_context_features
 								context_values (unzip case_values_map react_context_features)
-								hyperparam_map hyperparam_map
+								data_params_map data_params_map
 							))
 						)
 
@@ -1176,7 +1176,7 @@
 								robust_residuals .true
 								use_case_weights use_case_weights
 								weight_feature weight_feature
-								custom_hyperparam_map custom_hyperparam_map
+								custom_data_params_map custom_data_params_map
 								compute_all_statistics .false
 								confusion_matrix_min_count confusion_matrix_min_count
 								context_condition_filter_query context_condition_filter_query
@@ -1230,9 +1230,9 @@
 		(call !InitValueContributions)
 
 		(assign (assoc
-			k_parameter (get hyperparam_map "k")
-			p_parameter (get hyperparam_map "p")
-			dt_parameter (get hyperparam_map "dt")
+			k_parameter (get data_params_map "k")
+			p_parameter (get data_params_map "p")
+			dt_parameter (get data_params_map "dt")
 
 			;store an assoc of lag/rate/delta feature -> lag/order amount for time series flows
 			ts_feature_lag_amount_map (if !tsTimeFeature (call !BuildTSFeatureLagAmountMap))
@@ -1259,7 +1259,7 @@
 
 		(declare (assoc
 			enabled_num_features_probability_map (call !ComputeNumEnabledFeaturesProbabilitiesMap (assoc num_features num_features))
-			feature_deviations (get hyperparam_map "featureDeviations")
+			feature_deviations (get data_params_map "featureDeviations")
 
 			action_feature_is_non_string_edit_distance (and action_feature_is_edit_distance (!= "string_mixable" (get !editDistanceFeatureTypesMap action_feature)))
 			ac_feature_is_non_string_edit_distance_map (and ac_feature_is_edit_distance (!= "string_mixable" (get !editDistanceFeatureTypesMap value_robust_ac_feature)))
@@ -1286,7 +1286,7 @@
 							;map of feature -> value for all the case values
 							case_values_map (get case_to_values_map (current_value 1))
 							time_series_filter_query (list)
-							feature_weights (get hyperparam_map "featureWeights")
+							feature_weights (get data_params_map "featureWeights")
 							context_features context_features
 							categorical_action_probabilities_map (assoc)
 							dependent_queries_list (list)
@@ -1340,11 +1340,11 @@
 						)
 
 						;use dynamic deviations subtrainee if present
-						(if (get hyperparam_map "subtraineeName")
+						(if (get data_params_map "subtraineeName")
 							(call !UseDynamicDeviationsAndWeights (assoc
 								context_features react_context_features
 								context_values (unzip case_values_map react_context_features)
-								hyperparam_map hyperparam_map
+								data_params_map data_params_map
 							))
 						)
 
@@ -1501,11 +1501,11 @@
 						)
 
 						;use dynamic deviations subtrainee if present
-						(if (get hyperparam_map "subtraineeName")
+						(if (get data_params_map "subtraineeName")
 							(call !UseDynamicDeviationsAndWeights (assoc
 								context_features react_context_features
 								context_values (unzip case_values_map react_context_features)
-								hyperparam_map hyperparam_map
+								data_params_map data_params_map
 							))
 						)
 
@@ -1573,11 +1573,11 @@
 						)
 
 						;use dynamic deviations subtrainee if present
-						(if (get hyperparam_map "subtraineeName")
+						(if (get data_params_map "subtraineeName")
 							(call !UseDynamicDeviationsAndWeights (assoc
 								context_features react_context_features
 								context_values (unzip case_values_map react_context_features)
-								hyperparam_map hyperparam_map
+								data_params_map data_params_map
 							))
 						)
 

--- a/performance_tests/mnist_10k_test.amlg
+++ b/performance_tests/mnist_10k_test.amlg
@@ -39,7 +39,7 @@
 
 	(if (not do_analyze)
 		(call_entity "howso" "set_params" (assoc
-			hyperparameter_map
+			data_parameters_map
 				(assoc
 					"targetless" (associate all_features_key (assoc ".none" (assoc "k" 8 "p" 2 "dt" -1)))
 					"targeted" (assoc "target" (associate context_features_key (assoc ".none" (assoc "k" 13 "p" 2 "dt" -1))))

--- a/unit_tests/ut_abalone.amlg
+++ b/unit_tests/ut_abalone.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_abalone.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 21 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 21 "p" 2 "dt" -1)
 	)) ;autotuned parameters of 21/2 give > 30% accuracy
 
 	(declare (assoc

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -67,8 +67,8 @@
 
 	))
 	(assign (assoc
-		defaults (call_entity "howso" "debug_label" (assoc label "!defaultHyperparameters"))
-		hp_map (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		defaults (call_entity "howso" "debug_label" (assoc label "!defaultDataParametersMap"))
+		hp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(print "single target doesn't modify default: ")
@@ -101,7 +101,7 @@
 	(call_entity "howso" "analyze")
 
 	(assign (assoc
-		result (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		result (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(print "targetless analyzed all weights set to 1: ")
@@ -123,7 +123,7 @@
 
 	))
 	(assign (assoc
-		result (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		result (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(print "multi-target fruit is full, has attributes: ")
@@ -154,7 +154,7 @@
 		targeted_model "omni_targeted"
 	))
 	(assign (assoc
-		result (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		result (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 	(print "omni-target height is full, has attributes: ")
 	(call assert_true (assoc
@@ -183,7 +183,7 @@
 		condition_session "unit_test"
 	))
 	(assign (assoc
-		result (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		result (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(print "test feature is added to hyperparameters: " )

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -175,7 +175,7 @@
 			)
 	))
 
-	(call exit_if_failures (assoc msg "Analyzed Hyperparameters" ))
+	(call exit_if_failures (assoc msg "Analyzed DataParameters" ))
 
 	(call_entity "howso" "add_feature" (assoc
 		feature_name "TEST"
@@ -186,7 +186,7 @@
 		result (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
-	(print "test feature is added to hyperparameters: " )
+	(print "test feature is added to dataset parameters: " )
 	(call assert_true (assoc
 		obs
 			(and
@@ -272,7 +272,7 @@
 		obs (get result "TEST_NOM")
 	))
 
-	(call exit_if_failures (assoc msg "Hyperparameters with added features" ))
+	(call exit_if_failures (assoc msg "DataParameters with added features" ))
 
 	(assign (assoc
 		result

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -68,7 +68,7 @@
 	))
 	(assign (assoc
 		defaults (call_entity "howso" "debug_label" (assoc label "!defaultDataParametersMap"))
-		hp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
+		dp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(print "single target doesn't modify default: ")
@@ -90,10 +90,10 @@
 	(call assert_true (assoc
 		obs
 			(and
-				(!= .null (get hp_map ["targeted" "fruit" "height.length.size.sweet.tart.weight.width." ".none" "k"]))
-				(!= .null (get hp_map ["targeted" "fruit" "height.length.size.sweet.tart.weight.width." ".none" "p"]))
-				(!= .null (get hp_map ["targeted" "fruit" "height.length.size.sweet.tart.weight.width." ".none" "dt"]))
-				(> (size (get hp_map ["targeted" "fruit" "height.length.size.sweet.tart.weight.width." ".none" "featureWeights"])) 0)
+				(!= .null (get dp_map ["targeted" "fruit" "height.length.size.sweet.tart.weight.width." ".none" "k"]))
+				(!= .null (get dp_map ["targeted" "fruit" "height.length.size.sweet.tart.weight.width." ".none" "p"]))
+				(!= .null (get dp_map ["targeted" "fruit" "height.length.size.sweet.tart.weight.width." ".none" "dt"]))
+				(> (size (get dp_map ["targeted" "fruit" "height.length.size.sweet.tart.weight.width." ".none" "featureWeights"])) 0)
 			)
 	))
 

--- a/unit_tests/ut_h_analyze.amlg
+++ b/unit_tests/ut_h_analyze.amlg
@@ -320,7 +320,7 @@
 					context_features features
 					details (assoc feature_full_prediction_contributions .true)
 					feature_influences_action_feature "fruit"
-					hyperparameter_param_path ["targeted" "width" "fruit.height.length.size.sweet.tart.weight." ".none"]
+					dataparameters_param_path ["targeted" "width" "fruit.height.length.size.sweet.tart.weight." ".none"]
 					sample_model_fraction 1.0
 				))
 				[1 "payload" "feature_full_prediction_contributions"]

--- a/unit_tests/ut_h_analyze_feature_weights.amlg
+++ b/unit_tests/ut_h_analyze_feature_weights.amlg
@@ -53,12 +53,12 @@
 
 	;disable the computed feature weights
 	(declare (assoc context_key "Abdomen.Age.Ankle.Biceps.Chest.Density.Forearm.Height.Hip.Knee.Neck.Thigh.Weight.Wrist."))
-	(declare (assoc int_params (get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map"))))
+	(declare (assoc int_params (get (call_entity "howso" "get_params") (list 1 "payload" "data_parameters_map"))))
 	(declare (assoc target_params (get int_params (list "targeted" "target" context_key ".none"))))
 	(declare (assoc feature_weights (get target_params "featureWeights")))
 	(assign (assoc target_params (remove target_params "featureWeights")))
 	(accum (assoc int_params (assoc "targeted" (assoc "target" (associate context_key (assoc ".none" target_params ))) )))
-	(call_entity "howso" "set_params" (assoc hyperparameter_map int_params))
+	(call_entity "howso" "set_params" (assoc data_parameters_map int_params))
 
 	(assign (assoc total 0))
 	(map
@@ -86,7 +86,7 @@
 	;enable the computed feature weights
 	(accum (assoc target_params (assoc "featureWeights" feature_weights )))
 	(accum (assoc int_params (assoc "targeted" (assoc "target" (assoc context_key (assoc ".none" target_params ))) )))
-	(call_entity "howso" "set_params" (assoc hyperparameter_map int_params))
+	(call_entity "howso" "set_params" (assoc data_parameters_map int_params))
 
 
 	(assign (assoc total 0))

--- a/unit_tests/ut_h_anomaly.amlg
+++ b/unit_tests/ut_h_anomaly.amlg
@@ -38,7 +38,7 @@
 		cases
 			(get
 				(call_entity "howso" "get_cases" (assoc
-					features (list ".session_training_index" "similarity_conviction" "familiarity_conviction_addition" "reciprocity")
+					features (list ".session_training_index" ".similarity_conviction" ".familiarity_conviction_addition" "reciprocity")
 				))
 				(list 1 "payload" "cases")
 			)
@@ -81,7 +81,7 @@
 		ris_contributions
 			(get
 				(call_entity "howso" "get_cases" (assoc
-					features ["residual_contribution"]
+					features [".residual_contribution"]
 				))
 				[1 "payload" "cases"]
 			)

--- a/unit_tests/ut_h_basic_ablation.amlg
+++ b/unit_tests/ut_h_basic_ablation.amlg
@@ -5,7 +5,7 @@
 	;Set a non-default dataset parameter map since ablation checks for non-default
 	; dataset parameters.
 	(call_entity "howso" "set_params" (assoc
-		hyperparameter_map
+		data_parameters_map
 			{targetless { "A.B.C.D.E." { ".none"
 				{k 2 p 0.4 dt -1}
 			}}}

--- a/unit_tests/ut_h_basic_ablation.amlg
+++ b/unit_tests/ut_h_basic_ablation.amlg
@@ -2,8 +2,8 @@
 	(assign_to_entities (load "unit_test.amlg"))
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_basic_ablation.amlg"))
 
-	;Set a non-default hyperparameter map since ablation checks for non-default
-	; hyperparameters.
+	;Set a non-default dataset parameter map since ablation checks for non-default
+	; dataset parameters.
 	(call_entity "howso" "set_params" (assoc
 		hyperparameter_map
 			{targetless { "A.B.C.D.E." { ".none"

--- a/unit_tests/ut_h_boundary_cases.amlg
+++ b/unit_tests/ut_h_boundary_cases.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_boundary_cases.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" .4 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" .4 "dt" -1)
 	))
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes

--- a/unit_tests/ut_h_boundary_values.amlg
+++ b/unit_tests/ut_h_boundary_values.amlg
@@ -56,7 +56,7 @@
 		obs
 			(apply "="
 				(remove
-					(get result ["hyperparameter_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureProbabilitiesMap" "ord"])
+					(get result ["data_parameters_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureProbabilitiesMap" "ord"])
 					"ord"
 				)
 			)
@@ -65,7 +65,7 @@
 		obs
 			(apply "="
 				(remove
-					(get result ["hyperparameter_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureProbabilitiesMap" "ord_string"])
+					(get result ["data_parameters_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureProbabilitiesMap" "ord_string"])
 					"ord"
 				)
 			)

--- a/unit_tests/ut_h_boundary_values.amlg
+++ b/unit_tests/ut_h_boundary_values.amlg
@@ -56,7 +56,7 @@
 		obs
 			(apply "="
 				(remove
-					(get result ["hyperparameter_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureMdaMap" "ord"])
+					(get result ["hyperparameter_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureProbabilitiesMap" "ord"])
 					"ord"
 				)
 			)
@@ -65,7 +65,7 @@
 		obs
 			(apply "="
 				(remove
-					(get result ["hyperparameter_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureMdaMap" "ord_string"])
+					(get result ["hyperparameter_map" "targetless" "f1.f2.nom.ord.ord_string." ".none" "featureProbabilitiesMap" "ord_string"])
 					"ord"
 				)
 			)

--- a/unit_tests/ut_h_box_conviction.amlg
+++ b/unit_tests/ut_h_box_conviction.amlg
@@ -25,7 +25,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 1 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "react_into_features" (assoc

--- a/unit_tests/ut_h_box_conviction.amlg
+++ b/unit_tests/ut_h_box_conviction.amlg
@@ -34,7 +34,7 @@
 	))
 	(declare (assoc
 		result
-			(call_entity "howso" "get_cases" (assoc features (append features "familiarity_conviction_addition")))
+			(call_entity "howso" "get_cases" (assoc features (append features ".familiarity_conviction_addition")))
 	))
 
 	(declare (assoc
@@ -191,7 +191,7 @@
 
 	(assign (assoc
 		result
-			(call_entity "howso" "get_cases" (assoc features (append features "familiarity_conviction_addition" "cw")))
+			(call_entity "howso" "get_cases" (assoc features (append features ".familiarity_conviction_addition" "cw")))
 	))
 	(print "Weighted conviction is very different from un-weighted: ")
 	(call assert_approximate (assoc

--- a/unit_tests/ut_h_case_generation.amlg
+++ b/unit_tests/ut_h_case_generation.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_case_generation.amlg" retries 1))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc
@@ -342,7 +342,7 @@
 
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 4 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 4 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "train" (assoc

--- a/unit_tests/ut_h_case_generation_preserving.amlg
+++ b/unit_tests/ut_h_case_generation_preserving.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_case_generation_preserving.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_case_mda.amlg
+++ b/unit_tests/ut_h_case_mda.amlg
@@ -19,7 +19,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 4 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 4 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "train" (assoc

--- a/unit_tests/ut_h_case_removal.amlg
+++ b/unit_tests/ut_h_case_removal.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_case_removal.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 0.4 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 0.4 "dt" -1)
 	))
 
 	(declare (assoc

--- a/unit_tests/ut_h_constraints.amlg
+++ b/unit_tests/ut_h_constraints.amlg
@@ -4,7 +4,7 @@
 
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 
 	(declare (assoc
@@ -195,7 +195,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_constraints.amlg" skip_init .true) )
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_continuous_distribution.amlg
+++ b/unit_tests/ut_h_continuous_distribution.amlg
@@ -33,7 +33,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "train" (assoc

--- a/unit_tests/ut_h_conviction.amlg
+++ b/unit_tests/ut_h_conviction.amlg
@@ -274,7 +274,7 @@
 	(print "react_into_features\n")
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 0.4 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 0.4 "dt" -1)
 	))
 	(call_entity "howso" "react_into_features" (assoc
 		features iris_features
@@ -417,7 +417,7 @@
 	(call exit_if_failures (assoc msg "Conviction of holed iris vs iris" ))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 10 "p" 3 "dt" -1)
+		default_data_parameters_map (assoc "k" 10 "p" 3 "dt" -1)
 	))
 
 ;VERIFY SETTING and CALCULATING DEVIATIONS
@@ -428,7 +428,7 @@
 	))
 
 	(assign (assoc
-		result (get (call_entity "howso" "get_params") [1 "payload" "hyperparameter_map" "targetless" "A.B.C.D.E." ".none" "featureResiduals"])
+		result (get (call_entity "howso" "get_params") [1 "payload" "data_parameters_map" "targetless" "A.B.C.D.E." ".none" "featureResiduals"])
 	))
 
 	(declare (assoc residuals result))
@@ -470,7 +470,7 @@
 		params (get (call_entity "howso" "get_params" ) (list 1 "payload"))
 	))
 	(assign (assoc
-		result (get params ["hyperparameter_map" "targetless" "A.B.C.D.E." ".none" "featureDeviations"] )
+		result (get params ["data_parameters_map" "targetless" "A.B.C.D.E." ".none" "featureDeviations"] )
 	))
 
 	(assign (assoc result (remove result "E")))

--- a/unit_tests/ut_h_conviction.amlg
+++ b/unit_tests/ut_h_conviction.amlg
@@ -288,16 +288,16 @@
 	(call assert_true (assoc
 		obs
 			(and
-				(contains_index result "p_value_of_removal")
-				(contains_index result "familiarity_conviction_addition")
+				(contains_index result ".p_value_of_removal")
+				(contains_index result ".familiarity_conviction_addition")
 			)
 	))
 
 	(assign (assoc
 		result
 			(call_entity "howso" "get_extreme_cases" (assoc
-				features (list "familiarity_conviction_addition" "p_value_of_removal" )
-				sort_feature "familiarity_conviction_addition"
+				features (list ".familiarity_conviction_addition" ".p_value_of_removal" )
+				sort_feature ".familiarity_conviction_addition"
 				num 5
 			))
 	))
@@ -320,8 +320,8 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "get_extreme_cases" (assoc
-				features (append iris_features "familiarity_conviction_addition" )
-				sort_feature "familiarity_conviction_addition"
+				features (append iris_features ".familiarity_conviction_addition" )
+				sort_feature ".familiarity_conviction_addition"
 				num -2
 			))
 	))

--- a/unit_tests/ut_h_conviction.amlg
+++ b/unit_tests/ut_h_conviction.amlg
@@ -474,7 +474,7 @@
 	))
 
 	(assign (assoc result (remove result "E")))
-	(print "If deviations exist in hyperparameters, they are updated correctly: ")
+	(print "If deviations exist in dataset parameters, they are updated correctly: ")
 	(call assert_approximate (assoc
 		obs result
 		exp

--- a/unit_tests/ut_h_cyclic_dataset.amlg
+++ b/unit_tests/ut_h_cyclic_dataset.amlg
@@ -41,7 +41,7 @@
 
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 4 "p" 1 "dt" -1)
+		default_data_parameters_map (assoc "k" 4 "p" 1 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc
@@ -91,7 +91,7 @@
 ;VERIFY AMALGAM properly finds days around the pivot of the cycle
 	(print "Cyclic feature querying: ")
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 6 "p" 1 "dt" -1  )
+		default_data_parameters_map (assoc "k" 6 "p" 1 "dt" -1  )
 	))
 	(assign (assoc
 		result
@@ -110,7 +110,7 @@
 
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 1 "dt" -1  )
+		default_data_parameters_map (assoc "k" 1 "p" 1 "dt" -1  )
 	))
 	(assign (assoc
 		result
@@ -281,7 +281,7 @@
 	(call exit_if_failures (assoc msg "Generation of cyclics" ))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 1 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 1 "dt" -1)
 	))
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes

--- a/unit_tests/ut_h_datetimeformat.amlg
+++ b/unit_tests/ut_h_datetimeformat.amlg
@@ -36,7 +36,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 1 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc
@@ -168,7 +168,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 	(assign (assoc
 		result

--- a/unit_tests/ut_h_dependent_features.amlg
+++ b/unit_tests/ut_h_dependent_features.amlg
@@ -318,7 +318,7 @@
 	(print "Conditioned nominal react: ")
 	(call assert_approximate (assoc
 		obs (get result (list "action_values" 0))
-		;creatine leves should be ~.9, some variation due to different hyperparameters
+		;creatine leves should be ~.9, some variation due to different dataset parameters
 		exp 0.8
 		thresh 0.22
 	))

--- a/unit_tests/ut_h_derive_custom.amlg
+++ b/unit_tests/ut_h_derive_custom.amlg
@@ -32,7 +32,7 @@
 	))
 
     (call_entity "howso" "set_params" (assoc
-        default_hyperparameter_map (assoc "k" 3 "p" 1 "dt" -1)
+        default_data_parameters_map (assoc "k" 3 "p" 1 "dt" -1)
     ))
 
 	;TEST code parsing validation

--- a/unit_tests/ut_h_distance_contributions.amlg
+++ b/unit_tests/ut_h_distance_contributions.amlg
@@ -25,7 +25,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map
+		default_data_parameters_map
 			(assoc
 				dt -1
 				k 5
@@ -103,7 +103,7 @@
 
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map
+		default_data_parameters_map
 			(assoc
 				dt -1
 				k 2

--- a/unit_tests/ut_h_dynamic_deviations.amlg
+++ b/unit_tests/ut_h_dynamic_deviations.amlg
@@ -88,7 +88,7 @@
 		hps
 			(get
 				(call_entity "howso" "get_params" (assoc action_feature ""))
-				[1 "payload" "hyperparameter_map"]
+				[1 "payload" "data_parameters_map"]
 			)
 	))
 

--- a/unit_tests/ut_h_edit_dist_features.amlg
+++ b/unit_tests/ut_h_edit_dist_features.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_edit_dist_features.amlg" retries 2))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 1 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 1 "dt" -1)
 	))
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes

--- a/unit_tests/ut_h_feature_conviction.amlg
+++ b/unit_tests/ut_h_feature_conviction.amlg
@@ -68,7 +68,7 @@
 	(set_entity_rand_seed "howso" 12345)
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 1 "p" 2 "dt" -1)
 	))
 
 ;VALIDATE THE VALUES FOR TARGETED ACCURACY

--- a/unit_tests/ut_h_goal_features_agg.amlg
+++ b/unit_tests/ut_h_goal_features_agg.amlg
@@ -50,7 +50,7 @@
 					details {
 						"feature_robust_accuracy_contributions" .true
 					}
-					num_robust_accuracy_contributions_samples 3000
+					num_robust_accuracy_contributions_samples 10000
 				))
 				[1 "payload" "feature_robust_accuracy_contributions" "sold"]
 			)
@@ -65,7 +65,7 @@
 					details {
 						"feature_robust_accuracy_contributions" .true
 					}
-					num_robust_accuracy_contributions_samples 3000
+					num_robust_accuracy_contributions_samples 10000
 					goal_features_map {"price" {"goal" "max"}}
 					goal_dependent_features ["city"]
 				))

--- a/unit_tests/ut_h_id_features.amlg
+++ b/unit_tests/ut_h_id_features.amlg
@@ -56,7 +56,7 @@
 	))
 	(assign (assoc
 		context_key (apply "concat" (weave (sort (trunc features)) "."))
-		result (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		result (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(print "single target has expected attributes: ")
@@ -107,7 +107,7 @@
 		weight_feature "width"
 	))
 	(assign (assoc
-		result (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		result (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(print "now has color weight attributes: ")
@@ -162,7 +162,7 @@
 	))
 	(assign (assoc
 		context_key (apply "concat" (weave (sort features) "."))
-		result (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		result (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(print "targetless has .case_weight attributes: ")

--- a/unit_tests/ut_h_impute_sparse.amlg
+++ b/unit_tests/ut_h_impute_sparse.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_impute_sparse.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 0.4 "dt" -1)
+		default_data_parameters_map (assoc "k" 1 "p" 0.4 "dt" -1)
 	))
 
 	(declare (assoc
@@ -203,7 +203,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" .5 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" .5 "dt" -1)
 	))
 
 	(assign (assoc

--- a/unit_tests/ut_h_inactive.amlg
+++ b/unit_tests/ut_h_inactive.amlg
@@ -41,7 +41,7 @@
 		opt_hp_map
 			(get
 				(call_entity "howso" "get_params")
-				(list 1 "payload" "hyperparameter_map" "targetless" "A.B.C.D." ".none")
+				(list 1 "payload" "data_parameters_map" "targetless" "A.B.C.D." ".none")
 			)
 	))
 
@@ -166,7 +166,7 @@
 		opt_hp_map
 			(get
 				(call_entity "howso" "get_params")
-				(list 1 "payload" "hyperparameter_map" "targetless" "A.B.C.D." ".none")
+				(list 1 "payload" "data_parameters_map" "targetless" "A.B.C.D." ".none")
 			)
 	))
 

--- a/unit_tests/ut_h_inactive.amlg
+++ b/unit_tests/ut_h_inactive.amlg
@@ -54,12 +54,12 @@
 					;check that value may be within epsilon of 0, which is practically 0
 					(lambda (< (current_value) 2e-14))
 					[
-						(get opt_hp_map ["featureMdaMap" "A" "C"])
-						(get opt_hp_map ["featureMdaMap" "A" "D"])
-						(get opt_hp_map ["featureMdaMap" "B" "C"])
-						(get opt_hp_map ["featureMdaMap" "B" "D"])
-						(get opt_hp_map ["featureMdaMap" "C" "D"])
-						(get opt_hp_map ["featureMdaMap" "D" "C"])
+						(get opt_hp_map ["featureProbabilitiesMap" "A" "C"])
+						(get opt_hp_map ["featureProbabilitiesMap" "A" "D"])
+						(get opt_hp_map ["featureProbabilitiesMap" "B" "C"])
+						(get opt_hp_map ["featureProbabilitiesMap" "B" "D"])
+						(get opt_hp_map ["featureProbabilitiesMap" "C" "D"])
+						(get opt_hp_map ["featureProbabilitiesMap" "D" "C"])
 					]
 				)
 			))
@@ -179,9 +179,9 @@
 					;check that value may be within epsilon of 0, which is practically 0
 					(lambda (< (current_value) 2e-14))
 					[
-						(get opt_hp_map ["featureMdaMap" "A" "D"])
-						(get opt_hp_map ["featureMdaMap" "B" "D"])
-						(get opt_hp_map ["featureMdaMap" "C" "D"])
+						(get opt_hp_map ["featureProbabilitiesMap" "A" "D"])
+						(get opt_hp_map ["featureProbabilitiesMap" "B" "D"])
+						(get opt_hp_map ["featureProbabilitiesMap" "C" "D"])
 					]
 				)
 			))
@@ -192,9 +192,9 @@
 				(=  {A 1 B 1 C 1 D 1} (get opt_hp_map ["featureWeights"]) )
 				(!= 0 (get opt_hp_map ["featureDeviations" "C"]) )
 				(!= 0 (get opt_hp_map ["featureDeviations" "D"]) )
-				(!= 0 (get opt_hp_map ["featureMdaMap" "A" "C"]) )
-				(!= 0 (get opt_hp_map ["featureMdaMap" "B" "C"]) )
-				(!= 0 (get opt_hp_map ["featureMdaMap" "D" "C"]) )
+				(!= 0 (get opt_hp_map ["featureProbabilitiesMap" "A" "C"]) )
+				(!= 0 (get opt_hp_map ["featureProbabilitiesMap" "B" "C"]) )
+				(!= 0 (get opt_hp_map ["featureProbabilitiesMap" "D" "C"]) )
 			)
 	))
 

--- a/unit_tests/ut_h_inactive.amlg
+++ b/unit_tests/ut_h_inactive.amlg
@@ -38,7 +38,7 @@
 	(call_entity "howso" "analyze")
 
 	(declare (assoc
-		opt_hp_map
+		opt_dp_map
 			(get
 				(call_entity "howso" "get_params")
 				(list 1 "payload" "data_parameters_map" "targetless" "A.B.C.D." ".none")
@@ -54,12 +54,12 @@
 					;check that value may be within epsilon of 0, which is practically 0
 					(lambda (< (current_value) 2e-14))
 					[
-						(get opt_hp_map ["featureProbabilitiesMap" "A" "C"])
-						(get opt_hp_map ["featureProbabilitiesMap" "A" "D"])
-						(get opt_hp_map ["featureProbabilitiesMap" "B" "C"])
-						(get opt_hp_map ["featureProbabilitiesMap" "B" "D"])
-						(get opt_hp_map ["featureProbabilitiesMap" "C" "D"])
-						(get opt_hp_map ["featureProbabilitiesMap" "D" "C"])
+						(get opt_dp_map ["featureProbabilitiesMap" "A" "C"])
+						(get opt_dp_map ["featureProbabilitiesMap" "A" "D"])
+						(get opt_dp_map ["featureProbabilitiesMap" "B" "C"])
+						(get opt_dp_map ["featureProbabilitiesMap" "B" "D"])
+						(get opt_dp_map ["featureProbabilitiesMap" "C" "D"])
+						(get opt_dp_map ["featureProbabilitiesMap" "D" "C"])
 					]
 				)
 			))
@@ -69,8 +69,8 @@
 		obs
 			(=
 				(/ 1 15.5)
-				(get opt_hp_map ["featureDeviations" "C"])
-				(get opt_hp_map ["featureDeviations" "D"])
+				(get opt_dp_map ["featureDeviations" "C"])
+				(get opt_dp_map ["featureDeviations" "D"])
 			)
 	))
 
@@ -163,7 +163,7 @@
 	(call_entity "howso" "analyze")
 
 	(assign (assoc
-		opt_hp_map
+		opt_dp_map
 			(get
 				(call_entity "howso" "get_params")
 				(list 1 "payload" "data_parameters_map" "targetless" "A.B.C.D." ".none")
@@ -179,9 +179,9 @@
 					;check that value may be within epsilon of 0, which is practically 0
 					(lambda (< (current_value) 2e-14))
 					[
-						(get opt_hp_map ["featureProbabilitiesMap" "A" "D"])
-						(get opt_hp_map ["featureProbabilitiesMap" "B" "D"])
-						(get opt_hp_map ["featureProbabilitiesMap" "C" "D"])
+						(get opt_dp_map ["featureProbabilitiesMap" "A" "D"])
+						(get opt_dp_map ["featureProbabilitiesMap" "B" "D"])
+						(get opt_dp_map ["featureProbabilitiesMap" "C" "D"])
 					]
 				)
 			))
@@ -189,12 +189,12 @@
 	(call assert_true (assoc
 		obs
 			(and
-				(=  {A 1 B 1 C 1 D 1} (get opt_hp_map ["featureWeights"]) )
-				(!= 0 (get opt_hp_map ["featureDeviations" "C"]) )
-				(!= 0 (get opt_hp_map ["featureDeviations" "D"]) )
-				(!= 0 (get opt_hp_map ["featureProbabilitiesMap" "A" "C"]) )
-				(!= 0 (get opt_hp_map ["featureProbabilitiesMap" "B" "C"]) )
-				(!= 0 (get opt_hp_map ["featureProbabilitiesMap" "D" "C"]) )
+				(=  {A 1 B 1 C 1 D 1} (get opt_dp_map ["featureWeights"]) )
+				(!= 0 (get opt_dp_map ["featureDeviations" "C"]) )
+				(!= 0 (get opt_dp_map ["featureDeviations" "D"]) )
+				(!= 0 (get opt_dp_map ["featureProbabilitiesMap" "A" "C"]) )
+				(!= 0 (get opt_dp_map ["featureProbabilitiesMap" "B" "C"]) )
+				(!= 0 (get opt_dp_map ["featureProbabilitiesMap" "D" "C"]) )
 			)
 	))
 

--- a/unit_tests/ut_h_influential_cases.amlg
+++ b/unit_tests/ut_h_influential_cases.amlg
@@ -23,14 +23,14 @@
 
 
 	(call_entity "howso" "set_params" (assoc
-		hyperparameter_map
+		data_parameters_map
 			(assoc
 				"targeted"
 					(assoc
 						"y" (assoc "x." (assoc ".none" (assoc "k" 2 "p" 2 "dt" -1)))
 					)
 			)
-		default_hyperparameter_map (assoc "k" 2 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 2 "dt" -1)
 	))
 
 	(declare (assoc

--- a/unit_tests/ut_h_input_validation.amlg
+++ b/unit_tests/ut_h_input_validation.amlg
@@ -166,7 +166,7 @@
 	(call exit_if_failures (assoc msg "Adding feature with invalid and valid feature name."))
 
 
-	(assign (assoc result (get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map"))))
+	(assign (assoc result (get (call_entity "howso" "get_params") (list 1 "payload" "data_parameters_map"))))
 	(print "DataParameters updated with new feature:\n")
 	(if (get result ["targetless" "x.y.z." ".none" "featureDeviations"])
 		(seq

--- a/unit_tests/ut_h_input_validation.amlg
+++ b/unit_tests/ut_h_input_validation.amlg
@@ -167,7 +167,7 @@
 
 
 	(assign (assoc result (get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map"))))
-	(print "Hyperparameters updated with new feature:\n")
+	(print "DataParameters updated with new feature:\n")
 	(if (get result ["targetless" "x.y.z." ".none" "featureDeviations"])
 		(seq
 			(print "Deviations: ")
@@ -175,7 +175,7 @@
 		)
 	)
 
-	(call exit_if_failures (assoc msg "Hyperparameters updated after feature is added."))
+	(call exit_if_failures (assoc msg "DataParameters updated after feature is added."))
 
 	(assign (assoc
 		result

--- a/unit_tests/ut_h_migration.amlg
+++ b/unit_tests/ut_h_migration.amlg
@@ -254,9 +254,9 @@
 		trainee_json_filepath "../migrations/"
 	))
 
-	(print "Persisted new !hyperparameterMetadataMap: ")
+	(print "Persisted new !dataParametersMap: ")
 	(declare (assoc
-		updated_hp_map (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		updated_hp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 		ctx_key ".date_delta_1..date_lag_1..f1_delta_1..f1_lag_1..f1_rate_1..f2_delta_1..f2_delta_2..f2_lag_1..f2_rate_1..f2_rate_2..f3_delta_1..f3_lag_1..f3_rate_1..reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_to_horizon.ID.date.f1.f2.f3."
 	))
 	(call assert_true (assoc
@@ -264,7 +264,7 @@
 			(and
 				(contains_index (get updated_hp_map "targetless") ctx_key)
 				;all the deltas, lags, rates, series_progress features
-				(= 23 (size (get updated_hp_map ["targetless" ctx_key ".none" "featureMdaMap"])))
+				(= 23 (size (get updated_hp_map ["targetless" ctx_key ".none" "featureProbabilitiesMap"])))
 			)
 	))
 

--- a/unit_tests/ut_h_migration.amlg
+++ b/unit_tests/ut_h_migration.amlg
@@ -256,15 +256,15 @@
 
 	(print "Persisted new !dataParametersMap: ")
 	(declare (assoc
-		updated_hp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
+		updated_dp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 		ctx_key ".date_delta_1..date_lag_1..f1_delta_1..f1_lag_1..f1_rate_1..f2_delta_1..f2_delta_2..f2_lag_1..f2_rate_1..f2_rate_2..f3_delta_1..f3_lag_1..f3_rate_1..reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_to_horizon.ID.date.f1.f2.f3."
 	))
 	(call assert_true (assoc
 		obs
 			(and
-				(contains_index (get updated_hp_map "targetless") ctx_key)
+				(contains_index (get updated_dp_map "targetless") ctx_key)
 				;all the deltas, lags, rates, series_progress features
-				(= 23 (size (get updated_hp_map ["targetless" ctx_key ".none" "featureProbabilitiesMap"])))
+				(= 23 (size (get updated_dp_map ["targetless" ctx_key ".none" "featureProbabilitiesMap"])))
 			)
 	))
 

--- a/unit_tests/ut_h_nominal_distribution.amlg
+++ b/unit_tests/ut_h_nominal_distribution.amlg
@@ -32,7 +32,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -44,14 +44,14 @@
 	))
 
 	(declare (assoc
-		opt_hp_map
+		opt_dp_map
 			(get
 				(call_entity "howso" "get_params")
 				(list 1 "payload" "data_parameters_map")
 			)
 	))
 
-	(assign (assoc result (get opt_hp_map ["targetless" "A.B.C.D." ".none" "featureDeviations"]) ))
+	(assign (assoc result (get opt_dp_map ["targetless" "A.B.C.D." ".none" "featureDeviations"]) ))
 	(print "Analyzed with null deviations: ")
 
 	(call assert_approximate (assoc
@@ -83,7 +83,7 @@
 	(call_entity "howso" "set_params" (assoc
 		data_parameters_map
 			(modify
-				opt_hp_map
+				opt_dp_map
 				["targetless" "A.B.C.D." ".none" "featureDeviations"]
 				.null
 			)
@@ -119,7 +119,7 @@
 	(call exit_if_failures (assoc msg "Null-value uncertainty react." ))
 
 	(call_entity "howso" "set_params" (assoc
-		data_parameters_map opt_hp_map
+		data_parameters_map opt_dp_map
 	))
 
 	(assign (assoc

--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -180,7 +180,7 @@
 				(list 1 "payload" "hyperparameter_map" "targetless" "A.B.C.D." ".none" "featureDeviations" "C")
 			)
 	))
-	(print "SDM and null deviations are stored correctly in hyperparameters: ")
+	(print "SDM and null deviations are stored correctly in dataset parameters: ")
 	(print "tuple size of 3 [deviations, value-null, null-null]: ")
 	(call assert_same (assoc
 		exp 3

--- a/unit_tests/ut_h_null_null_react.amlg
+++ b/unit_tests/ut_h_null_null_react.amlg
@@ -47,7 +47,7 @@
 		opt_hp_map
 			(get
 				(call_entity "howso" "get_params")
-				(list 1 "payload" "hyperparameter_map")
+				(list 1 "payload" "data_parameters_map")
 			)
 	))
 
@@ -81,7 +81,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		hyperparameter_map
+		data_parameters_map
 			(modify
 				opt_hp_map
 				["targetless" "A.B.C.D." ".none" "featureDeviations"]
@@ -119,7 +119,7 @@
 	(call exit_if_failures (assoc msg "Null-value uncertainty react." ))
 
 	(call_entity "howso" "set_params" (assoc
-		hyperparameter_map opt_hp_map
+		data_parameters_map opt_hp_map
 	))
 
 	(assign (assoc
@@ -177,7 +177,7 @@
 		result
 			(get
 				(call_entity "howso" "get_params")
-				(list 1 "payload" "hyperparameter_map" "targetless" "A.B.C.D." ".none" "featureDeviations" "C")
+				(list 1 "payload" "data_parameters_map" "targetless" "A.B.C.D." ".none" "featureDeviations" "C")
 			)
 	))
 	(print "SDM and null deviations are stored correctly in dataset parameters: ")
@@ -225,7 +225,7 @@
 		result
 			(get
 				(call_entity "howso" "get_params")
-				(list 1 "payload" "hyperparameter_map" "targetless" "A.B.C.D." ".none" "featureDeviations" "C")
+				(list 1 "payload" "data_parameters_map" "targetless" "A.B.C.D." ".none" "featureDeviations" "C")
 			)
 	))
 	(print "There's no SDM,  first value is simply a deviation: ")

--- a/unit_tests/ut_h_null_react.amlg
+++ b/unit_tests/ut_h_null_react.amlg
@@ -50,7 +50,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 
 
@@ -210,7 +210,7 @@
 
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 
 

--- a/unit_tests/ut_h_one_value_cont.amlg
+++ b/unit_tests/ut_h_one_value_cont.amlg
@@ -67,7 +67,7 @@
 				(call_entity "howso" "get_params" (assoc
 					action_feature ""
 				))
-				[1 "payload" "hyperparameter_map"]
+				[1 "payload" "data_parameters_map"]
 			)
 	))
 

--- a/unit_tests/ut_h_one_value_cont.amlg
+++ b/unit_tests/ut_h_one_value_cont.amlg
@@ -62,7 +62,7 @@
 				))
 				[1 "payload"]
 			)
-		hyperparams
+		dataparams
 			(get
 				(call_entity "howso" "get_params" (assoc
 					action_feature ""
@@ -80,7 +80,7 @@
 				up_b 0.45
 				target 0
 			}
-		obs (get hyperparams ["featureProbabilitiesMap" "target"])
+		obs (get dataparams ["featureProbabilitiesMap" "target"])
 		thresh 0.1
 	))
 
@@ -93,7 +93,7 @@
 				up_b 0.5
 				target 0.5
 			}
-		obs (get hyperparams ["featureProbabilitiesMap" "a"])
+		obs (get dataparams ["featureProbabilitiesMap" "a"])
 		thresh 0.05
 	))
 

--- a/unit_tests/ut_h_one_value_cont.amlg
+++ b/unit_tests/ut_h_one_value_cont.amlg
@@ -80,7 +80,7 @@
 				up_b 0.45
 				target 0
 			}
-		obs (get hyperparams ["featureMdaMap" "target"])
+		obs (get hyperparams ["featureProbabilitiesMap" "target"])
 		thresh 0.1
 	))
 
@@ -93,7 +93,7 @@
 				up_b 0.5
 				target 0.5
 			}
-		obs (get hyperparams ["featureMdaMap" "a"])
+		obs (get hyperparams ["featureProbabilitiesMap" "a"])
 		thresh 0.05
 	))
 

--- a/unit_tests/ut_h_ordinal.amlg
+++ b/unit_tests/ut_h_ordinal.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_ordinal.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 4 "p" 2 "dt" -1 "paramPath" (list ".default"))
+		default_data_parameters_map (assoc "k" 4 "p" 2 "dt" -1 "paramPath" (list ".default"))
 	))
 
 	(assign (assoc

--- a/unit_tests/ut_h_pairwise_distances.amlg
+++ b/unit_tests/ut_h_pairwise_distances.amlg
@@ -39,7 +39,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		hyperparameter_map
+		data_parameters_map
 			(assoc
 				"targeted" (assoc "y" (assoc "x." (assoc ".none" (assoc "k" 5 "p" 2 "dt" -1))))
 				"targetless" (assoc "x.y." (assoc ".none" (assoc "k" 3 "p" 1 "dt" -1)))

--- a/unit_tests/ut_h_params.amlg
+++ b/unit_tests/ut_h_params.amlg
@@ -17,7 +17,7 @@
 				hyperparameter_map (assoc "single_targeted" (assoc "k" 5 "p" 2 "dt" -1))
 			))
 	))
-	(print "bad hyperparameter map: ")
+	(print "bad dataset parameter map: ")
 	(call assert_same (assoc exp 0 obs (first result)))
 	(print "1 error: ")
 	(call assert_same (assoc exp "string" obs (get_type_string (get result (list 1 "detail"))) ))
@@ -30,7 +30,7 @@
 					(assoc "targetless" (assoc "A.B.C." (assoc ".none" (assoc "k" 5 "p" 2 "dt" -1))))
 			))
 	))
-	(print "good hyperparameter map: ")
+	(print "good dataset parameter map: ")
 	(call assert_same (assoc exp 1 obs (first result) ))
 
 	(assign (assoc result (call_entity "howso" "get_params" )))
@@ -38,7 +38,7 @@
 	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list 1 "payload" "hyperparameter_map" "targetless" "A.B.C." ".none"))))
 
 	(assign (assoc result (call_entity "howso" "get_params" (assoc action_feature ""))))
-	(print "Test get_params with GetHyperparameters logic: ")
+	(print "Test get_params with GetDataParameters logic: ")
 	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list 1 "payload" "hyperparameter_map"))))
 
 	(call_entity "howso" "set_params" (assoc

--- a/unit_tests/ut_h_params.amlg
+++ b/unit_tests/ut_h_params.amlg
@@ -14,7 +14,7 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "set_params" (assoc
-				hyperparameter_map (assoc "single_targeted" (assoc "k" 5 "p" 2 "dt" -1))
+				data_parameters_map (assoc "single_targeted" (assoc "k" 5 "p" 2 "dt" -1))
 			))
 	))
 	(print "bad dataset parameter map: ")
@@ -26,7 +26,7 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "set_params" (assoc
-				hyperparameter_map
+				data_parameters_map
 					(assoc "targetless" (assoc "A.B.C." (assoc ".none" (assoc "k" 5 "p" 2 "dt" -1))))
 			))
 	))
@@ -35,11 +35,11 @@
 
 	(assign (assoc result (call_entity "howso" "get_params" )))
 	(print "Test get_params: ")
-	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list 1 "payload" "hyperparameter_map" "targetless" "A.B.C." ".none"))))
+	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list 1 "payload" "data_parameters_map" "targetless" "A.B.C." ".none"))))
 
 	(assign (assoc result (call_entity "howso" "get_params" (assoc action_feature ""))))
 	(print "Test get_params with GetDataParameters logic: ")
-	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list 1 "payload" "hyperparameter_map"))))
+	(call assert_same (assoc exp (assoc "k" 5  "p" 2 "dt" -1) obs (get result (list 1 "payload" "data_parameters_map"))))
 
 	(call_entity "howso" "set_params" (assoc
 		numerical_precision "fast"
@@ -75,7 +75,7 @@
 	(print "Other parameters weren't reset or changed: ")
 	(call assert_same (assoc
 		exp (assoc "k" 5  "p" 2 "dt" -1)
-		obs (get result ["hyperparameter_map" "targetless" "A.B.C." ".none"] )
+		obs (get result ["data_parameters_map" "targetless" "A.B.C." ".none"] )
 	))
 	(call assert_same (assoc
 		obs (get result "analyze_threshold")
@@ -244,7 +244,7 @@
 	(assign (assoc result (call_entity "howso" "get_params" )))
 	(print "no action features results in targetless analysis: ")
 	(call assert_true (assoc
-		obs (contains_index (get result (list 1 "payload" "hyperparameter_map")) "targetless")
+		obs (contains_index (get result (list 1 "payload" "data_parameters_map")) "targetless")
 	))
 
 	(call_entity "howso" "analyze" (assoc
@@ -253,7 +253,7 @@
 	))
 
 
-	(assign (assoc result (get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map")) ))
+	(assign (assoc result (get (call_entity "howso" "get_params") (list 1 "payload" "data_parameters_map")) ))
 	(print "omni_targeted analysis parameters: " )
 	(call assert_true (assoc
 		obs

--- a/unit_tests/ut_h_react_audit.amlg
+++ b/unit_tests/ut_h_react_audit.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_react_audit.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 0.4 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 0.4 "dt" -1)
 	))
 
 	(declare (assoc

--- a/unit_tests/ut_h_react_distance_ratio.amlg
+++ b/unit_tests/ut_h_react_distance_ratio.amlg
@@ -20,7 +20,7 @@
 				"con_B" (assoc type "continuous")
 				"nom_A" (assoc type "nominal" data_type "string")
 			)
-		default_hyperparameter_map
+		default_data_parameters_map
 			(assoc "k" 4 "p" 1 "dt" -1)
 	))
 
@@ -29,7 +29,7 @@
 		feature_attributes features
 	))
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map default_hyperparameter_map
+		default_data_parameters_map default_data_parameters_map
 	))
 	(call_entity "howso" "train" (assoc
 		features context_features

--- a/unit_tests/ut_h_react_explain.amlg
+++ b/unit_tests/ut_h_react_explain.amlg
@@ -5,7 +5,7 @@
 	(call_entity "howso" "set_feature_attributes" (assoc feature_attributes (assoc "E" (assoc "type" "nominal"))))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 0.4 "dt" -1 "paramPath" (list ".default") )
+		default_data_parameters_map (assoc "k" 3 "p" 0.4 "dt" -1 "paramPath" (list ".default") )
 	))
 
 	(declare (assoc
@@ -567,7 +567,7 @@
 
 ;VERIFY CATEGORICAL ACTION PROBABILITIES
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 10 "p" 0.4 "dt" -1 "paramPath" (list ".default"))
+		default_data_parameters_map (assoc "k" 10 "p" 0.4 "dt" -1 "paramPath" (list ".default"))
 	))
 
 	(assign (assoc

--- a/unit_tests/ut_h_react_into_features.amlg
+++ b/unit_tests/ut_h_react_into_features.amlg
@@ -51,7 +51,7 @@
 	(call keep_result_payload)
 	(print "Analyzed to color, x and y: ")
 	(call assert_same (assoc
-		obs (first (indices (get result ["hyperparameter_map" "targetless"])))
+		obs (first (indices (get result ["data_parameters_map" "targetless"])))
 		exp "color.x.y."
 	))
 
@@ -130,7 +130,7 @@
 
 	(print "Auto analyzed to color, dc, fc, if, sc, x and y: ")
 	(call assert_same (assoc
-		obs (first (indices (get result ["hyperparameter_map" "targetless"])))
+		obs (first (indices (get result ["data_parameters_map" "targetless"])))
 		exp "color.dc.fc.if.sc.x.y."
 	))
 

--- a/unit_tests/ut_h_react_into_features.amlg
+++ b/unit_tests/ut_h_react_into_features.amlg
@@ -64,7 +64,7 @@
 	(declare (assoc
 		result_first
 			(call_entity "howso" "get_cases" (assoc
-				features ["distance_contribution" "similarity_conviction"]
+				features [".distance_contribution" ".similarity_conviction"]
 				num_cases 3
 			))
 	))
@@ -113,12 +113,12 @@
 		exp
 			{
 				color {type "nominal"}
-				distance_contribution { bounds {max .infinity min 0} data_type "number" type "continuous" }
+				".distance_contribution" { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				dc { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				fc { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				if { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				sc { bounds {max .infinity min 0} data_type "number" type "continuous" }
-				similarity_conviction { bounds {max .infinity min 0} data_type "number" type "continuous" }
+				".similarity_conviction" { bounds {max .infinity min 0} data_type "number" type "continuous" }
 				x { bounds {allow_null .true} type "continuous"  }
 				y { bounds {allow_null .true} type "continuous" }
 			}

--- a/unit_tests/ut_h_react_into_features.amlg
+++ b/unit_tests/ut_h_react_into_features.amlg
@@ -134,7 +134,7 @@
 		exp "color.dc.fc.if.sc.x.y."
 	))
 
-	(call exit_if_failures (assoc msg "Feature attributes and hyperparameters updated."))
+	(call exit_if_failures (assoc msg "Feature attributes and dataset parameters updated."))
 
 	(call_entity "howso" "train" (assoc
 		cases

--- a/unit_tests/ut_h_rl.amlg
+++ b/unit_tests/ut_h_rl.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_rl.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 2 "dt" -1)
 	))
 	(call_entity "howso" "set_feature_attributes" (assoc
 		feature_attributes

--- a/unit_tests/ut_h_rounding.amlg
+++ b/unit_tests/ut_h_rounding.amlg
@@ -37,7 +37,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 1 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_shared_deviations.amlg
+++ b/unit_tests/ut_h_shared_deviations.amlg
@@ -97,7 +97,7 @@
 
 	(declare (assoc
 		shared_feature_deviations
-			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targeted" "color2" "color1.fruit.height.length.size.sweet.tart.weight.width." ".none" "featureDeviations"))
+			(get (call_entity "howso" "get_params") (list 1 "payload" "data_parameters_map" "targeted" "color2" "color1.fruit.height.length.size.sweet.tart.weight.width." ".none" "featureDeviations"))
 	))
 
 	(print "Features with shared deviations have same deviations: weight and height ")

--- a/unit_tests/ut_h_shared_deviations_series.amlg
+++ b/unit_tests/ut_h_shared_deviations_series.amlg
@@ -98,7 +98,7 @@
 			(get (call_entity "howso" "get_params") (list 1 "payload" "data_parameters_map" "targetless" ".reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
-	(declare (assoc shared_feature_deviations (get shared_deviations_hp_map deviations_param_path)))
+	(declare (assoc shared_feature_deviations (get shared_deviations_dp_map deviations_param_path)))
 
 	(print "Series lag features with shared deviations are same: time and .time_lag_1.")
 	(call assert_same (assoc

--- a/unit_tests/ut_h_shared_deviations_series.amlg
+++ b/unit_tests/ut_h_shared_deviations_series.amlg
@@ -95,7 +95,7 @@
 
 	(declare (assoc
 		shared_feature_deviations
-			(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+			(get (call_entity "howso" "get_params") (list 1 "payload" "data_parameters_map" "targetless" ".reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(declare (assoc shared_feature_deviations (get shared_deviations_hp_map deviations_param_path)))
@@ -160,7 +160,7 @@
 	(call_entity "howso" "analyze" (assoc use_deviations .true))
 
 	(assign (assoc shared_feature_deviations
-		(get (call_entity "howso" "get_params") (list 1 "payload" "hyperparameter_map" "targetless" ".reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
+		(get (call_entity "howso" "get_params") (list 1 "payload" "data_parameters_map" "targetless" ".reverse_series_index..series_index..synchronous_counter..synchronous_counter_lag_1..time_delta_1..time_lag_1..value_delta_1..value_lag_1..value_lag_2.stock.time.value." ".none" "featureDeviations"))
 	))
 
 	(print "Series lag features with no shared deviations are different: .value_lag_1 and .value_lag_2.")

--- a/unit_tests/ut_h_string_ordinals.amlg
+++ b/unit_tests/ut_h_string_ordinals.amlg
@@ -224,12 +224,12 @@
 				num_nom 1
 				value 1
 			}
-		obs (get hp_map ["featureMdaMap" "inactive"])
+		obs (get hp_map ["featureProbabilitiesMap" "inactive"])
 	))
 
 	(print "id feature does not have weights assigned since it's unique: ")
 	(call assert_true (assoc
-		obs (not (contains_index (get hp_map "featureMdaMap") "id"))
+		obs (not (contains_index (get hp_map "featureProbabilitiesMap") "id"))
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))

--- a/unit_tests/ut_h_string_ordinals.amlg
+++ b/unit_tests/ut_h_string_ordinals.amlg
@@ -201,17 +201,17 @@
 	))
 	(call keep_result_payload)
 
-	(declare (assoc hp_map (get result ["data_parameters_map" "targetless" "bool.bool_nom.count.id.inactive.num_nom.value." ".none"]) ))
+	(declare (assoc dp_map (get result ["data_parameters_map" "targetless" "bool.bool_nom.count.id.inactive.num_nom.value." ".none"]) ))
 
 
 	(print "Unique ID feature and inactive feature have the smallest theoretical deviation: ")
 	(call assert_approximate (assoc
 		exp 0.037746
-		obs (get hp_map ["featureDeviations" "id"])
+		obs (get dp_map ["featureDeviations" "id"])
 	))
 	(call assert_approximate (assoc
 		exp 0.037746
-		obs (get hp_map ["featureDeviations" "inactive"])
+		obs (get dp_map ["featureDeviations" "inactive"])
 	))
 
 	(print "Inactive feature has weights but does not have id (unique) feature: ")
@@ -224,12 +224,12 @@
 				num_nom 1
 				value 1
 			}
-		obs (get hp_map ["featureProbabilitiesMap" "inactive"])
+		obs (get dp_map ["featureProbabilitiesMap" "inactive"])
 	))
 
 	(print "id feature does not have weights assigned since it's unique: ")
 	(call assert_true (assoc
-		obs (not (contains_index (get hp_map "featureProbabilitiesMap") "id"))
+		obs (not (contains_index (get dp_map "featureProbabilitiesMap") "id"))
 	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))

--- a/unit_tests/ut_h_string_ordinals.amlg
+++ b/unit_tests/ut_h_string_ordinals.amlg
@@ -39,7 +39,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc
@@ -201,7 +201,7 @@
 	))
 	(call keep_result_payload)
 
-	(declare (assoc hp_map (get result ["hyperparameter_map" "targetless" "bool.bool_nom.count.id.inactive.num_nom.value." ".none"]) ))
+	(declare (assoc hp_map (get result ["data_parameters_map" "targetless" "bool.bool_nom.count.id.inactive.num_nom.value." ".none"]) ))
 
 
 	(print "Unique ID feature and inactive feature have the smallest theoretical deviation: ")

--- a/unit_tests/ut_h_synthetic_dataset1.amlg
+++ b/unit_tests/ut_h_synthetic_dataset1.amlg
@@ -76,7 +76,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 1 "p" 2 "dt" -1)
 	))
 
 	(declare (assoc
@@ -155,7 +155,7 @@
 		int_params
 			(get
 				(call_entity "howso" "get_params")
-				(list 1 "payload" "default_hyperparameter_map")
+				(list 1 "payload" "default_data_parameters_map")
 			)
 	))
 
@@ -178,7 +178,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map int_params
+		default_data_parameters_map int_params
 	))
 
 	(assign (assoc
@@ -210,7 +210,7 @@
 			)
 	))
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map int_params
+		default_data_parameters_map int_params
 	))
 
 	(assign (assoc
@@ -231,7 +231,7 @@
 	(assign (assoc result (call_entity "howso" "get_params")))
 
 	(print "Feature weights for W: ")
-	(call assert_same (assoc obs (get result (list 1 "payload" "default_hyperparameter_map" "featureWeights")) exp (assoc "v" 1 "x" 1 "z" 0 "w" 1 "y" 1)	))
+	(call assert_same (assoc obs (get result (list 1 "payload" "default_data_parameters_map" "featureWeights")) exp (assoc "v" 1 "x" 1 "z" 0 "w" 1 "y" 1)	))
 
 	(call exit_if_failures (assoc msg unit_test_name ))
 )

--- a/unit_tests/ut_h_time_format.amlg
+++ b/unit_tests/ut_h_time_format.amlg
@@ -24,7 +24,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_time_series.amlg
+++ b/unit_tests/ut_h_time_series.amlg
@@ -395,7 +395,7 @@
 
 
 	(call_entity "howso" "set_params" (assoc
-		hyperparameter_map
+		data_parameters_map
 			(assoc "targetless"
 				(assoc ".date_delta_1..date_lag_1..f1_lag_1..f1_rate_1..f2_lag_1..f2_rate_1..f2_rate_2..f3_lag_1..f3_rate_1..series_progress..series_progress_delta.ID.date.f1.f2.f3."
 					(assoc

--- a/unit_tests/ut_h_time_series_datetime.amlg
+++ b/unit_tests/ut_h_time_series_datetime.amlg
@@ -34,7 +34,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		hyperparameter_map
+		data_parameters_map
 			(assoc
 				"targetless" (assoc "name.owner.stock.time.value." (assoc ".none" (assoc "k" 3 "p" .1 "dt" -1 "paramPath" ["targetless" "name.owner.stock.time.value." ".none"]) ) )
 			)

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -50,7 +50,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" .1 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" .1 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc

--- a/unit_tests/ut_h_train_react.amlg
+++ b/unit_tests/ut_h_train_react.amlg
@@ -3,7 +3,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_h_train_react.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 0.4 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 0.4 "dt" -1)
 	))
 
 	(declare (assoc

--- a/unit_tests/ut_h_unique_ids.amlg
+++ b/unit_tests/ut_h_unique_ids.amlg
@@ -38,7 +38,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 3 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 3 "p" 2 "dt" -1)
 	))
 
 	(call_entity "howso" "set_feature_attributes" (assoc
@@ -210,7 +210,7 @@
 	(call assert_approximate (assoc
 		obs
 			(keep
-				(get result (list "hyperparameter_map" "targetless" "count.n_id.s_id.value." ".none" "featureDeviations"))
+				(get result (list "data_parameters_map" "targetless" "count.n_id.s_id.value." ".none" "featureDeviations"))
 				(list "n_id" "s_id")
 			)
 		exp (assoc n_id 0.0392 s_id 0.0392)

--- a/unit_tests/ut_h_warnings.amlg
+++ b/unit_tests/ut_h_warnings.amlg
@@ -47,7 +47,7 @@
 	(print "Error about overwrite: ")
 	(call assert_same (assoc
 		obs result
-		exp "The following features already exist: familiarity_conviction_addition, call react_into_features() with overwrite=True to overwrite the values for these features."
+		exp "The following features already exist: .familiarity_conviction_addition, call react_into_features() with overwrite=True to overwrite the values for these features."
 	))
 
 	(call_entity "howso" "analyze" )
@@ -197,7 +197,7 @@
 	(assign (assoc
 		result
 			(call_entity "howso" "react" (assoc
-				action_features (list "familiarity_conviction_addition")
+				action_features (list ".familiarity_conviction_addition")
 				desired_conviction 5.0
 				num_cases_to_generate 5
 			))
@@ -214,13 +214,13 @@
 	))
 
 	(call_entity "howso" "remove_feature" (assoc
-		feature "familiarity_conviction_addition"
+		feature ".familiarity_conviction_addition"
 	))
 
 	(assign (assoc
 		result
 			(call_entity "howso" "react" (assoc
-				action_features (list "familiarity_conviction_addition")
+				action_features (list ".familiarity_conviction_addition")
 				desired_conviction 5.0
 				num_cases_to_generate 5
 			))

--- a/unit_tests/ut_h_weighted_residuals_cont.amlg
+++ b/unit_tests/ut_h_weighted_residuals_cont.amlg
@@ -19,7 +19,7 @@
 	))
 
     (call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 1 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 1 "dt" -1)
 	))
 
     ;206 total case weight

--- a/unit_tests/ut_h_weighted_residuals_nom.amlg
+++ b/unit_tests/ut_h_weighted_residuals_nom.amlg
@@ -26,7 +26,7 @@
 	))
 
     (call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 2 "p" 1 "dt" -1)
+		default_data_parameters_map (assoc "k" 2 "p" 1 "dt" -1)
 	))
 
     ;210 total case weight

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -612,7 +612,7 @@
 
 
 	(assign (assoc
-		hp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
+		dp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(map
@@ -621,9 +621,9 @@
 				(assoc
 					context_key (apply "concat" (weave (sort (filter (lambda (!= (current_value) (current_value 2))) (append context_labels action_labels))) "."))
 				)
-				(print " analyzed " (current_value) " k " (get hp_map ["targeted" (current_value 1) context_key ".none" "k"]) " p " (get hp_map ["targeted" (current_value 1) context_key ".none" "p"]) " : ")
+				(print " analyzed " (current_value) " k " (get dp_map ["targeted" (current_value 1) context_key ".none" "k"]) " p " (get dp_map ["targeted" (current_value 1) context_key ".none" "p"]) " : ")
 				(call assert_true (assoc
-					obs (!= .null (get hp_map ["targeted" (current_value 2) context_key ".none"]))
+					obs (!= .null (get dp_map ["targeted" (current_value 2) context_key ".none"]))
 				))
 
 			)
@@ -642,7 +642,7 @@
 			))
 		context_key (apply "concat" (weave (sort (list "sepal_length" "sepal_width" "petal_length" "species")) "."))
 	))
-	(declare (assoc expected_k (get hp_map ["targeted" "petal_width" context_key ".none" "k"]) ))
+	(declare (assoc expected_k (get dp_map ["targeted" "petal_width" context_key ".none" "k"]) ))
 	(print "Closest K matches analyzed dataset parameter for petal_width " expected_k " : ")
 	(call assert_approximate (assoc
 		exp expected_k
@@ -661,7 +661,7 @@
 			))
 		context_key (apply "concat" (weave (sort (list "sepal_length" "petal_length" "petal_width" "species")) "."))
 	))
-	(assign (assoc expected_k (get hp_map ["targeted" "sepal_width" context_key ".none" "k"]) ))
+	(assign (assoc expected_k (get dp_map ["targeted" "sepal_width" context_key ".none" "k"]) ))
 	(print "Closest K matches analyzed dataset parameter for sepal_width " expected_k  " : ")
 	(call assert_approximate (assoc
 		exp expected_k
@@ -681,7 +681,7 @@
 		context_key (apply "concat" (weave (sort (list "sepal_length" "sepal_width" "petal_length" "petal_width")) "."))
 	))
 	(call keep_result_payload)
-	(assign (assoc expected_k (get hp_map ["targeted" "species" context_key ".none" "k"]) ))
+	(assign (assoc expected_k (get dp_map ["targeted" "species" context_key ".none" "k"]) ))
 	(print "Closest K matches analyzed dataset parameter for species " expected_k " : ")
 	(call assert_approximate (assoc
 		exp expected_k

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -643,7 +643,7 @@
 		context_key (apply "concat" (weave (sort (list "sepal_length" "sepal_width" "petal_length" "species")) "."))
 	))
 	(declare (assoc expected_k (get hp_map ["targeted" "petal_width" context_key ".none" "k"]) ))
-	(print "Closest K matches analyzed hyperparameter for petal_width " expected_k " : ")
+	(print "Closest K matches analyzed dataset parameter for petal_width " expected_k " : ")
 	(call assert_approximate (assoc
 		exp expected_k
 		obs (size (get result (list 1 "payload" "influential_cases")))
@@ -662,7 +662,7 @@
 		context_key (apply "concat" (weave (sort (list "sepal_length" "petal_length" "petal_width" "species")) "."))
 	))
 	(assign (assoc expected_k (get hp_map ["targeted" "sepal_width" context_key ".none" "k"]) ))
-	(print "Closest K matches analyzed hyperparameter for sepal_width " expected_k  " : ")
+	(print "Closest K matches analyzed dataset parameter for sepal_width " expected_k  " : ")
 	(call assert_approximate (assoc
 		exp expected_k
 		obs (size (get result (list 1 "payload" "influential_cases")))
@@ -682,7 +682,7 @@
 	))
 	(call keep_result_payload)
 	(assign (assoc expected_k (get hp_map ["targeted" "species" context_key ".none" "k"]) ))
-	(print "Closest K matches analyzed hyperparameter for species " expected_k " : ")
+	(print "Closest K matches analyzed dataset parameter for species " expected_k " : ")
 	(call assert_approximate (assoc
 		exp expected_k
 		obs (size (get result "influential_cases"))

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -554,7 +554,7 @@
 		weight_feature ".none"
 	))
 
-	(assign (assoc result (- 1 (get (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap")) ["targeted" "species" context_key ".none" "gridSearchError"])) ))
+	(assign (assoc result (- 1 (get (call_entity "howso" "debug_label" (assoc label "!dataParametersMap")) ["targeted" "species" context_key ".none" "gridSearchError"])) ))
 	(print "analyze accuracy score >= 96: " result " ")
 	(call assert_true (assoc obs (>= result 0.96)))
 
@@ -612,7 +612,7 @@
 
 
 	(assign (assoc
-		hp_map (call_entity "howso" "debug_label" (assoc label "!hyperparameterMetadataMap"))
+		hp_map (call_entity "howso" "debug_label" (assoc label "!dataParametersMap"))
 	))
 
 	(map

--- a/unit_tests/ut_iris.amlg
+++ b/unit_tests/ut_iris.amlg
@@ -4,7 +4,7 @@
 	(call (load "unit_test_howso.amlg") (assoc name "ut_iris.amlg"))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 8 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 8 "p" 2 "dt" -1)
 	))
 
 	(declare (assoc
@@ -267,7 +267,7 @@
 
 	;cache targeted dataset accuracy
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 10 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 10 "p" 2 "dt" -1)
 	))
 
 ;VERIFY DETAILS OF CASE
@@ -411,7 +411,7 @@
 
 ;VERIFY ACCURACY WITH LOW K
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 2 "dt" -1)
+		default_data_parameters_map (assoc "k" 1 "p" 2 "dt" -1)
 	))
 
 	;label
@@ -452,7 +452,7 @@
 ;VERIFY ACCURACY WITH HIGH K
 	;rerunning with higher P and closest N of 10
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 10 "p" 2.4 "dt" -1)
+		default_data_parameters_map (assoc "k" 10 "p" 2.4 "dt" -1)
 	))
 
 	(assign (assoc total_correct 0))
@@ -493,7 +493,7 @@
 	(print "Model size: " (call !get_num_cases) "\n")
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 1 "p" 2.4 "dt" -1)
+		default_data_parameters_map (assoc "k" 1 "p" 2.4 "dt" -1)
 	))
 
 	(assign (assoc total_correct 0))

--- a/unit_tests/ut_iris_generate_data.amlg
+++ b/unit_tests/ut_iris_generate_data.amlg
@@ -166,7 +166,7 @@
 	))
 
 	(call_entity "howso" "set_params" (assoc
-		default_hyperparameter_map (assoc "k" 8 "p" 2.25 "dt" -1)
+		default_data_parameters_map (assoc "k" 8 "p" 2.25 "dt" -1)
 	))
 
 	(set_entity_rand_seed "howso" 12345)
@@ -215,7 +215,7 @@
 		residuals
 			(get
 				(call_entity "howso" "get_params")
-				[1 "payload" "default_hyperparameter_map" "featureResiduals"]
+				[1 "payload" "default_data_parameters_map" "featureResiduals"]
 			)
  	))
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
   "dependencies": {
-    "amalgam": "81.3.3"
+    "amalgam": "81.4.0"
   }
 }


### PR DESCRIPTION
1) renames:
  !hyperparameterParamPaths to !dataParametersPaths 
  !defaultHyperparameters to !defaultDataParametersMap 
  !hyperparameterMetadataMap to !hyperparameterMetadataMap
2) all other internal variables or parameters referencing 'hyperparameters' to 'data parameters' 

3) internal data parameter: 'featureMdaMap' is renamed to 'featureProbabilitiesMap'
    'hyperparameter_map' key to 'data_parameters_map'

4) adds a leading '.' to conviction-related auto-computed features such as '.distance_contribution' and '.similarity_conviction' for flows where user does not manually specify a feature name

5) remove unused robust_hyperparameters parameter from react_aggregate()
