### PR TITLE
25905: Fixes an issue where unnecessary metrics are computed when calling `react_into_features`

### DIFF
--- a/module/clustering.amlg
+++ b/module/clustering.amlg
@@ -49,8 +49,8 @@
 						[".distance_contribution" ".similarity_conviction"]
 						(retrieve_from_entity existing_case_id
 							[
-							(get !clusteringParametersMap "distance_contribution_feature")
-							(get !clusteringParametersMap "similarity_conviction_feature")
+								(get !computedFeaturesMap ["computed_map" "distance_contribution"])
+								(get !computedFeaturesMap ["computed_map" "similarity_conviction"])
 							]
 						)
 					)
@@ -103,8 +103,8 @@
 			context_features
 				(append
 					context_features
-					(get !clusteringParametersMap "distance_contribution_feature")
-					(get !clusteringParametersMap "similarity_conviction_feature")
+					(get !computedFeaturesMap ["computed_map" "distance_contribution"])
+					(get !computedFeaturesMap ["computed_map" "similarity_conviction"])
 				)
 			context_values
 				(append

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -203,7 +203,7 @@
 		;flag set to true if similarity_conviction was requested without distance_contribution
 		(declare (assoc only_similiarity_conviction .false ))
 		(if (and
-				(or (= .null similarity_conviction) (= .false similarity_conviction))
+				similarity_conviction
 				(or (= .null distance_contribution) (= .false distance_contribution))
 				(= .null case_ids)
 			)

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -203,7 +203,7 @@
 		;flag set to true if similarity_conviction was requested without distance_contribution
 		(declare (assoc only_similiarity_conviction .false ))
 		(if (and
-				(!= .false similarity_conviction)
+				(or (= .null similarity_conviction) (= .false similarity_conviction))
 				(or (= .null distance_contribution) (= .false distance_contribution))
 				(= .null case_ids)
 			)

--- a/module/conviction.amlg
+++ b/module/conviction.amlg
@@ -130,25 +130,6 @@
 		(if residual_contribution (accum (assoc num_steps 1)) )
 		(if influence_weight_entropy (accum (assoc num_steps 1)) )
 
-		(if clustering
-			(seq
-				(accum (assoc num_steps 2))
-
-				(if (not similarity_conviction)
-					(assign (assoc
-						similarity_conviction ".similarity_conviction"
-						num_steps (+ 1 num_steps)
-					))
-				)
-				(if (not distance_contribution)
-					(assign (assoc
-						distance_contribution ".distance_contribution"
-						num_steps (+ 1 num_steps)
-					))
-				)
-			)
-		)
-
 		(call !EstimateProgress (assoc
 			task_id task_id
 			internal internal
@@ -222,7 +203,7 @@
 		;flag set to true if similarity_conviction was requested without distance_contribution
 		(declare (assoc only_similiarity_conviction .false ))
 		(if (and
-				(!= .null similarity_conviction)
+				(!= .false similarity_conviction)
 				(or (= .null distance_contribution) (= .false distance_contribution))
 				(= .null case_ids)
 			)
@@ -742,8 +723,6 @@
 					!clusteringParametersMap
 						(assoc
 							"feature" clustering
-							"distance_contribution_feature" distance_contribution
-							"similarity_conviction_feature" similarity_conviction
 							"clustering_min_cluster_mass" clustering_min_cluster_mass
 						)
 				))

--- a/module/trainee.amlg
+++ b/module/trainee.amlg
@@ -203,8 +203,6 @@
 		;map for caching parameters used for clustering, used to determine which (if any) cluster hypothetical cases would belong to
 		;the following fixed keys store parameters as specified:
 		; feature: name of clustering feature
-		; distance_contribution_feature: name of distance contribution feature used for clustering
-		; similarity_conviction_feature: name of similarity conviction feature used for clustering
 		; clustering_min_cluster_mass: value of clustering_min_cluster_mass used for clustering
 		!clusteringParametersMap .null
 


### PR DESCRIPTION
Clustering no longer requires SC and DC, so the code computing those for clustering has been removed. Additionally fixes a bug where DC is computed without being requested.