### PR TITLE
25939: Fixes uniqueness check when substituting novel nominals

### DIFF
--- a/module/synthesis_validation.amlg
+++ b/module/synthesis_validation.amlg
@@ -45,6 +45,7 @@
 			;override global residuals with calculated residuals per feature
 			threshold_feature_residuals_map
 				(append (get data_params_map "featureDeviations") (zip rand_ordered_features threshold_feature_residuals))
+			has_novel_substitions .false
 		))
 
 		;check if an exact duplicate already exists in the dataset and if so re-try up to 2 times to re-generate a novel case
@@ -241,8 +242,8 @@
 
 	;helper method to find the closest cases to the generated values and sets local_data_cases_tuple to the result of that query
 	!FindClosestCasesForUniquenessCheck
-	(let
-		(assoc has_novel_substitions (and exclude_novel_nominals_from_uniqueness_check (size !novelSubstitionFeatureSet)) )
+	(seq
+		(assign (assoc has_novel_substitions (and exclude_novel_nominals_from_uniqueness_check (size !novelSubstitionFeatureSet)) ))
 
 		(assign (assoc
 			context_numeric_values

--- a/module/synthesis_validation.amlg
+++ b/module/synthesis_validation.amlg
@@ -45,7 +45,7 @@
 			;override global residuals with calculated residuals per feature
 			threshold_feature_residuals_map
 				(append (get data_params_map "featureDeviations") (zip rand_ordered_features threshold_feature_residuals))
-			has_novel_substitions .false
+			has_novel_substitions (and exclude_novel_nominals_from_uniqueness_check (size !novelSubstitionFeatureSet))
 		))
 
 		;check if an exact duplicate already exists in the dataset and if so re-try up to 2 times to re-generate a novel case
@@ -243,8 +243,6 @@
 	;helper method to find the closest cases to the generated values and sets local_data_cases_tuple to the result of that query
 	!FindClosestCasesForUniquenessCheck
 	(seq
-		(assign (assoc has_novel_substitions (and exclude_novel_nominals_from_uniqueness_check (size !novelSubstitionFeatureSet)) ))
-
 		(assign (assoc
 			context_numeric_values
 				;output of generative retries are decoded, non-substituted string nominals


### PR DESCRIPTION
Fixes issues when novel nominals where generated, the novel nominal feature was still included in the generation uniqueness check 