### PR TITLE
25873: Update's `react_group`'s "distance_contribution" behavior to compute while holding out the rest of the group, MAJOR

### DIFF
--- a/module/react_group.amlg
+++ b/module/react_group.amlg
@@ -5,9 +5,8 @@
 	; output an assoc react key -> list of corresponding values from each individual group.
 	; example output for 2 groups:
 	; (assoc
-	; 	"base_model_average_distance_contribution" (list 4.0 4.1)
-	;	"combined_model_average_distance_contribution" (list 4.05 3.9)
 	;	"distance_contributions" (list 4.5 3.2)
+	;	"similarity_conviction" (list 0.8 1.3)
 	; )
 	#{long_running .true statistically_idempotent .true}
 	react_group
@@ -39,16 +38,16 @@
 			;a list of assocs defining conditions that each select a collection of cases to react to.
 			#{type "list" values {ref "Condition"} min_size 1}
 			conditions .null
-			;calculate and output familiarity conviction of adding the specified new_cases in the output assoc
+			;calculate and output familiarity conviction of adding the specified new_cases
 			#{type "boolean"}
 			familiarity_conviction_addition .false
-			;calculate and output familiarity conviction of removing the specified new_cases in the output assoc
+			;calculate and output familiarity conviction of removing the specified new_cases
 			#{type "boolean"}
 			familiarity_conviction_removal .false
-			;calculate and output the KL divergence of adding the specified new_cases in the output assoc
+			;calculate and output the KL divergence of adding the specified new_cases
 			#{type "boolean"}
 			kl_divergence_addition .false
-			;calculate and output the KL divergence of removing the specified new_cases in the output assoc
+			;calculate and output the KL divergence of removing the specified new_cases
 			#{type "boolean"}
 			kl_divergence_removal .false
 			;if true will output p value of addition
@@ -60,10 +59,10 @@
 			;calculate and output the mean similarity conviction of cases in each group
 			#{type "boolean"}
 			similarity_conviction .false
-			;calculate and output distance contribution ratios in the output assoc
+			;calculate and output average distance contribution of each group holding out other cases in the group
 			#{type "boolean"}
 			distance_contributions .false
-			;calculate and output residual contribution ratios in the output assoc
+			;calculate and output average residual contribution of each group
 			#{type "boolean"}
 			residual_contributions .false
 			;flag, if set to true will scale influence weights by each case's weight_feature weight.
@@ -296,9 +295,7 @@
 			output_influential_cases .null
 			output_caps_map .null
 			feature_full_residuals_map .null
-			holdout_avg_distance_contribution .null
-			combined_average_distance_contribution .null
-			avg_new_cases_distance_contribution .null
+			cases_avg_distance_contribution .null
 			avg_new_cases_residual_contribution .null
 			new_case_entropies_value .null
 			average_new_cases_conviction_addition .null
@@ -640,10 +637,7 @@
 			)
 			(if distance_contributions
 				(assoc
-					"distance_contribution" avg_new_cases_distance_contribution
-					"base_model_average_distance_contribution" !averageCaseDistanceContribution
-					"combined_model_average_distance_contribution" combined_average_distance_contribution
-					"holdout_distance_contribution" holdout_avg_distance_contribution
+					"distance_contribution" cases_avg_distance_contribution
 				)
 				(assoc)
 			)
@@ -753,54 +747,28 @@
 
 	;Helper method to compute dataset avg distance contribution and new cases' avg distance contribution
 	!ComputeNewCasesDistanceContributions
-	(let
-		(assoc
-			combined_distance_contributions_map
-				(compute_on_contained_entities
-					||(query_entity_distance_contributions
-						closest_k
-						features
-						.null
-						(get hyperparam_map "p")
-						feature_weights
-						!queryFeatureAttributeTypeMap
-						feature_deviations
-						.null
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
-						(if valid_weight_feature weight_feature .null)
-						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
-						"fixed rand seed"
-						.null ;radius
-						!numericalPrecision
-					)
+	(assign (assoc
+		cases_avg_distance_contribution
+			(generalized_mean (compute_on_contained_entities
+				filtering_queries
+				||(query_entity_distance_contributions
+					closest_k
+					features
+					case_ids
+					(get hyperparam_map "p")
+					feature_weights
+					!queryFeatureAttributeTypeMap
+					feature_deviations
+					.null
+					(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+					(if valid_weight_feature weight_feature .null)
+					;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
+					"fixed rand seed"
+					.null ;radius
+					!numericalPrecision
 				)
-		)
-
-		(assign (assoc
-			combined_average_distance_contribution (generalized_mean combined_distance_contributions_map)
-			avg_new_cases_distance_contribution (generalized_mean (unzip combined_distance_contributions_map case_ids))
-			holdout_avg_distance_contribution
-				(generalized_mean (compute_on_contained_entities
-					filtering_queries
-					||(query_entity_distance_contributions
-						closest_k
-						features
-						case_ids
-						(get hyperparam_map "p")
-						feature_weights
-						!queryFeatureAttributeTypeMap
-						feature_deviations
-						.null
-						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
-						(if valid_weight_feature weight_feature .null)
-						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
-						"fixed rand seed"
-						.null ;radius
-						!numericalPrecision
-					)
-				))
-		))
-	)
+			))
+	))
 
 	;Helper method to compute average residual contribution for a group of cases
 	!ComputeNewCasesResidualContributions

--- a/module/react_group.amlg
+++ b/module/react_group.amlg
@@ -296,6 +296,7 @@
 			output_influential_cases .null
 			output_caps_map .null
 			feature_full_residuals_map .null
+			holdout_avg_distance_contribution .null
 			combined_average_distance_contribution .null
 			avg_new_cases_distance_contribution .null
 			avg_new_cases_residual_contribution .null
@@ -642,6 +643,7 @@
 					"distance_contribution" avg_new_cases_distance_contribution
 					"base_model_average_distance_contribution" !averageCaseDistanceContribution
 					"combined_model_average_distance_contribution" combined_average_distance_contribution
+					"holdout_distance_contribution" holdout_avg_distance_contribution
 				)
 				(assoc)
 			)
@@ -777,6 +779,26 @@
 		(assign (assoc
 			combined_average_distance_contribution (generalized_mean combined_distance_contributions_map)
 			avg_new_cases_distance_contribution (generalized_mean (unzip combined_distance_contributions_map case_ids))
+			holdout_avg_distance_contribution
+				(generalized_mean (compute_on_contained_entities
+					filtering_queries
+					||(query_entity_distance_contributions
+						closest_k
+						features
+						case_ids
+						(get hyperparam_map "p")
+						feature_weights
+						!queryFeatureAttributeTypeMap
+						feature_deviations
+						.null
+						(if (= (get hyperparam_map "dt") "surprisal_to_prob") "surprisal" (get hyperparam_map "dt") )
+						(if valid_weight_feature weight_feature .null)
+						;use a fixed random seed to guarantee deterministic behavior for reacts (named "fixed rand seed")
+						"fixed rand seed"
+						.null ;radius
+						!numericalPrecision
+					)
+				))
 		))
 	)
 

--- a/module/return_types.amlg
+++ b/module/return_types.amlg
@@ -1000,22 +1000,7 @@
 					"distance_contribution" {
 						type "list"
 						values "number"
-						description "The average distance contributions of cases in each group."
-					}
-					"base_model_average_distance_contribution" {
-						type "list"
-						values "number"
-						description "The average distance contribution of cases in the dataset."
-					}
-					"combined_model_average_distance_contribution" {
-						type "list"
-						values "number"
-						description "The average distance contribution of cases in the dataset and the cases of each group."
-					}
-					"holdout_distance_contribution" {
-						type "list"
-						values "number"
-						description "The average distance contribution of cases in the group when the group's cases are held out."
+						description "The average distance contributions of cases in each group holding out the rest of the group."
 					}
 					"residual_contribution" {
 						type "list"

--- a/module/return_types.amlg
+++ b/module/return_types.amlg
@@ -1012,6 +1012,11 @@
 						values "number"
 						description "The average distance contribution of cases in the dataset and the cases of each group."
 					}
+					"holdout_distance_contribution" {
+						type "list"
+						values "number"
+						description "The average distance contribution of cases in the group when the group's cases are held out."
+					}
 					"residual_contribution" {
 						type "list"
 						values "number"

--- a/unit_tests/ut_h_box_conviction.amlg
+++ b/unit_tests/ut_h_box_conviction.amlg
@@ -141,9 +141,6 @@
 	(print "\nnew case conviction for point at 3,0 with x as a cyclic: ")
 	(call assert_approximate (assoc percent 0.00001 obs (get result (list "familiarity_conviction_addition" 0)) exp 0.111692205))
 
-	(print "combined_average_distance_contribution:" )
-	(call assert_approximate (assoc percent 0.00001 obs (get result (list "combined_model_average_distance_contribution" 0)) exp 0.8828427124))
-
 	(print "distance_contribution: " )
 	(call assert_same (assoc obs (get result (list "distance_contribution" 0) ) exp 0.5))
 

--- a/unit_tests/ut_h_time_series_stock.amlg
+++ b/unit_tests/ut_h_time_series_stock.amlg
@@ -756,14 +756,14 @@
 		obs
 			(>
 				(get result ["distance_contribution" 0])
-				(get result ["base_model_average_distance_contribution" 0])
+				57735545 ;This is the base model's average distance contribution (skipping the compute for it here)
 			)
 	))
 	(call assert_true (assoc
 		obs
 			(>
 				(get result ["distance_contribution" 1])
-				(get result ["base_model_average_distance_contribution" 0])
+				57735545 ;This is the base model's average distance contribution (skipping the compute for it here)
 			)
 	))
 


### PR DESCRIPTION
also removes formerly output metrics when computing react_group distance_contributions that are unused